### PR TITLE
refactor: simplify model selection and remove tiny option

### DIFF
--- a/src/components/ChatBox/ModelSelector.tsx
+++ b/src/components/ChatBox/ModelSelector.tsx
@@ -1,12 +1,16 @@
 import { useState, useEffect } from "react";
-import { MODEL_SIZE_NAMES, getModelSizeFromSelection } from "@/components/ChatBox/utils/modelSelection";
+import {
+  MODEL_SIZE_NAMES,
+  MODEL_SIZES,
+  getModelSizeFromSelection,
+  selectModelBasedOnDevice,
+  type ModelSizeKey,
+} from "@/components/ChatBox/utils/modelSelection";
 import {
   setPreferredModelSize,
   clearModelPreference,
-  ModelSizeKey,
   getAutoDetectedModelSize,
 } from "@/components/ChatBox/utils/modelPreferences";
-import { selectModelBasedOnDevice } from "@/components/ChatBox/utils/modelSelection";
 import { clearMessageHistory } from "@/components/ChatBox/utils/messageHistory";
 
 interface ModelSelectorProps {
@@ -42,9 +46,9 @@ export default function ModelSelector({ onClose }: ModelSelectorProps) {
     setSelectedModel(currentModelInUse); // Reset to the model in use
   };
 
-  const allowedModels: ModelSizeKey[] = ["TINY", "SMALL", "MEDIUM", "LARGE"];
   // Show reload message if the selected model is different from the model currently in use
-  const showReloadMessage = selectedModel !== null && selectedModel !== currentModelInUse;
+  const showReloadMessage =
+    selectedModel !== null && selectedModel !== currentModelInUse;
 
   if (!showSettings) {
     return (
@@ -130,7 +134,7 @@ export default function ModelSelector({ onClose }: ModelSelectorProps) {
         <div className="p-6">
           <div className="mb-6">
             <div className="space-y-3">
-              {allowedModels.map((key) => (
+              {MODEL_SIZES.map((key) => (
                 <label
                   key={key}
                   className="flex items-center p-3 rounded-lg border border-gray-700 hover:border-gray-600 hover:bg-gray-800 cursor-pointer transition-all duration-200 group"
@@ -172,11 +176,6 @@ export default function ModelSelector({ onClose }: ModelSelectorProps) {
                       {key === "SMALL" && (
                         <span className="ml-2 px-2 py-1 text-xs bg-green-600 text-white rounded-full">
                           Fast
-                        </span>
-                      )}
-                      {key === "TINY" && (
-                        <span className="ml-2 px-2 py-1 text-xs bg-orange-600 text-white rounded-full">
-                          Ultra Fast
                         </span>
                       )}
                     </div>

--- a/src/components/ChatBox/utils/modelLoader.ts
+++ b/src/components/ChatBox/utils/modelLoader.ts
@@ -3,7 +3,11 @@ import {
   env,
   type TextGenerationPipeline,
 } from "@huggingface/transformers";
-import { type ModelSelection, getNextModelSelection } from "./modelSelection";
+import {
+  type ModelSelection,
+  getNextModelSelection,
+  MODEL_SIZES,
+} from "./modelSelection";
 
 // Configure environment for browser usage
 env.allowLocalModels = false;
@@ -21,7 +25,7 @@ export async function loadModelWithFallback(
   let currentSelection = { ...selection };
   let generator: TextGenerationPipeline | null = null;
   let attempts = 0;
-  const maxAttempts = 4;
+  const maxAttempts = MODEL_SIZES.length;
 
   while (!generator && attempts < maxAttempts) {
     attempts++;

--- a/src/components/ChatBox/utils/modelPreferences.ts
+++ b/src/components/ChatBox/utils/modelPreferences.ts
@@ -1,20 +1,22 @@
-import { selectModelBasedOnDevice, getModelSizeFromSelection, ModelSelection } from './modelSelection';
+import {
+  selectModelBasedOnDevice,
+  getModelSizeFromSelection,
+  type ModelSelection,
+  type ModelSizeKey,
+} from "./modelSelection";
 
-export type ModelSizeKey = 'LARGE' | 'MEDIUM' | 'SMALL' | 'TINY';
+export type { ModelSizeKey };
 
 /**
  * Gets the auto-detected model size based on device capabilities or fallback state.
  * Optionally accepts a ModelSelection to reflect the current fallback.
  */
-export function getAutoDetectedModelSize(currentSelection?: ModelSelection): ModelSizeKey {
-  // Only use device detection, no manual override logic
-  let autoSelection;
-  if (currentSelection) {
-    return getModelSizeFromSelection(currentSelection);
-  } else {
-    autoSelection = selectModelBasedOnDevice();
-    return getModelSizeFromSelection(autoSelection);
-  }
+export function getAutoDetectedModelSize(
+  currentSelection?: ModelSelection
+): ModelSizeKey {
+  return currentSelection
+    ? getModelSizeFromSelection(currentSelection)
+    : getModelSizeFromSelection(selectModelBasedOnDevice());
 }
 
 /**

--- a/src/components/ChatBox/utils/modelSelection.ts
+++ b/src/components/ChatBox/utils/modelSelection.ts
@@ -1,229 +1,106 @@
-// Model options and selection logic for text generation models
+// Simplified model options and selection logic for text generation models
 // Using ONNX-compatible SmolLM2 variants
-export const MODEL_OPTIONS = {
-  LARGE: "sledgedev/SmolLM2-1.7B-Instruct-ONNX-ARM64",
-  MEDIUM: "onnx-community/SmolLM2-360M-Instruct-ONNX", 
-  SMALL: "onnx-community/SmolLM2-135M-Instruct-ONNX",
-  TINY: "onnx-community/SmolLM2-135M-Instruct-ONNX"
-} as const;
 
-// Model size names for user-friendly display
-export const MODEL_SIZE_NAMES = {
-  LARGE: "large",
-  MEDIUM: "medium",
-  SMALL: "small",
-  TINY: "tiny",
-};
-
-// Data types for each model - using auto (let the library decide)
-export const MODEL_DTYPES = {
-  LARGE: "auto" as const,  // Let library choose the best dtype
-  MEDIUM: "auto" as const, // Let library choose the best dtype  
-  SMALL: "auto" as const,  // Let library choose the best dtype
-  TINY: "auto" as const    // Let library choose the best dtype
-};
-
-// Approximate memory requirements in MB, based on model parameters and data types
-export const MODEL_MEMORY_REQUIREMENTS = {
-  LARGE: 3500,
-  MEDIUM: 800,
-  SMALL: 300,
-  TINY: 300,
-};
-
-// All defaults should fall back on the smallest model
-const DEFAULT_SELECTION = { model: MODEL_OPTIONS.TINY, dtype: MODEL_DTYPES.TINY }
-
-// Type for model selection result
-export type ModelSizeKey = 'LARGE' | 'MEDIUM' | 'SMALL' | 'TINY';
-
-export type ModelDType = "auto";
+export const MODEL_SIZES = ["SMALL", "MEDIUM", "LARGE"] as const;
+export type ModelSizeKey = typeof MODEL_SIZES[number];
 
 export interface ModelSelection {
   model: string;
-  dtype: ModelDType;
+  dtype: "auto";
 }
 
-// Helper functions to convert between model names and size keys
-export function getModelSizeFromModelName(modelName: string): ModelSizeKey {
-  if (modelName === MODEL_OPTIONS.LARGE) return 'LARGE';
-  if (modelName === MODEL_OPTIONS.MEDIUM) return 'MEDIUM';
-  if (modelName === MODEL_OPTIONS.SMALL) return 'SMALL';
-  return 'TINY';
+export const MODEL_OPTIONS: Record<ModelSizeKey, string> = {
+  SMALL: "onnx-community/SmolLM2-135M-Instruct-ONNX",
+  MEDIUM: "onnx-community/SmolLM2-360M-Instruct-ONNX",
+  LARGE: "sledgedev/SmolLM2-1.7B-Instruct-ONNX-ARM64",
+};
+
+// Model size names for user-friendly display
+export const MODEL_SIZE_NAMES: Record<ModelSizeKey, string> = {
+  SMALL: "Small",
+  MEDIUM: "Medium",
+  LARGE: "Large",
+};
+
+export const MODEL_DTYPES: Record<ModelSizeKey, "auto"> = {
+  SMALL: "auto",
+  MEDIUM: "auto",
+  LARGE: "auto",
+};
+
+// Approximate memory requirements in MB
+export const MODEL_MEMORY_REQUIREMENTS: Record<ModelSizeKey, number> = {
+  SMALL: 300,
+  MEDIUM: 800,
+  LARGE: 3500,
+};
+
+// Small model is the default and smallest option
+const DEFAULT_SELECTION: ModelSelection = {
+  model: MODEL_OPTIONS.SMALL,
+  dtype: MODEL_DTYPES.SMALL,
+};
+
+export function getModelSizeFromSelection(
+  selection: ModelSelection
+): ModelSizeKey {
+  const entry = (Object.entries(MODEL_OPTIONS) as [ModelSizeKey, string][]).find(
+    ([, model]) => model === selection.model
+  );
+  return entry ? entry[0] : "SMALL";
 }
 
-// Enhanced function that considers both model name and dtype
-export function getModelSizeFromSelection(selection: ModelSelection): ModelSizeKey {
-  if (selection.model === MODEL_OPTIONS.LARGE) return 'LARGE';
-  if (selection.model === MODEL_OPTIONS.MEDIUM) return 'MEDIUM';
-  if (selection.model === MODEL_OPTIONS.SMALL) return 'SMALL';
-  if (selection.model === MODEL_OPTIONS.TINY) return 'TINY';
-  
-  return 'TINY'; // Default fallback
+export function getModelSelectionFromSizeKey(
+  sizeKey: ModelSizeKey
+): ModelSelection {
+  return { model: MODEL_OPTIONS[sizeKey], dtype: MODEL_DTYPES[sizeKey] };
 }
 
-export function getModelSelectionFromSizeKey(sizeKey: ModelSizeKey): ModelSelection {
-  switch (sizeKey) {
-    case 'LARGE':
-      return { model: MODEL_OPTIONS.LARGE, dtype: MODEL_DTYPES.LARGE };
-    case 'MEDIUM':
-      return { model: MODEL_OPTIONS.MEDIUM, dtype: MODEL_DTYPES.MEDIUM };
-    case 'SMALL':
-      return { model: MODEL_OPTIONS.SMALL, dtype: MODEL_DTYPES.SMALL };
-    case 'TINY':
-    default:
-      return { model: MODEL_OPTIONS.TINY, dtype: MODEL_DTYPES.TINY };
-  }
-}
-
-// Function to detect device capabilities and select appropriate model
+/**
+ * Detect device capabilities and select an appropriate model.
+ * A manual override stored in localStorage takes precedence.
+ */
 export function selectModelBasedOnDevice(): ModelSelection {
-  // Check for a manual override in localStorage
   if (typeof window !== "undefined" && window.localStorage) {
-    const manualOverride = window.localStorage.getItem('preferredModelSize');
-    if (manualOverride) {
-      if (manualOverride === 'LARGE' || manualOverride === 'MEDIUM' || manualOverride === 'SMALL') {
-        return getModelSelectionFromSizeKey(manualOverride as ModelSizeKey);
-      }
+    const override = window.localStorage.getItem(
+      "preferredModelSize"
+    ) as ModelSizeKey | null;
+    if (override && MODEL_SIZES.includes(override)) {
+      return getModelSelectionFromSizeKey(override);
     }
   }
 
   if (typeof navigator === "undefined" || typeof window === "undefined") {
-    // Default to small model if not in browser environment
     return DEFAULT_SELECTION;
   }
 
-  try {
-    // Try to get a more accurate memory assessment
-    // First, attempt to use the deviceMemory API
-    let estimatedMemoryInGB: number;
-    const deviceMemoryAPI = (navigator as Navigator & { deviceMemory?: number }).deviceMemory;
+  const deviceMemory =
+    (navigator as Navigator & { deviceMemory?: number }).deviceMemory ?? 4;
+  const cores = navigator.hardwareConcurrency ?? 4;
+  const isMobile = /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(
+    navigator.userAgent
+  );
 
-    if (deviceMemoryAPI) {
-      estimatedMemoryInGB = deviceMemoryAPI;
-    } else {
-      // If deviceMemory isn't available, make an educated guess based on performance
-      const startTime = performance.now();
-      for (let i = 0; i < 1000000; i++) {
-        Math.sqrt(i);
-      }
-      const endTime = performance.now();
-      const perfScore = 1000000 / (endTime - startTime); // Higher is better
-
-      // Use performance to estimate available memory with conservative criteria
-      if (perfScore > 15000) {
-        estimatedMemoryInGB = 4; // Very fast machine, likely has decent memory
-      } else if (perfScore > 8000) {
-        estimatedMemoryInGB = 2; // Decent machine
-      } else {
-        estimatedMemoryInGB = 1; // Slower machine, likely mobile or old device
-      }
-    }
-
-    // Check if device is mobile
-    const isMobile = /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(
-      navigator.userAgent
-    );
-
-    // Check for very old mobile devices (like Samsung Galaxy S3)
-    const isVeryOldMobile = /Android [1-4]\.|iPhone OS [1-8]_|iPad.*OS [1-8]_|BlackBerry|Windows Phone|webOS/i.test(
-      navigator.userAgent
-    );
-
-    // Estimate for machines that might have browser limitations
-    const memoryInMB = Math.max(estimatedMemoryInGB, 1) * 1024;
-
-    // Use more conservative memory allocation for mobile devices
-    const memoryMultiplier = isMobile ? 0.4 : 0.7; // Mobile devices get much less memory allocation
-    const safeMemory = memoryInMB * memoryMultiplier;
-
-    // Check logical processors
-    const logicalProcessors = navigator.hardwareConcurrency || 4; // Default to 4 cores if not available
-
-    // Run a quick performance test
-    const startTime = performance.now();
-    for (let i = 0; i < 1000000; i++) {
-      Math.sqrt(i);
-    }
-    const endTime = performance.now();
-    const perfScore = 1000000 / (endTime - startTime); // Higher is better
-
-    console.log(`Device specs: Memory: ${estimatedMemoryInGB}GB (Safe: ${Math.round(safeMemory)}MB), Cores: ${logicalProcessors}, Mobile: ${isMobile}, Very old mobile: ${isVeryOldMobile}, Performance score: ${perfScore.toFixed(2)}`);
-
-    // Select model based on device capabilities with more stringent requirements
-    let selectedModel: ModelSelection;
-
-    // Force very old mobile devices to use tiny model
-    if (isVeryOldMobile || (isMobile && estimatedMemoryInGB <= 1)) {
-      selectedModel = DEFAULT_SELECTION;
-      console.log("Using tiny model for very old or low-memory mobile device");
-    }
-    // Force all mobile devices to use small or medium model at most
-    else if (isMobile) {
-      if (safeMemory >= MODEL_MEMORY_REQUIREMENTS.MEDIUM && 
-          perfScore > 80 && 
-          logicalProcessors >= 4 && 
-          estimatedMemoryInGB >= 3) {
-        selectedModel = getModelSelectionFromSizeKey('MEDIUM');
-        console.log("Using medium model for high-end mobile device");
-      } else if (safeMemory >= MODEL_MEMORY_REQUIREMENTS.SMALL &&
-                 perfScore > 40 &&
-                 estimatedMemoryInGB >= 2) {
-        selectedModel = getModelSelectionFromSizeKey('SMALL');
-        console.log("Using small model for mid-range mobile device");
-      } else {
-        selectedModel = DEFAULT_SELECTION;
-        console.log("Using tiny model for low-end mobile device");
-      }
-    }
-    // Desktop/laptop devices with more stringent requirements
-    else {
-      // High-end devices - require full memory and strong performance
-      if (safeMemory >= MODEL_MEMORY_REQUIREMENTS.LARGE &&
-          perfScore > 120 && 
-          logicalProcessors >= 6 && 
-          estimatedMemoryInGB >= 4) {
-        selectedModel = getModelSelectionFromSizeKey('LARGE');
-        console.log("Using large model for high-end desktop device");
-      }
-      // Mid-range devices - require both memory AND performance
-      else if (safeMemory >= MODEL_MEMORY_REQUIREMENTS.MEDIUM &&
-               perfScore > 80 && 
-               logicalProcessors >= 4 && 
-               estimatedMemoryInGB >= 2) {
-        selectedModel = getModelSelectionFromSizeKey('MEDIUM');
-        console.log("Using medium model for mid-range desktop device");
-      }
-      // Low-end devices - use small model
-      else {
-        selectedModel = getModelSelectionFromSizeKey('SMALL');
-        console.log("Using small model for low-end desktop device");
-      }
-    }
-
-    return selectedModel;
-  } catch (error) {
-    console.error("Error detecting device capabilities:", error);
-    // Fallback to small model for safety
-    return DEFAULT_SELECTION;
+  if (!isMobile && deviceMemory >= 8 && cores >= 6) {
+    return getModelSelectionFromSizeKey("LARGE");
   }
+  if (deviceMemory >= 4 && cores >= 4) {
+    return getModelSelectionFromSizeKey("MEDIUM");
+  }
+  return DEFAULT_SELECTION;
 }
 
-// Initial model selection for new users or reset state
 export function getInitialModelSelection(): ModelSelection {
-  return DEFAULT_SELECTION
+  return DEFAULT_SELECTION;
 }
 
-// Get the next model selection based on current, for cycling through models or fallback
-export function getNextModelSelection(current: ModelSelection): ModelSelection {
+export function getNextModelSelection(
+  current: ModelSelection
+): ModelSelection {
   const currentSize = getModelSizeFromSelection(current);
-  if (currentSize === 'LARGE') {
-    return getModelSelectionFromSizeKey('MEDIUM');
-  } else if (currentSize === 'MEDIUM') {
-    return getModelSelectionFromSizeKey('SMALL');
-  } else if (currentSize === 'SMALL') {
-    return DEFAULT_SELECTION;
-  }
-  // Already at smallest
+  if (currentSize === "LARGE") return getModelSelectionFromSizeKey("MEDIUM");
+  if (currentSize === "MEDIUM")
+    return getModelSelectionFromSizeKey("SMALL");
   return current;
 }
+


### PR DESCRIPTION
## Summary
- remove Tiny model option and default to Small with capitalized user-facing names
- centralize model size constants and simplify preference helpers
- streamline model selection and fallback logic across components

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: next not found; dependencies could not be installed)*

------
https://chatgpt.com/codex/tasks/task_b_6893f53c4a58832b9689b47f1b93d660