### PR TITLE
Fix resume viewer for mobile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+# avoid committing generated or external documents
+public/**/*.pdf

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "@huggingface/transformers": "^3.3.3",
     "next": "^15.3.3",
     "react": "^19.0.0",
-    "react-dom": "^19.0.0"
+    "react-dom": "^19.0.0",
+    "pdfjs-dist": "^3.11.174"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",

--- a/src/components/ResumeCoverLetterViewer.tsx
+++ b/src/components/ResumeCoverLetterViewer.tsx
@@ -1,20 +1,83 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
+import {
+  GlobalWorkerOptions,
+  getDocument,
+  version as pdfjsVersion,
+} from "pdfjs-dist";
+
+GlobalWorkerOptions.workerSrc = `https://cdnjs.cloudflare.com/ajax/libs/pdf.js/${pdfjsVersion}/pdf.worker.min.js`;
+
+const PDF_URL =
+  "https://drive.google.com/uc?export=download&id=1o3hw7mOlJ5JB9XfoDQNdv8aBdCVPl8cp";
 
 export default function ResumeCoverLetterViewer() {
-  const [isClient, setIsClient] = useState(false);
+  const [pdfBlobUrl, setPdfBlobUrl] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const viewerRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
-    setIsClient(true);
+    let objectUrl: string | null = null;
+    const fetchPdf = async () => {
+      try {
+        const response = await fetch(PDF_URL);
+        if (!response.ok) {
+          throw new Error(`HTTP ${response.status}`);
+        }
+        const blob = await response.blob();
+        objectUrl = URL.createObjectURL(blob);
+        setPdfBlobUrl(objectUrl);
+      } catch (error) {
+        console.error("Failed to load PDF", error);
+        setError("Failed to load PDF");
+      }
+    };
+
+    fetchPdf();
+    return () => {
+      if (objectUrl) {
+        URL.revokeObjectURL(objectUrl);
+      }
+    };
   }, []);
 
-  const pdfUrl =
-    "https://drive.google.com/uc?export=download&id=1o3hw7mOlJ5JB9XfoDQNdv8aBdCVPl8cp";
-  const driveUrl =
-    "https://drive.google.com/file/d/1o3hw7mOlJ5JB9XfoDQNdv8aBdCVPl8cp/view";
+  useEffect(() => {
+    if (!pdfBlobUrl || !viewerRef.current) return;
 
-  if (!isClient) {
+    const renderPdf = async () => {
+      const pdf = await getDocument(pdfBlobUrl).promise;
+      const container = viewerRef.current!;
+      container.innerHTML = "";
+      for (let pageNum = 1; pageNum <= pdf.numPages; pageNum++) {
+        const page = await pdf.getPage(pageNum);
+        const viewport = page.getViewport({ scale: 1 });
+        const scale = container.clientWidth / viewport.width;
+        const scaledViewport = page.getViewport({ scale });
+        const canvas = document.createElement("canvas");
+        const context = canvas.getContext("2d")!;
+        canvas.width = scaledViewport.width;
+        canvas.height = scaledViewport.height;
+        container.appendChild(canvas);
+        await page.render({ canvasContext: context, viewport: scaledViewport }).promise;
+      }
+    };
+
+    renderPdf();
+  }, [pdfBlobUrl]);
+
+  if (error) {
+    return (
+      <div className="w-full max-w-5xl h-full p-4 flex flex-col items-center justify-center">
+        <div className="text-center">
+          <h3 className="text-lg font-semibold mb-4">Resume</h3>
+          <div className="text-red-500">{error}</div>
+        </div>
+      </div>
+    );
+  }
+
+  if (!pdfBlobUrl) {
     return (
       <div className="w-full max-w-5xl h-full p-4 flex flex-col items-center justify-center">
         <div className="text-center">
@@ -27,27 +90,22 @@ export default function ResumeCoverLetterViewer() {
 
   return (
     <div className="w-full max-w-5xl h-full p-4 flex flex-col items-center">
-      <div className="w-full max-w-4xl h-full border border-gray-300 rounded-lg overflow-hidden shadow-lg mb-4">
-        <embed
-          src={pdfUrl}
-          type="application/pdf"
-          width="100%"
-          height="100%"
-          className="w-full h-full"
-        />
-      </div>
+      <div
+        ref={viewerRef}
+        className="w-full max-w-4xl h-full border border-gray-300 rounded-lg overflow-auto shadow-lg mb-4"
+      />
 
       <div className="text-center">
         <div className="flex gap-2 items-center justify-center">
           <a
-            href={pdfUrl}
+            href={pdfBlobUrl}
             download="Justin_Law_Resume.pdf"
             className="inline-block bg-blue-600 text-white px-4 py-2 rounded-lg hover:bg-blue-700 transition-colors text-sm"
           >
             📄 Download PDF
           </a>
           <a
-            href={driveUrl}
+            href={pdfBlobUrl}
             target="_blank"
             rel="noopener noreferrer"
             className="inline-block bg-gray-600 text-white px-4 py-2 rounded-lg hover:bg-gray-700 transition-colors text-sm"


### PR DESCRIPTION
## Summary
- fetch resume PDF from Google Drive and render inline with pdf.js so pages display on mobile
- download and new-tab actions reference the fetched blob instead of repository files
- add `pdfjs-dist` runtime and keep repository free of PDF binaries

## Testing
- `npm install` (fails: connect ENETUNREACH 140.82.113.4:443 while installing onnxruntime-node)
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: next not found)


------
https://chatgpt.com/codex/tasks/task_b_689403349368832bae4754a06652a139