### PR TITLE
fix: test workflow permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: Playwright Tests
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/justinthelaw/justinthelaw/security/code-scanning/1](https://github.com/justinthelaw/justinthelaw/security/code-scanning/1)

To fix the problem, add a `permissions` block to the workflow to explicitly restrict the GITHUB_TOKEN permissions. The best way is to add the block at the root level of the workflow file, so it applies to all jobs unless overridden. For this workflow, the minimal required permission is `contents: read`, which allows the workflow to check out code but not modify repository contents. No additional permissions are needed for the steps shown, as uploading artifacts does not require repository write access. The change should be made at the top of the file, after the `name` field and before the `on` field.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
