### PR TITLE
fix: cross OS, browser model loading

### DIFF
--- a/src/services/ai/modelLoader.ts
+++ b/src/services/ai/modelLoader.ts
@@ -186,46 +186,46 @@ export async function loadModel(
 
   for (const dtype of dtypeFallbackOrder) {
     attempts++;
+    let isDownloading = true;
+
+    const pipelineOptions: Record<string, unknown> = {
+      dtype,
+      device: "wasm",
+      progress_callback: (progressData: unknown) => {
+        if (typeof progressData !== "object" || progressData === null) {
+          return;
+        }
+
+        const data = progressData as {
+          progress?: number;
+          status?: string;
+        };
+
+        if (data.progress === undefined || !callbacks.onProgress) {
+          return;
+        }
+
+        const progress = Math.round(data.progress);
+        let message: string;
+
+        if (data.status === "progress") {
+          message = `Downloading model... ${progress}%`;
+          isDownloading = true;
+        } else if (data.status === "done" || progress === 100) {
+          message = `Loading into memory... ${progress}%`;
+          isDownloading = false;
+        } else {
+          message = isDownloading
+            ? `Downloading model... ${progress}%`
+            : `Loading into memory... ${progress}%`;
+        }
+
+        callbacks.onProgress(progress, message);
+      },
+    };
+
     try {
       logger.log(`loading model (${dtype}): ${MODEL_ID}`);
-
-      let isDownloading = true;
-
-      const pipelineOptions: Record<string, unknown> = {
-        dtype,
-        device: "wasm",
-        progress_callback: (progressData: unknown) => {
-          if (typeof progressData !== "object" || progressData === null) {
-            return;
-          }
-
-          const data = progressData as {
-            progress?: number;
-            status?: string;
-          };
-
-          if (data.progress === undefined || !callbacks.onProgress) {
-            return;
-          }
-
-          const progress = Math.round(data.progress);
-          let message: string;
-
-          if (data.status === "progress") {
-            message = `Downloading model... ${progress}%`;
-            isDownloading = true;
-          } else if (data.status === "done" || progress === 100) {
-            message = `Loading into memory... ${progress}%`;
-            isDownloading = false;
-          } else {
-            message = isDownloading
-              ? `Downloading model... ${progress}%`
-              : `Loading into memory... ${progress}%`;
-          }
-
-          callbacks.onProgress(progress, message);
-        },
-      };
 
       const pipelineResult = await createPipeline(
         "text-generation",

--- a/src/services/ai/modelLoader.ts
+++ b/src/services/ai/modelLoader.ts
@@ -6,6 +6,7 @@
 import {
   pipeline,
   env,
+  type Text2TextGenerationPipeline,
   type TextGenerationPipeline,
 } from "@huggingface/transformers";
 import {
@@ -20,6 +21,32 @@ env.remoteHost = "https://huggingface.co";
 
 const logger = createLogger(LOG_AREAS.AI_MODEL_LOADER);
 
+export type GenerationTask = "text-generation" | "text2text-generation";
+
+export type GenerationPipeline =
+  | TextGenerationPipeline
+  | Text2TextGenerationPipeline;
+
+export type GenerationPipelineFactory = (
+  task: GenerationTask,
+  modelId: string,
+  options: Record<string, unknown>
+) => Promise<GenerationPipeline>;
+
+export interface LoadedTextGenerationPipeline {
+  task: "text-generation";
+  generator: TextGenerationPipeline;
+}
+
+export interface LoadedText2TextGenerationPipeline {
+  task: "text2text-generation";
+  generator: Text2TextGenerationPipeline;
+}
+
+export type LoadedGenerationPipeline =
+  | LoadedTextGenerationPipeline
+  | LoadedText2TextGenerationPipeline;
+
 export interface LoaderCallbacks {
   viewportWidth?: number;
   onProgress?: (progress: number, message: string) => void;
@@ -29,6 +56,7 @@ interface NormalizedLoadError {
   message: string;
   isLikelyMemoryError: boolean;
   isNumericRuntimeCode: boolean;
+  isLikelyTaskMismatch: boolean;
 }
 
 function safeJsonStringify(value: unknown): string {
@@ -45,6 +73,7 @@ function normalizeLoadError(error: unknown): NormalizedLoadError {
       message: `Runtime error code: ${error}`,
       isLikelyMemoryError: true,
       isNumericRuntimeCode: true,
+      isLikelyTaskMismatch: false,
     };
   }
 
@@ -57,6 +86,7 @@ function normalizeLoadError(error: unknown): NormalizedLoadError {
         lower.includes("allocation") ||
         lower.includes("out of bounds"),
       isNumericRuntimeCode: /^\d+$/.test(error.trim()),
+      isLikelyTaskMismatch: isLikelyTaskMismatchMessage(lower),
     };
   }
 
@@ -70,6 +100,7 @@ function normalizeLoadError(error: unknown): NormalizedLoadError {
         lower.includes("allocation") ||
         lower.includes("out of bounds"),
       isNumericRuntimeCode: false,
+      isLikelyTaskMismatch: isLikelyTaskMismatchMessage(lower),
     };
   }
 
@@ -98,6 +129,7 @@ function normalizeLoadError(error: unknown): NormalizedLoadError {
         lower.includes("out of bounds") ||
         (maybeCode !== null && /^\d+$/.test(maybeCode)),
       isNumericRuntimeCode: maybeCode !== null && /^\d+$/.test(maybeCode),
+      isLikelyTaskMismatch: isLikelyTaskMismatchMessage(lower),
     };
   }
 
@@ -105,7 +137,33 @@ function normalizeLoadError(error: unknown): NormalizedLoadError {
     message: String(error),
     isLikelyMemoryError: false,
     isNumericRuntimeCode: false,
+    isLikelyTaskMismatch: false,
   };
+}
+
+export function isLikelyTaskMismatchMessage(message: string): boolean {
+  const lower = message.toLowerCase();
+
+  return (
+    lower.includes("unsupported model type") ||
+    lower.includes('for task "text-generation"') ||
+    lower.includes("modelwithlmhead") ||
+    lower.includes("modelforcausallm")
+  );
+}
+
+async function createGenerationPipeline(
+  task: GenerationTask,
+  modelId: string,
+  options: Record<string, unknown>
+): Promise<GenerationPipeline> {
+  if (task === "text-generation") {
+    const pipelineResult = await pipeline("text-generation", modelId, options);
+    return pipelineResult as TextGenerationPipeline;
+  }
+
+  const pipelineResult = await pipeline("text2text-generation", modelId, options);
+  return pipelineResult as Text2TextGenerationPipeline;
 }
 
 /**
@@ -113,8 +171,9 @@ function normalizeLoadError(error: unknown): NormalizedLoadError {
  * Dtype is selected from viewport-aware preferences with fallback ordering.
  */
 export async function loadModel(
-  callbacks: LoaderCallbacks = {}
-): Promise<TextGenerationPipeline | null> {
+  callbacks: LoaderCallbacks = {},
+  createPipeline: GenerationPipelineFactory = createGenerationPipeline
+): Promise<LoadedGenerationPipeline | null> {
   let attempts = 0;
   const preferredDtype = getDeviceSpecificDtype(callbacks.viewportWidth);
   const dtypeFallbackOrder = getDtypeFallbackOrder(preferredDtype);
@@ -168,13 +227,16 @@ export async function loadModel(
         },
       };
 
-      const pipelineResult = await pipeline(
+      const pipelineResult = await createPipeline(
         "text-generation",
         MODEL_ID,
         pipelineOptions
       );
 
-      return pipelineResult as TextGenerationPipeline;
+      return {
+        task: "text-generation",
+        generator: pipelineResult as TextGenerationPipeline,
+      };
     } catch (error) {
       const normalizedError = normalizeLoadError(error);
       const fallbackHint = normalizedError.isLikelyMemoryError
@@ -182,8 +244,49 @@ export async function loadModel(
         : "Trying next dtype fallback option.";
 
       logger.error(
-        `attempt ${attempts} failed for ${dtype}: ${normalizedError.message}`
+        `attempt ${attempts} failed for ${dtype} (text-generation): ${normalizedError.message}`
       );
+
+      if (normalizedError.isLikelyTaskMismatch) {
+        logger.warn(
+          `model ${MODEL_ID} appears incompatible with text-generation; retrying text2text-generation for the same dtype.`
+        );
+
+        try {
+          const pipelineResult = await createPipeline(
+            "text2text-generation",
+            MODEL_ID,
+            pipelineOptions
+          );
+
+          return {
+            task: "text2text-generation",
+            generator: pipelineResult as Text2TextGenerationPipeline,
+          };
+        } catch (fallbackError) {
+          const normalizedFallbackError = normalizeLoadError(fallbackError);
+          const fallbackTaskHint = normalizedFallbackError.isLikelyMemoryError
+            ? "Likely memory/runtime pressure while retrying text2text-generation."
+            : "Trying next dtype fallback option.";
+
+          logger.error(
+            `attempt ${attempts} failed for ${dtype} (text2text-generation): ${normalizedFallbackError.message}`
+          );
+
+          if (
+            normalizedFallbackError.isLikelyMemoryError ||
+            normalizedFallbackError.isNumericRuntimeCode
+          ) {
+            logger.warn(fallbackTaskHint);
+            if (normalizedFallbackError.isNumericRuntimeCode) {
+              logger.warn(
+                "numeric runtime codes from ONNX/WebAssembly are often opaque; fallback will continue."
+              );
+            }
+          }
+        }
+      }
+
       if (
         normalizedError.isLikelyMemoryError ||
         normalizedError.isNumericRuntimeCode

--- a/src/services/ai/worker.ts
+++ b/src/services/ai/worker.ts
@@ -6,20 +6,66 @@
 import {
   TextStreamer,
   env,
-  type TextGenerationPipeline,
+  type Text2TextGenerationOutput,
+  type TextGenerationOutput,
 } from "@huggingface/transformers";
 import { WorkerAction, WorkerStatus, type WorkerRequest } from "@/types/worker";
 import { GENERATION_PARAMS } from "@/config/prompts";
 import { createLogger, LOG_AREAS } from "@/utils";
 import { generatePrompt, cleanInput } from "./contextProvider";
-import { loadModel } from "./modelLoader";
+import { loadModel, type LoadedGenerationPipeline } from "./modelLoader";
 
 env.allowLocalModels = false;
 env.remoteHost = "https://huggingface.co";
 
 let viewportWidth: number | undefined;
-let generator: TextGenerationPipeline | null = null;
+let loadedPipeline: LoadedGenerationPipeline | null = null;
 const logger = createLogger(LOG_AREAS.AI_WORKER);
+
+function extractGeneratedText(output: TextGenerationOutput): string {
+  const generated = output[0]?.generated_text;
+
+  if (typeof generated === "string") {
+    return generated.trim();
+  }
+
+  if (Array.isArray(generated)) {
+    for (let index = generated.length - 1; index >= 0; index -= 1) {
+      const message = generated[index];
+      if (message.role !== "assistant") {
+        continue;
+      }
+
+      if (typeof message.content === "string") {
+        return message.content.trim();
+      }
+
+      if (Array.isArray(message.content)) {
+        return message.content
+          .map((part) => {
+            if (typeof part === "string") {
+              return part;
+            }
+
+            if (
+              typeof part === "object" &&
+              part !== null &&
+              "text" in part &&
+              typeof part.text === "string"
+            ) {
+              return part.text;
+            }
+
+            return "";
+          })
+          .join("")
+          .trim();
+      }
+    }
+  }
+
+  return "";
+}
 
 self.addEventListener("message", async (event: MessageEvent<WorkerRequest>) => {
   const { action, input, viewportWidth: nextViewportWidth } = event.data;
@@ -32,7 +78,7 @@ self.addEventListener("message", async (event: MessageEvent<WorkerRequest>) => {
 
   if (action === WorkerAction.LOAD) {
     try {
-      generator = await loadModel({
+      loadedPipeline = await loadModel({
         viewportWidth,
         onProgress: (progress, message) => {
           self.postMessage({
@@ -43,8 +89,8 @@ self.addEventListener("message", async (event: MessageEvent<WorkerRequest>) => {
         },
       });
 
-      if (generator) {
-        logger.info("model loaded");
+      if (loadedPipeline) {
+        logger.info(`model loaded via ${loadedPipeline.task}`);
         self.postMessage({
           status: WorkerStatus.LOAD,
           message: "Model loaded successfully!",
@@ -76,7 +122,7 @@ self.addEventListener("message", async (event: MessageEvent<WorkerRequest>) => {
       return;
     }
 
-    if (!generator) {
+    if (!loadedPipeline) {
       self.postMessage({
         status: WorkerStatus.STREAM,
         response:
@@ -86,7 +132,7 @@ self.addEventListener("message", async (event: MessageEvent<WorkerRequest>) => {
       return;
     }
 
-    if (!generator.tokenizer) {
+    if (!loadedPipeline.generator.tokenizer) {
       self.postMessage({
         status: WorkerStatus.STREAM,
         response:
@@ -103,7 +149,7 @@ self.addEventListener("message", async (event: MessageEvent<WorkerRequest>) => {
     let streamedText = "";
 
     try {
-      const streamer = new TextStreamer(generator.tokenizer, {
+      const streamer = new TextStreamer(loadedPipeline.generator.tokenizer, {
         skip_prompt: true,
         skip_special_tokens: true,
         callback_function: (text: string) => {
@@ -112,22 +158,51 @@ self.addEventListener("message", async (event: MessageEvent<WorkerRequest>) => {
         },
       });
 
-      const output = await generator(prompt, {
-        temperature: generationParams.temperature,
-        max_new_tokens: generationParams.maxTokens,
-        do_sample: false,
-        repetition_penalty: generationParams.repetitionPenalty,
-        top_k: generationParams.topK,
-        early_stopping: true,
-        streamer,
-      });
-
-      const generatedText = output[0]?.generated_text.trim() ?? "";
-      if (!streamedText.trim() && generatedText.length > 0) {
-        self.postMessage({
-          status: WorkerStatus.STREAM,
-          response: generatedText,
+      if (loadedPipeline.task === "text-generation") {
+        const output = await loadedPipeline.generator(prompt, {
+          temperature: generationParams.temperature,
+          max_new_tokens: generationParams.maxTokens,
+          do_sample: false,
+          repetition_penalty: generationParams.repetitionPenalty,
+          top_k: generationParams.topK,
+          early_stopping: true,
+          return_full_text: false,
+          streamer,
         });
+
+        const generatedText = extractGeneratedText(
+          output as TextGenerationOutput
+        );
+        if (!generatedText) {
+          logger.warn("text-generation output completed without assistant text");
+        } else if (!streamedText.trim()) {
+          self.postMessage({
+            status: WorkerStatus.STREAM,
+            response: generatedText,
+          });
+        }
+      } else {
+        const output = await loadedPipeline.generator(prompt, {
+          temperature: generationParams.temperature,
+          max_new_tokens: generationParams.maxTokens,
+          do_sample: false,
+          repetition_penalty: generationParams.repetitionPenalty,
+          top_k: generationParams.topK,
+          early_stopping: true,
+          streamer,
+        });
+
+        const generatedText =
+          (output as Text2TextGenerationOutput)[0]?.generated_text.trim() ?? "";
+
+        if (!generatedText) {
+          logger.warn("text2text-generation output completed without text");
+        } else if (!streamedText.trim()) {
+          self.postMessage({
+            status: WorkerStatus.STREAM,
+            response: generatedText,
+          });
+        }
       }
     } catch (e) {
       self.postMessage({

--- a/tests/export.spec.ts
+++ b/tests/export.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect } from "@playwright/test";
 import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
-import { access, readFile } from "node:fs/promises";
+import { access, readFile, readdir } from "node:fs/promises";
 import path from "node:path";
 import { DERIVED_CONFIG, SITE_CONFIG } from "../src/config/site";
 
@@ -39,6 +39,35 @@ function isBlockedRawGitHubHost(urlValue: string): boolean {
   } catch {
     return false;
   }
+}
+
+async function getJavaScriptFiles(directory: string): Promise<string[]> {
+  const entries = await readdir(directory, { withFileTypes: true });
+  const files: string[] = [];
+
+  for (const entry of entries) {
+    const entryPath = path.join(directory, entry.name);
+
+    if (entry.isDirectory()) {
+      files.push(...(await getJavaScriptFiles(entryPath)));
+    } else if (entry.isFile() && entry.name.endsWith(".js")) {
+      files.push(entryPath);
+    }
+  }
+
+  return files;
+}
+
+async function readExportedJavaScript(): Promise<string> {
+  const chunksDir = path.resolve(process.cwd(), "out", "_next", "static");
+  const files = await getJavaScriptFiles(chunksDir).catch(() => {
+    throw new Error(
+      "Missing exported JavaScript at out/_next/static. Run `npm run build` before Playwright tests.",
+    );
+  });
+  const contents = await Promise.all(files.map((filePath) => readFile(filePath, "utf8")));
+
+  return contents.join("\n");
 }
 
 interface StaticPreviewServer {
@@ -156,6 +185,17 @@ test("should export bundled social icon assets with valid local paths", async ()
   expect(hasBlockedRawGitHubSource).toBe(false);
 });
 
+test("should export the current browser AI worker bundle", async () => {
+  const exportedJavaScript = await readExportedJavaScript();
+
+  expect(exportedJavaScript).toContain("teapotai/teapotllm");
+  expect(exportedJavaScript).toContain("text2text-generation");
+  expect(exportedJavaScript).not.toContain(
+    "justinthelaw/Qwen2.5-0.5B-Instruct-Resume-Cover-Letter-SFT",
+  );
+  expect(exportedJavaScript).not.toContain("onnx-community/Qwen2.5-0.5B-Instruct");
+});
+
 test("should preview static export from the emitted base path", async () => {
   const socialIconFiles = getSocialIconFiles();
   const previewServer = await startStaticPreviewServer();
@@ -179,6 +219,47 @@ test("should preview static export from the emitted base path", async () => {
     const iconResponse = await fetch(new URL(`${basePath}/${socialIconFiles[0]}`, rootUrl));
     expect(iconResponse.status).toBe(200);
     expect(iconResponse.headers.get("content-type")).toBe("image/png");
+  } finally {
+    await previewServer.close();
+  }
+});
+
+test("should initialize the exported AI worker from the base path", async ({
+  page,
+}) => {
+  const previewServer = await startStaticPreviewServer();
+  const staticFailures: string[] = [];
+  const workerLogs: string[] = [];
+
+  page.on("response", (response) => {
+    const responseUrl = response.url();
+    if (responseUrl.includes("/_next/static/") && response.status() >= 400) {
+      staticFailures.push(`${response.status()} ${responseUrl}`);
+    }
+  });
+
+  page.on("console", (message) => {
+    const text = message.text();
+    if (text.includes("[AI WORKER]")) {
+      workerLogs.push(text);
+    }
+  });
+
+  await page.route("https://huggingface.co/**", (route) => {
+    route.abort();
+  });
+
+  try {
+    await page.goto(previewServer.origin);
+    await page.getByTestId("ai-chatbot-button").click();
+
+    await expect
+      .poll(() =>
+        workerLogs.some((line) => line.includes("[AI WORKER] initialized")),
+      )
+      .toBeTruthy();
+
+    expect(staticFailures).toEqual([]);
   } finally {
     await previewServer.close();
   }

--- a/tests/models.spec.ts
+++ b/tests/models.spec.ts
@@ -12,6 +12,19 @@ import {
   getPersonalContextBudget,
   getPromptBudget,
 } from "../src/services/ai/contextProvider";
+import {
+  isLikelyTaskMismatchMessage,
+  loadModel,
+  type GenerationPipelineFactory,
+  type GenerationTask,
+} from "../src/services/ai/modelLoader";
+import type { Text2TextGenerationPipeline } from "@huggingface/transformers";
+
+interface PipelineCall {
+  task: GenerationTask;
+  modelId: string;
+  dtype: string;
+}
 
 function estimateTokenCount(text: string): number {
   return Math.ceil(text.length / 4);
@@ -26,6 +39,58 @@ test.describe("Model dtype policy", () => {
 
   test("does not automatically retry q4 after a q4 preference", () => {
     expect(getDtypeFallbackOrder("q4")).toEqual(["int8", "uint8"]);
+  });
+
+  test("detects incompatible live model architectures for task fallback", () => {
+    expect(
+      isLikelyTaskMismatchMessage("Unsupported model type: t5")
+    ).toBeTruthy();
+    expect(
+      isLikelyTaskMismatchMessage(
+        'Unsupported model type "t5" for task "text-generation".'
+      )
+    ).toBeTruthy();
+    expect(
+      isLikelyTaskMismatchMessage("Failed to allocate memory buffer")
+    ).toBeFalsy();
+  });
+
+  test("retries text2text generation after a task mismatch", async () => {
+    const calls: PipelineCall[] = [];
+    const fakeText2TextGenerator = {} as unknown as Text2TextGenerationPipeline;
+    const fakePipeline: GenerationPipelineFactory = async (
+      task,
+      modelId,
+      options
+    ) => {
+      calls.push({
+        task,
+        modelId,
+        dtype: typeof options.dtype === "string" ? options.dtype : "unknown",
+      });
+
+      if (task === "text-generation") {
+        throw new Error("Unsupported model type: t5");
+      }
+
+      return fakeText2TextGenerator;
+    };
+
+    const loadedPipeline = await loadModel({}, fakePipeline);
+
+    expect(loadedPipeline?.task).toBe("text2text-generation");
+    expect(calls).toEqual([
+      {
+        task: "text-generation",
+        modelId: MODEL_ID,
+        dtype: "int8",
+      },
+      {
+        task: "text2text-generation",
+        modelId: MODEL_ID,
+        dtype: "int8",
+      },
+    ]);
   });
 });
 


### PR DESCRIPTION
## Summary

Fixes browser-side model loading for the deployed static GitHub Pages site by making the AI worker resilient when the live Teapot model rejects the initial `text-generation` task on Windows Brave and other browser/runtime combinations.

The loader now retries the same model/dtype as `text2text-generation` when Transformers.js reports a task/model architecture mismatch, while preserving the existing int8 to uint8 dtype fallback chain. The worker records the loaded task and uses the matching generation path so live model downloads still work across browsers and operating systems without hardcoded asset paths.

## Validation

- [ ] `pre-commit run --all-files`
- [x] Repo-specific tests and lint checks were run locally: `npm run flight-check` (`112 passed`, `3 skipped`)
- [x] Docs were updated for user-facing or contributor-facing changes (N/A: focused runtime compatibility fix)

## Checklist

- [x] Scope is focused and reviewable
- [x] Security impact considered
- [x] Breaking changes are clearly documented (N/A: no breaking changes)