### PR TITLE
Improve Justin chatbot responses

### DIFF
--- a/src/components/ChatBox/utils/contextProvider.ts
+++ b/src/components/ChatBox/utils/contextProvider.ts
@@ -27,6 +27,7 @@ export function getSystemInstructions(): string {
     "You are an AI assistant created by Justin Law.",
     "Use the provided background to answer questions about Justin.",
     "Keep responses brief, factual and only based on the supplied information.",
+    "Limit answers to at most three sentences.",
     "If information is missing, respond that you do not know."
   ].join(" ");
 }

--- a/src/components/ChatBox/utils/generation.ts
+++ b/src/components/ChatBox/utils/generation.ts
@@ -92,7 +92,12 @@ self.addEventListener("message", async (event: MessageEvent<MessageData>) => {
 
     self.postMessage({ status: "initiate" });
     const messages = generateConversationMessages(cleanedInput);
-    
+    const prompt =
+      messages
+        .map(({ role, content }) => `${role.toUpperCase()}: ${content}`)
+        .join("\n") +
+      "\nASSISTANT:";
+
     try {
       // Handle real pipeline with streamer
       const streamer = new TextStreamer(generator.tokenizer, {
@@ -103,11 +108,10 @@ self.addEventListener("message", async (event: MessageEvent<MessageData>) => {
         },
       });
 
-      await generator(messages, {
-        temperature: 0.1,
-        max_new_tokens: 512,
-        do_sample: true,
-        top_p: 0.9,
+      await generator(prompt, {
+        temperature: 0.2,
+        max_new_tokens: 128,
+        do_sample: false,
         repetition_penalty: 1.2,
         early_stopping: true,
         streamer,


### PR DESCRIPTION
## Summary
- Keep AI answers short by limiting the assistant to at most three sentences
- Convert conversation context into a single prompt and tune inference hyperparameters for concise, consistent replies

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: next not found; `npm install` failed: connect ENETUNREACH to GitHub onnxruntime)*

------
https://chatgpt.com/codex/tasks/task_b_6893feb8eee8832b9901ec8c5e9a2553