### PR TITLE
feat: improve model context provider

### DIFF
--- a/src/components/ChatBox/utils/contextProvider.ts
+++ b/src/components/ChatBox/utils/contextProvider.ts
@@ -1,58 +1,48 @@
 /**
- * This file provides the context information about Justin Law for the chat assistant.
- * The context is used to generate responses that are relevant to Justin's background.
+ * Provides contextual information about Justin Law for the chat assistant.
+ * The context is injected as a system prompt so that all model sizes start
+ * with the same background knowledge about Justin.
  */
 
-/**
- * This file provides the context information about Justin Law for the chat assistant.
- * The context is used to generate responses that are relevant to Justin's background.
- * Uses a single-turn conversation pattern optimized for smaller language models.
- */
-
-// Function to get Justin Law's context as a single comprehensive conversation
-export function getJustinLawContext(): Array<{ role: string, content: string }> {
-  return [
-    {
-      role: "user",
-      content: "Tell me about Justin Law - his job, education, military background, and interests."
-    },
-    {
-      role: "assistant", 
-      content: "Justin Law is an AI/ML Software Engineer at Defense Unicorns, where he works on full-stack AI applications and MLOps/GenAIOps platforms. He has a bachelor's in Mechanical Engineering with minors in Communications and Military Leadership from Rochester Institute of Technology, plus master's level studies in Computer Science at Johns Hopkins University and Georgia Institute of Technology focusing on Enterprise Web computing and AI. Justin is a veteran of the US Air and Space Forces, served as a Captain (O3) and Developmental Engineer (62E), and was honorably discharged. He's organized, disciplined, and diligent. In his free time, Justin likes to run, cook, play video games, travel, and work on personal coding projects."
-    }
-  ];
+export interface ChatMessage {
+  role: string;
+  content: string;
 }
 
-// System instructions for the AI assistant - optimized for smaller models
+// Core factual background about Justin Law presented in a concise format.
+function getJustinBackground(): string {
+  return [
+    "Name: Justin Law",
+    "Occupation: AI/ML Software Engineer at Defense Unicorns where he builds full-stack AI applications and MLOps/GenAIOps platforms.",
+    "Education: Bachelor's in Mechanical Engineering with minors in Communications and Military Leadership from Rochester Institute of Technology; graduate studies in Computer Science at Johns Hopkins University and Georgia Tech focusing on Enterprise Web computing and AI.",
+    "Military: Veteran of the US Air and Space Forces, served as a Captain (O3) and Developmental Engineer (62E) before an honorable discharge.",
+    "Traits: Organized, disciplined and diligent.",
+    "Interests: Running, cooking, playing video games, traveling and personal coding projects."
+  ].join("\n");
+}
+
+// Base system instructions shared by all models.
 export function getSystemInstructions(): string {
   return [
     "You are an AI assistant created by Justin Law.",
-    "Answer questions about Justin using the conversation context provided.",
-    "Keep responses brief, factual, and focused only on the information given.",
-    "If asked about something not covered in the context, politely say you don't have that information."
+    "Use the provided background to answer questions about Justin.",
+    "Keep responses brief, factual and only based on the supplied information.",
+    "If information is missing, respond that you do not know."
   ].join(" ");
 }
 
-// Generate conversation messages for the AI assistant with single-turn context
-export function generateConversationMessages(userInput: string): Array<{ role: string, content: string }> {
-  const messages = [
-    {
-      role: "system",
-      content: getSystemInstructions(),
-    },
-    // Add single-turn context learning example
-    ...getJustinLawContext(),
-    // Add the user's actual query
-    {
-      role: "user",
-      content: cleanInput(userInput),
-    },
+// Create conversation messages that include background context in the system prompt.
+export function generateConversationMessages(userInput: string): ChatMessage[] {
+  const systemContent = `${getSystemInstructions()}\n\nBackground Information:\n${getJustinBackground()}`;
+  return [
+    { role: "system", content: systemContent },
+    { role: "user", content: cleanInput(userInput) }
   ];
-
-  return messages;
 }
 
-// Helper function to clean user input
+// Helper to sanitise user input before sending to models.
 export const cleanInput = (input?: string): string => {
   return input ? input.replace(/`/g, "").trim() : "";
 };
+
+export { getJustinBackground };


### PR DESCRIPTION
## Summary
- refactor chat context provider to inject Justin's background as system prompt

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm install` *(fails: connect ENETUNREACH 140.82.112.4:443)*
- `npm run lint` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_b_6893f93e4b20832b801d3fa466053d69