### PR TITLE
chore(docs): Remove GitHub stats from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,3 @@ Learn more about me on my [GitHub pages website](https://justinthelaw.github.io/
 🔥 Interested in videogames, hiking, running, and traveling
 
 👉 Connect with me on [LinkedIn](https://www.linkedin.com/in/justinwingchunglaw/)
-
-## Justin's Github Stats
-
-[![Justin's Top Programming Languages](https://github-readme-stats.vercel.app/api/top-langs/?username=justinthelaw&langs_count=6&&layout=donut&theme=transparent)](https://github.com/anuraghazra/github-readme-stats)
-[![Justin's GitHub stats](https://github-readme-stats.vercel.app/api?username=justinthelaw&show_icons=true&theme=transparent)](https://github.com/anuraghazra/github-readme-stats)


### PR DESCRIPTION
Removed GitHub stats section from README.