### PR TITLE
feat: add browser profile-QA fine-tune pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,5 +45,20 @@ yarn-error.log*
 *.tsbuildinfo
 next-env.d.ts
 
+# python
+__pycache__/
+*.py[cod]
+
 # avoid committing generated or external documents
 public/*.pdf
+
+# local profile-QA training outputs
+/ml/profile-qa/.venv/
+/ml/profile-qa/data/
+/ml/profile-qa/checkpoints/
+/ml/profile-qa/hf/
+/ml/profile-qa/merged/
+/ml/profile-qa/onnx/
+/ml/profile-qa/reports/
+/ml/profile-qa/runs/
+/ml/profile-qa/*.log

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,6 +72,7 @@ tests/                   # Playwright E2E tests
 - **Barrel exports** - every feature directory has an `index.ts` for clean imports.
 - **Typed worker messages** - use `WorkerAction`/`WorkerStatus` enums for worker communication. No magic strings.
 - **Browser-safe dtype loading** - automatic model loading uses int8 with uint8 fallback on all viewports. Do not re-enable q4 by default unless ORT WASM can reliably mount external `.onnx.data` model files in browser workers.
+- **Reusable profile sections** - keep chatbot context sections generic and temporally prioritized (`identity`, `current_role`, `experience`, `projects`, `education`, `recommendations`, `skills`, `interests`). Experience should outrank education; recommendations should sit just below education and above hobbies/interests or personality traits. Put person- or employer-specific terms in fact text/keywords, not section IDs.
 
 ## Code Standards
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,11 @@ downloadable PDF version of my resume and cover letter.
 >
 > Developer workflow docs are available at
 > [docs/DEVELOPMENT.md](docs/DEVELOPMENT.md).
+>
+> Local profile-QA training scaffolding lives in
+> [ml/profile-qa/](ml/profile-qa/README.md). It is designed for local NVIDIA GPU
+> LoRA/QLoRA runs and keeps generated datasets, checkpoints, and ONNX artifacts
+> out of git.
 
 ## Quick Facts
 

--- a/docs/CUSTOMIZATION.md
+++ b/docs/CUSTOMIZATION.md
@@ -47,11 +47,11 @@ Pre-commit hooks mirror the repo's current lint checks:
 
 ## Configuration Files
 
-| File                    | Purpose                                    |
-| ----------------------- | ------------------------------------------ |
-| `src/config/site.ts`    | Personal info, resume, and chatbot profile sections |
-| `src/config/models.ts`  | AI model ID and browser dtype policy       |
-| `src/config/prompts.ts` | Chatbot messages and generation settings   |
+| File                    | Purpose                                                    |
+| ----------------------- | ---------------------------------------------------------- |
+| `src/config/site.ts`    | Personal info, resume, and chatbot profile sections        |
+| `src/config/models.ts`  | AI model ID and browser dtype policy                       |
+| `src/config/prompts.ts` | Chatbot messages and generation settings                   |
 
 The default browser model is
 `justinthelaw/teapot-profile-qa-browser-1024`, a browser ONNX profile-QA model

--- a/docs/CUSTOMIZATION.md
+++ b/docs/CUSTOMIZATION.md
@@ -1,7 +1,7 @@
 # Customization Guide
 
 Make this website your own with an AI chatbot that answers questions about you
-using a plain personal context block from the site configuration.
+using reusable public resume/profile sections from the site configuration.
 
 ## Quick Setup Checklist
 
@@ -20,7 +20,7 @@ Edit `src/config/site.ts` and `src/config/prompts.ts`:
 - [ ] Set `repository.owner` and `repository.name`
 - [ ] Set `resumeFileId` (from Google Drive share link)
 - [ ] Update `socialLinks` (empty string hides a link)
-- [ ] Summarize resume, cover letter, and personal knowledge in `PERSONAL_CONTEXT`
+- [ ] Summarize resume, cover letter, and personal knowledge in `PROFILE_SECTIONS`
 - [ ] Update `CHATBOT_CONFIG.welcomeMessages`
 
 ### 3. Upload Resume (~2 min)
@@ -49,35 +49,55 @@ Pre-commit hooks mirror the repo's current lint checks:
 
 | File                    | Purpose                                    |
 | ----------------------- | ------------------------------------------ |
-| `src/config/site.ts`    | Personal info, resume, and chatbot context |
+| `src/config/site.ts`    | Personal info, resume, and chatbot profile sections |
 | `src/config/models.ts`  | AI model ID and browser dtype policy       |
 | `src/config/prompts.ts` | Chatbot messages and generation settings   |
 
-The default browser model is `teapotai/teapotllm`.
+The default browser model is
+`justinthelaw/teapot-profile-qa-browser-1024`, a browser ONNX profile-QA model
+published with `int8` and `uint8` variants.
 
 ## Common Customizations
 
 ### Update Chatbot Context
 
-Edit `PERSONAL_CONTEXT` in `src/config/site.ts`:
+Edit `PROFILE_SECTIONS` in `src/config/site.ts`. Keep the section IDs generic
+so forks can reuse the retrieval behavior:
 
 ```typescript
-export const PERSONAL_CONTEXT = `
-Paste your resume, cover letter, biography, project notes, recommendations,
-or any other public information the chatbot should use here.
-`.trim();
+export const PROFILE_SECTIONS = [
+  {
+    id: "identity",
+    title: "Identity",
+    priority: 100,
+    alwaysInclude: true,
+    keywords: ["name", "location", "identity"],
+    facts: [
+      {
+        id: "identity_location",
+        text: "Your Name is based in Your Location.",
+        keywords: ["your name", "your location"],
+      },
+    ],
+  },
+  // current_role, experience, projects, education, skills, interests,
+  // and recommendations follow the same shape.
+] as const satisfies readonly ProfileSection[];
 ```
 
-The chatbot receives this text block as its source of truth. Keep it concise:
-roughly 150-220 words is a good target for Teapot LLM, leaving room for the
-prompt and the visitor's question. Short paragraphs and high-signal
-bullet-style sentences work best.
+`PERSONAL_CONTEXT` is derived from these sections for compatibility. The
+browser prompt builder always includes identity facts, retrieves relevant
+sections from the latest question plus recent turns, and trims user input only
+after selected sections and history fit the active model budget.
 
-Put the most important facts first. If the profile text is still too long for
-the browser model, the app trims from the tail and shows a small warning icon
-under the first chat message. Hover or focus the icon for exact overage details.
-The chat input also shows a warning icon when a visitor's message would exceed
-the remaining prompt budget before tail trimming.
+Put reusable categories in section IDs and person-specific terms in fact text or
+fact keywords. Keep generic sections temporally prioritized: `current_role`,
+`experience`, `projects`, `education`, `recommendations`, `skills`, then
+`interests`. Experience should outrank education; recommendations should sit
+just below education and above hobbies/interests or personality-trait sections.
+Avoid employer- or person-specific section IDs. If selected profile sections or
+visitor input exceed the browser model budget, the chat UI shows a small
+warning icon with exact overage details.
 
 ### Hide a Social Link
 
@@ -98,7 +118,8 @@ socialLinks: {
 Edit `src/config/models.ts`:
 
 ```typescript
-export const MODEL_ID = "teapotai/teapotllm";
+export const MODEL_ID = "justinthelaw/teapot-profile-qa-browser-1024";
+export const MODEL_CONTEXT_LIMIT = 1024;
 ```
 
 Use a model that is compatible with Transformers.js browser inference. If the

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -5,7 +5,19 @@ import reactHooksPlugin from "eslint-plugin-react-hooks";
 
 export default tseslint.config(
   {
-    ignores: [".next/**", "out/**", "node_modules/**", "*.config.*"],
+    ignores: [
+      ".next/**",
+      "out/**",
+      "node_modules/**",
+      "ml/profile-qa/.venv/**",
+      "ml/profile-qa/checkpoints/**",
+      "ml/profile-qa/data/**",
+      "ml/profile-qa/merged/**",
+      "ml/profile-qa/onnx/**",
+      "ml/profile-qa/reports/**",
+      "ml/profile-qa/runs/**",
+      "*.config.*",
+    ],
   },
   js.configs.recommended,
   {

--- a/ml/profile-qa/README.md
+++ b/ml/profile-qa/README.md
@@ -1,0 +1,87 @@
+# Local NVIDIA Profile-QA Pipeline
+
+This directory contains the local-only training and promotion pipeline for a
+browser profile Q&A model targeting a 1024-token prompt budget. Generated data,
+checkpoints, merged weights, ONNX exports, and reports are ignored by git.
+
+The profile ontology is intentionally generic for fork reuse: section IDs should
+stay in resume categories such as `identity`, `current_role`, `experience`,
+`projects`, `education`, `recommendations`, `skills`, and `interests`. Keep
+that order temporal and practical: experience outranks education, and
+recommendations sit just below education but above hobbies/interests or
+personality-trait sections. Put person-specific names, employers, schools, and
+projects in fact text and keywords.
+
+## Prerequisites
+
+- Run from a normal host shell with visible `/dev/nvidia*` devices, or from a
+  container launched with NVIDIA device passthrough.
+- CUDA-enabled PyTorch wheels are sufficient for v1; `nvcc` is optional unless a
+  dependency needs CUDA extension compilation.
+- Install Python dependencies:
+
+```bash
+python -m venv .venv
+. .venv/bin/activate
+pip install -r ml/profile-qa/requirements.txt
+```
+
+## Commands
+
+```bash
+python -m profile_qa.gpu_health
+python -m profile_qa.synthetic_data --output ml/profile-qa/data/profile_qa.jsonl
+python -m profile_qa.train_lora --dataset ml/profile-qa/data/profile_qa.jsonl
+python -m profile_qa.evaluate --dataset ml/profile-qa/data/profile_qa.jsonl --model-id teapotai/teapotllm
+python -m profile_qa.merge_adapter --adapter-model-id ml/profile-qa/checkpoints/teapot-profile-qa-lora/checkpoint-400 --output-dir ml/profile-qa/merged/teapot-profile-qa
+python -m profile_qa.export_onnx --model ml/profile-qa/merged/teapot-profile-qa --output-dir ml/profile-qa/onnx/candidate
+python -m profile_qa.prepare_hf_artifacts --model-browser-dir ml/profile-qa/onnx/candidate/browser
+python -m profile_qa.publish --repo-id justinthelaw/teapot-profile-qa-browser-1024 --artifact-dir ml/profile-qa/hf/model
+python -m profile_qa.publish --repo-type dataset --repo-id justinthelaw/profile-qa-synthetic-public-v1 --artifact-dir ml/profile-qa/hf/dataset
+```
+
+For targeted continuation from an existing LoRA adapter:
+
+```bash
+python -m profile_qa.train_lora \
+  --dataset ml/profile-qa/data/profile_qa.jsonl \
+  --adapter-model-id ml/profile-qa/checkpoints/teapot-profile-qa-lora/checkpoint-400 \
+  --output-dir ml/profile-qa/checkpoints/teapot-profile-qa-lora-v2 \
+  --max-steps 160 \
+  --learning-rate 7e-5 \
+  --lr-scheduler-type constant_with_warmup
+```
+
+If Teapot cannot pass the 1024-token promotion gate, keep the same pipeline and
+rerun training with:
+
+```bash
+python -m profile_qa.train_lora --model-id Qwen/Qwen2.5-0.5B-Instruct
+```
+
+## Promotion Gate
+
+Do not update the app's browser `MODEL_ID` or default `MODEL_CONTEXT_LIMIT`
+until all of these are true:
+
+- `python -m profile_qa.gpu_health` passes on the training host.
+- Training completed locally on the NVIDIA GPU with the 8GB-safe defaults.
+- Loss targets are met on a split-isolated validation set: eval loss <= 0.12
+  and recent training-loss windows <= 0.05.
+- The promoted model accepts 1024-token prompts without truncating below 1024.
+- Eval beats the current Teapot baseline by at least 15% macro score.
+- Refusal accuracy is at least 95%.
+- Multi-turn follow-up accuracy is at least 80%.
+- Browser smoke loads and answers a 900-1024 token prompt in Chromium desktop
+  and Mobile Chrome without worker crashes.
+- ONNX artifacts include `int8` and `uint8` variants and no `.onnx.data` files.
+
+## Tests
+
+The Python tests cover deterministic generation, schema validation, split
+isolation, evidence references, no private-data leakage in non-refusal examples,
+and GPU health-check behavior:
+
+```bash
+PYTHONPATH=ml/profile-qa python -m pytest ml/profile-qa/tests
+```

--- a/ml/profile-qa/profile_qa/__init__.py
+++ b/ml/profile-qa/profile_qa/__init__.py
@@ -1,2 +1,1 @@
 """Local profile-QA training helpers."""
-

--- a/ml/profile-qa/profile_qa/__init__.py
+++ b/ml/profile-qa/profile_qa/__init__.py
@@ -1,0 +1,2 @@
+"""Local profile-QA training helpers."""
+

--- a/ml/profile-qa/profile_qa/config.py
+++ b/ml/profile-qa/profile_qa/config.py
@@ -1,0 +1,36 @@
+"""Configuration for the local profile-QA pipeline."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[3]
+PACKAGE_ROOT = Path(__file__).resolve().parents[1]
+
+MODEL_CONTEXT_LIMIT = 1024
+PRIMARY_BASE_MODEL_ID = "teapotai/teapotllm"
+FALLBACK_BASE_MODEL_ID = "Qwen/Qwen2.5-0.5B-Instruct"
+DATASET_VERSION = "public-profile-v1"
+
+DATA_DIR = PACKAGE_ROOT / "data"
+CHECKPOINT_DIR = PACKAGE_ROOT / "checkpoints"
+MERGED_DIR = PACKAGE_ROOT / "merged"
+ONNX_DIR = PACKAGE_ROOT / "onnx"
+REPORT_DIR = PACKAGE_ROOT / "reports"
+
+DEFAULT_DATASET_PATH = DATA_DIR / "profile_qa.jsonl"
+DEFAULT_TRAIN_OUTPUT_DIR = CHECKPOINT_DIR / "teapot-profile-qa-lora"
+DEFAULT_EVAL_REPORT_PATH = REPORT_DIR / "profile_qa_eval.json"
+
+LORA_RANK = 16
+LORA_ALPHA = 32
+LORA_DROPOUT = 0.03
+TRAIN_BATCH_SIZE = 1
+EVAL_BATCH_SIZE = 1
+GRADIENT_ACCUMULATION_STEPS = 8
+MAX_STEPS = 720
+LEARNING_RATE = 1e-4
+WEIGHT_DECAY = 0.01
+WARMUP_RATIO = 0.03
+EVAL_STEPS = 40
+SAVE_STEPS = 40

--- a/ml/profile-qa/profile_qa/evaluate.py
+++ b/ml/profile-qa/profile_qa/evaluate.py
@@ -1,0 +1,174 @@
+"""Evaluate profile-QA model outputs against the public synthetic set."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from collections import defaultdict
+from pathlib import Path
+from typing import Any
+
+from .config import DEFAULT_DATASET_PATH, DEFAULT_EVAL_REPORT_PATH, MODEL_CONTEXT_LIMIT
+from .train_lora import format_instruction
+from .validation import read_jsonl
+
+
+def score_answer(record: dict[str, Any], prediction: str) -> dict[str, float]:
+    """Score a prediction with deterministic public-profile metrics."""
+
+    normalized = prediction.lower()
+    expected_terms = [str(term).lower() for term in record.get("expected_terms", [])]
+    term_hits = sum(1 for term in expected_terms if term in normalized)
+    term_score = 1.0 if not expected_terms else term_hits / len(expected_terms)
+    requires_refusal = bool(record.get("requires_refusal"))
+    refusal_hit = "does not say" in normalized or "not in the public profile" in normalized
+    refusal_score = 1.0 if refusal_hit == requires_refusal else 0.0
+    if requires_refusal:
+        return {"macro": refusal_score, "term": 1.0, "refusal": refusal_score}
+    macro = (term_score + refusal_score) / 2
+    return {"macro": macro, "term": term_score, "refusal": refusal_score}
+
+
+def score_predictions(records: list[dict[str, Any]], predictions: dict[str, str]) -> dict[str, Any]:
+    """Aggregate macro, per-task, refusal, and multi-turn metrics."""
+
+    per_record: list[dict[str, Any]] = []
+    by_task: dict[str, list[float]] = defaultdict(list)
+    refusal_scores: list[float] = []
+    multi_turn_scores: list[float] = []
+
+    for record in records:
+        prediction = predictions.get(str(record["id"]), "")
+        scores = score_answer(record, prediction)
+        task = str(record.get("task", "unknown"))
+        by_task[task].append(scores["macro"])
+        if record.get("requires_refusal"):
+            refusal_scores.append(scores["refusal"])
+        if task == "multi_turn":
+            multi_turn_scores.append(scores["macro"])
+        per_record.append({"id": record["id"], "task": task, "prediction": prediction, **scores})
+
+    macro_scores = [item["macro"] for item in per_record]
+    return {
+        "macro": _mean(macro_scores),
+        "by_task": {task: _mean(scores) for task, scores in sorted(by_task.items())},
+        "refusal_accuracy": _mean(refusal_scores),
+        "multi_turn_accuracy": _mean(multi_turn_scores),
+        "records": per_record,
+    }
+
+
+def _mean(values: list[float]) -> float:
+    return sum(values) / len(values) if values else 0.0
+
+
+def _load_generation_stack() -> dict[str, Any]:
+    try:
+        import torch
+        from peft import PeftModel
+        from transformers import (
+            AutoConfig,
+            AutoModelForCausalLM,
+            AutoModelForSeq2SeqLM,
+            AutoTokenizer,
+        )
+    except ImportError as exc:
+        raise RuntimeError("Install eval dependencies with pip install -r ml/profile-qa/requirements.txt") from exc
+    return {
+        "torch": torch,
+        "AutoConfig": AutoConfig,
+        "AutoModelForCausalLM": AutoModelForCausalLM,
+        "AutoModelForSeq2SeqLM": AutoModelForSeq2SeqLM,
+        "AutoTokenizer": AutoTokenizer,
+        "PeftModel": PeftModel,
+    }
+
+
+def _adapter_base_model_id(model_id: str) -> str | None:
+    adapter_config_path = Path(model_id) / "adapter_config.json"
+    if not adapter_config_path.exists():
+        return None
+    adapter_config = json.loads(adapter_config_path.read_text(encoding="utf-8"))
+    base_model_id = adapter_config.get("base_model_name_or_path")
+    return str(base_model_id) if isinstance(base_model_id, str) else None
+
+
+def generate_predictions(model_id: str, records: list[dict[str, Any]]) -> dict[str, str]:
+    """Generate answers locally for a model or adapter directory."""
+
+    stack = _load_generation_stack()
+    adapter_base_model_id = _adapter_base_model_id(model_id)
+    config_model_id = adapter_base_model_id or model_id
+    config = stack["AutoConfig"].from_pretrained(config_model_id, trust_remote_code=True)
+    tokenizer = stack["AutoTokenizer"].from_pretrained(model_id, trust_remote_code=True)
+    if tokenizer.pad_token is None and tokenizer.eos_token is not None:
+        tokenizer.pad_token = tokenizer.eos_token
+    is_encoder_decoder = bool(getattr(config, "is_encoder_decoder", False))
+    model_cls = (
+        stack["AutoModelForSeq2SeqLM"] if is_encoder_decoder else stack["AutoModelForCausalLM"]
+    )
+    model = model_cls.from_pretrained(
+        config_model_id,
+        device_map="auto",
+        torch_dtype=stack["torch"].float16,
+        trust_remote_code=True,
+    )
+    if adapter_base_model_id:
+        model = stack["PeftModel"].from_pretrained(model, model_id)
+    model.eval()
+
+    predictions: dict[str, str] = {}
+    for record in records:
+        prompt = format_instruction(record)
+        inputs = tokenizer(
+            prompt,
+            truncation=True,
+            max_length=MODEL_CONTEXT_LIMIT,
+            return_tensors="pt",
+        )
+        inputs = {key: value.to(model.device) for key, value in inputs.items()}
+        with stack["torch"].no_grad():
+            output_ids = model.generate(
+                **inputs,
+                max_new_tokens=160,
+                do_sample=False,
+            )
+        if is_encoder_decoder:
+            generated_ids = output_ids[0]
+        else:
+            prompt_length = int(inputs["input_ids"].shape[-1])
+            generated_ids = output_ids[0][prompt_length:]
+        generated = tokenizer.decode(generated_ids, skip_special_tokens=True)
+        predictions[str(record["id"])] = str(generated).strip()
+    return predictions
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--dataset", default=str(DEFAULT_DATASET_PATH))
+    parser.add_argument("--model-id")
+    parser.add_argument("--predictions-json")
+    parser.add_argument("--split", default="test")
+    parser.add_argument("--output", default=str(DEFAULT_EVAL_REPORT_PATH))
+    args = parser.parse_args()
+
+    records = [
+        record for record in read_jsonl(Path(args.dataset)) if record.get("split") == args.split
+    ]
+    if args.predictions_json:
+        predictions = json.loads(Path(args.predictions_json).read_text(encoding="utf-8"))
+    elif args.model_id:
+        predictions = generate_predictions(args.model_id, records)
+    else:
+        raise RuntimeError("provide --model-id or --predictions-json")
+
+    report = score_predictions(records, predictions)
+    output_path = Path(args.output)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(report, indent=2, sort_keys=True), encoding="utf-8")
+    print(json.dumps({key: value for key, value in report.items() if key != "records"}, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ml/profile-qa/profile_qa/export_onnx.py
+++ b/ml/profile-qa/profile_qa/export_onnx.py
@@ -1,0 +1,143 @@
+"""Export and validate browser-compatible ONNX artifacts."""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+from .config import ONNX_DIR
+
+
+def reject_external_data_files(output_dir: Path) -> None:
+    """Reject exports that require external .onnx.data sidecar files."""
+
+    external_files = sorted(output_dir.rglob("*.onnx.data"))
+    if external_files:
+        joined = "\n".join(str(path) for path in external_files)
+        raise RuntimeError(f"ONNX export uses external data files, which are not browser-safe:\n{joined}")
+
+
+def run_command(command: list[str]) -> None:
+    result = subprocess.run(command, check=False)
+    if result.returncode != 0:
+        raise RuntimeError(f"command failed with exit code {result.returncode}: {' '.join(command)}")
+
+
+def venv_tool(name: str) -> str:
+    tool_path = Path(sys.executable).parent / name
+    return str(tool_path) if tool_path.exists() else name
+
+
+def export_onnx(model: str, output_dir: Path, task: str) -> None:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    run_command(
+        [
+            venv_tool("optimum-cli"),
+            "export",
+            "onnx",
+            "--model",
+            model,
+            "--task",
+            task,
+            str(output_dir),
+        ]
+    )
+    reject_external_data_files(output_dir)
+
+
+def quantize_onnx(input_dir: Path, output_dir: Path, dtype: str) -> None:
+    if output_dir.exists():
+        shutil.rmtree(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    try:
+        from onnxruntime.quantization import QuantType, quantize_dynamic
+    except ImportError as exc:
+        raise RuntimeError("Install export dependencies with pip install -r ml/profile-qa/requirements.txt") from exc
+
+    weight_type = QuantType.QInt8 if dtype == "int8" else QuantType.QUInt8
+    for source_path in sorted(input_dir.iterdir()):
+        target_path = output_dir / source_path.name
+        if source_path.suffix == ".onnx":
+            quantize_dynamic(
+                model_input=str(source_path),
+                model_output=str(target_path),
+                weight_type=weight_type,
+                extra_options={"EnableSubgraph": True},
+            )
+        elif source_path.is_file():
+            shutil.copy2(source_path, target_path)
+    reject_external_data_files(output_dir)
+
+
+def get_browser_model_paths(quantized_dir: Path) -> list[Path]:
+    """Return ONNX session files needed by Transformers.js browser loading."""
+
+    encoder_path = quantized_dir / "encoder_model.onnx"
+    merged_decoder_path = quantized_dir / "decoder_model_merged.onnx"
+    decoder_only_path = quantized_dir / "model.onnx"
+
+    if encoder_path.exists() and merged_decoder_path.exists():
+        return [encoder_path, merged_decoder_path]
+    if decoder_only_path.exists():
+        return [decoder_only_path]
+    return sorted(quantized_dir.glob("*.onnx"))
+
+
+def assemble_browser_artifact(fp_dir: Path, quantized_dirs: dict[str, Path], output_dir: Path) -> None:
+    """Create a Transformers.js-compatible upload directory."""
+
+    if output_dir.exists():
+        shutil.rmtree(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    onnx_dir = output_dir / "onnx"
+    onnx_dir.mkdir(parents=True, exist_ok=True)
+
+    for source_path in sorted(fp_dir.iterdir()):
+        if source_path.is_file() and source_path.suffix != ".onnx":
+            shutil.copy2(source_path, output_dir / source_path.name)
+
+    for dtype, quantized_dir in quantized_dirs.items():
+        suffix = f"_{dtype}"
+        model_paths = get_browser_model_paths(quantized_dir)
+        if not model_paths:
+            raise RuntimeError(f"no quantized ONNX files found in {quantized_dir}")
+        for model_path in model_paths:
+            shutil.copy2(model_path, onnx_dir / f"{model_path.stem}{suffix}.onnx")
+
+    reject_external_data_files(output_dir)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--model", required=True)
+    parser.add_argument("--output-dir", default=str(ONNX_DIR / "candidate"))
+    parser.add_argument("--task", default="text2text-generation-with-past")
+    parser.add_argument("--skip-export", action="store_true")
+    parser.add_argument("--skip-quantize", action="store_true")
+    args = parser.parse_args()
+
+    output_dir = Path(args.output_dir)
+    fp_dir = output_dir / "onnx"
+    if args.skip_export:
+        reject_external_data_files(fp_dir)
+    else:
+        export_onnx(args.model, fp_dir, args.task)
+
+    quantized_dirs = {
+        "int8": output_dir / "int8",
+        "uint8": output_dir / "uint8",
+    }
+    if not args.skip_quantize:
+        for dtype, quantized_dir in quantized_dirs.items():
+            quantize_onnx(fp_dir, quantized_dir, dtype)
+    assemble_browser_artifact(fp_dir, quantized_dirs, output_dir / "browser")
+
+    print(f"validated browser-safe ONNX artifacts under {output_dir / 'browser'}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ml/profile-qa/profile_qa/gpu_health.py
+++ b/ml/profile-qa/profile_qa/gpu_health.py
@@ -1,0 +1,176 @@
+"""Fail-fast NVIDIA/CUDA health checks for local training."""
+
+from __future__ import annotations
+
+import argparse
+import glob
+import importlib
+import json
+import re
+import subprocess
+from collections.abc import Callable
+from dataclasses import asdict, dataclass
+from typing import Protocol
+
+
+class TorchCudaLike(Protocol):
+    def is_available(self) -> bool: ...
+
+    def get_device_name(self, index: int) -> str: ...
+
+    def get_device_properties(self, index: int) -> object: ...
+
+
+class TorchLike(Protocol):
+    cuda: TorchCudaLike
+
+
+@dataclass(frozen=True)
+class HealthCheck:
+    name: str
+    ok: bool
+    message: str
+
+
+@dataclass(frozen=True)
+class HealthReport:
+    ok: bool
+    checks: list[HealthCheck]
+
+
+def _run_nvidia_smi() -> HealthCheck:
+    try:
+        result = subprocess.run(
+            [
+                "nvidia-smi",
+                "--query-gpu=name,memory.total,driver_version",
+                "--format=csv,noheader",
+            ],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except FileNotFoundError:
+        return HealthCheck("nvidia-smi", False, "nvidia-smi not found on PATH")
+    except subprocess.TimeoutExpired:
+        return HealthCheck("nvidia-smi", False, "nvidia-smi timed out")
+
+    if result.returncode != 0:
+        stderr = result.stderr.strip() or "nvidia-smi returned a non-zero status"
+        return HealthCheck("nvidia-smi", False, stderr)
+
+    summary = result.stdout.strip().splitlines()[0] if result.stdout.strip() else "GPU present"
+    return HealthCheck("nvidia-smi", True, summary)
+
+
+def _check_nvidia_devices(glob_func: Callable[[str], list[str]] = glob.glob) -> HealthCheck:
+    devices = sorted(glob_func("/dev/nvidia*"))
+    if not devices:
+        return HealthCheck(
+            "nvidia-devices",
+            False,
+            "no /dev/nvidia* devices are visible; run from the host or with NVIDIA passthrough",
+        )
+    has_control = "/dev/nvidiactl" in devices
+    has_gpu = any(re.fullmatch(r"/dev/nvidia[0-9]+", device) for device in devices)
+    if not has_control or not has_gpu:
+        return HealthCheck(
+            "nvidia-devices",
+            False,
+            (
+                "NVIDIA capability nodes are visible, but /dev/nvidiactl and a "
+                "GPU node such as /dev/nvidia0 are required for CUDA training"
+            ),
+        )
+    return HealthCheck("nvidia-devices", True, ", ".join(devices))
+
+
+def _import_torch(
+    importer: Callable[[str], object] = importlib.import_module,
+) -> tuple[HealthCheck, TorchLike | None]:
+    try:
+        module = importer("torch")
+    except ImportError:
+        return HealthCheck("torch-import", False, "PyTorch is not installed"), None
+
+    return HealthCheck("torch-import", True, "PyTorch import succeeded"), module  # type: ignore[return-value]
+
+
+def _check_torch_cuda(torch_module: TorchLike | None, min_vram_gb: float) -> list[HealthCheck]:
+    if torch_module is None:
+        return [
+            HealthCheck(
+                "torch-cuda",
+                False,
+                "skipped because PyTorch could not be imported",
+            )
+        ]
+
+    if not torch_module.cuda.is_available():
+        return [HealthCheck("torch-cuda", False, "torch.cuda.is_available() is false")]
+
+    device_name = torch_module.cuda.get_device_name(0)
+    props = torch_module.cuda.get_device_properties(0)
+    total_memory = getattr(props, "total_memory", 0)
+    total_gb = total_memory / 1024**3
+    checks = [
+        HealthCheck(
+            "torch-cuda",
+            True,
+            f"CUDA device 0: {device_name} ({total_gb:.1f} GB)",
+        )
+    ]
+
+    if total_gb < min_vram_gb:
+        checks.append(
+            HealthCheck(
+                "vram",
+                False,
+                f"GPU has {total_gb:.1f} GB VRAM; expected at least {min_vram_gb:.1f} GB",
+            )
+        )
+    else:
+        checks.append(
+            HealthCheck(
+                "vram",
+                True,
+                f"GPU has {total_gb:.1f} GB VRAM; minimum is {min_vram_gb:.1f} GB",
+            )
+        )
+
+    return checks
+
+
+def collect_health_report(min_vram_gb: float = 7.0) -> HealthReport:
+    """Collect NVIDIA and CUDA readiness checks."""
+
+    checks: list[HealthCheck] = [_run_nvidia_smi(), _check_nvidia_devices()]
+    torch_check, torch_module = _import_torch()
+    checks.append(torch_check)
+    checks.extend(_check_torch_cuda(torch_module, min_vram_gb))
+    return HealthReport(ok=all(check.ok for check in checks), checks=checks)
+
+
+def assert_gpu_ready(min_vram_gb: float = 7.0) -> HealthReport:
+    """Return the health report or raise RuntimeError when any check fails."""
+
+    report = collect_health_report(min_vram_gb=min_vram_gb)
+    if not report.ok:
+        failures = [f"{check.name}: {check.message}" for check in report.checks if not check.ok]
+        raise RuntimeError("GPU health check failed:\n" + "\n".join(failures))
+    return report
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--min-vram-gb", type=float, default=7.0)
+    args = parser.parse_args()
+
+    report = collect_health_report(min_vram_gb=args.min_vram_gb)
+    print(json.dumps(asdict(report), indent=2))
+    return 0 if report.ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ml/profile-qa/profile_qa/merge_adapter.py
+++ b/ml/profile-qa/profile_qa/merge_adapter.py
@@ -1,0 +1,45 @@
+"""Merge a trained LoRA adapter into its base model for export."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from .config import MERGED_DIR, PRIMARY_BASE_MODEL_ID
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--adapter-model-id", required=True)
+    parser.add_argument("--base-model-id", default=PRIMARY_BASE_MODEL_ID)
+    parser.add_argument("--output-dir", default=str(MERGED_DIR / "teapot-profile-qa"))
+    args = parser.parse_args()
+
+    try:
+        import torch
+        from peft import PeftModel
+        from transformers import AutoModelForSeq2SeqLM, AutoTokenizer
+    except ImportError as exc:
+        raise RuntimeError("Install merge dependencies with pip install -r ml/profile-qa/requirements.txt") from exc
+
+    output_dir = Path(args.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    tokenizer = AutoTokenizer.from_pretrained(args.adapter_model_id, trust_remote_code=True)
+    base_model = AutoModelForSeq2SeqLM.from_pretrained(
+        args.base_model_id,
+        torch_dtype=torch.float16,
+        device_map="auto",
+        trust_remote_code=True,
+    )
+    model = PeftModel.from_pretrained(base_model, args.adapter_model_id)
+    merged_model = model.merge_and_unload()
+
+    merged_model.save_pretrained(output_dir, safe_serialization=True)
+    tokenizer.save_pretrained(output_dir)
+    print(f"merged adapter {args.adapter_model_id} into {output_dir}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ml/profile-qa/profile_qa/prepare_hf_artifacts.py
+++ b/ml/profile-qa/profile_qa/prepare_hf_artifacts.py
@@ -1,0 +1,446 @@
+"""Prepare Hugging Face model and dataset repository payloads."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+from collections import Counter
+from pathlib import Path
+from typing import Any
+
+from .config import DEFAULT_DATASET_PATH, ONNX_DIR, PACKAGE_ROOT, REPORT_DIR
+from .export_onnx import reject_external_data_files
+from .public_profile import PROFILE_SECTIONS
+from .validation import read_jsonl, write_jsonl
+
+DEFAULT_MODEL_REPO_ID = "justinthelaw/teapot-profile-qa-browser-1024"
+DEFAULT_DATASET_REPO_ID = "justinthelaw/profile-qa-synthetic-public-v1"
+
+
+def _load_report(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _metric(value: float) -> str:
+    return f"{value:.4f}"
+
+
+def _copy_tree_contents(source_dir: Path, target_dir: Path) -> None:
+    if target_dir.exists():
+        shutil.rmtree(target_dir)
+    target_dir.mkdir(parents=True, exist_ok=True)
+    for source_path in sorted(source_dir.iterdir()):
+        target_path = target_dir / source_path.name
+        if source_path.is_dir():
+            shutil.copytree(source_path, target_path, dirs_exist_ok=True)
+        elif source_path.is_file():
+            shutil.copy2(source_path, target_path)
+
+
+def _write_json(path: Path, value: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(value, indent=2, sort_keys=True), encoding="utf-8")
+
+
+def _split_records(records: list[dict[str, Any]], split: str) -> list[dict[str, Any]]:
+    return [record for record in records if record.get("split") == split]
+
+
+def _counter_table(counter: Counter[str], header: str) -> str:
+    lines = [f"| {header} | Count |", "| --- | ---: |"]
+    for key, count in sorted(counter.items()):
+        lines.append(f"| `{key}` | {count} |")
+    return "\n".join(lines)
+
+
+def _evaluation_table(
+    baseline_test: dict[str, Any],
+    promoted_validation: dict[str, Any],
+    promoted_test: dict[str, Any],
+) -> str:
+    return "\n".join(
+        [
+            "| Run | Macro | Refusal Accuracy | Multi-Turn Accuracy |",
+            "| --- | ---: | ---: | ---: |",
+            (
+                "| Teapot baseline, test | "
+                f"{_metric(float(baseline_test['macro']))} | "
+                f"{_metric(float(baseline_test['refusal_accuracy']))} | "
+                f"{_metric(float(baseline_test['multi_turn_accuracy']))} |"
+            ),
+            (
+                "| Promoted checkpoint, validation | "
+                f"{_metric(float(promoted_validation['macro']))} | "
+                f"{_metric(float(promoted_validation['refusal_accuracy']))} | "
+                f"{_metric(float(promoted_validation['multi_turn_accuracy']))} |"
+            ),
+            (
+                "| Promoted checkpoint, test | "
+                f"{_metric(float(promoted_test['macro']))} | "
+                f"{_metric(float(promoted_test['refusal_accuracy']))} | "
+                f"{_metric(float(promoted_test['multi_turn_accuracy']))} |"
+            ),
+        ]
+    )
+
+
+def _task_table(report: dict[str, Any]) -> str:
+    lines = ["| Task | Macro |", "| --- | ---: |"]
+    for task, score in sorted(report["by_task"].items()):
+        lines.append(f"| `{task}` | {_metric(float(score))} |")
+    return "\n".join(lines)
+
+
+def _write_model_card(
+    output_path: Path,
+    *,
+    model_repo_id: str,
+    dataset_repo_id: str,
+    baseline_test: dict[str, Any],
+    promoted_validation: dict[str, Any],
+    promoted_test: dict[str, Any],
+) -> None:
+    output_path.write_text(
+        f"""---
+license: mit
+library_name: transformers.js
+base_model: teapotai/teapotllm
+pipeline_tag: text-generation
+tags:
+- transformers.js
+- onnx
+- int8
+- uint8
+- lora
+- profile-qa
+datasets:
+- {dataset_repo_id}
+metrics:
+- accuracy
+---
+
+# Teapot Profile-QA Browser 1024
+
+## Description
+
+This model is a browser-oriented ONNX export of a local LoRA continuation from
+`teapotai/teapotllm`. It is tuned for public resume/profile Q&A prompts that fit
+within a 1024-token browser context budget.
+
+Hugging Face model metadata uses the official `text-generation` task category;
+the browser runtime still loads this T5-style export with the Transformers.js
+`text2text-generation` pipeline.
+
+The target use case is a static portfolio or resume site that runs inference in
+the browser with Transformers.js, without API routes, hosted inference, server
+actions, or cloud training. The profile schema is intentionally generic for repo
+reuse: `identity`, `current_role`, `experience`, `projects`, `education`,
+`recommendations`, `skills`, and `interests`.
+
+## Browser Artifacts
+
+The repository payload contains tokenizer/config files at the root and
+Transformers.js ONNX files under `onnx/`:
+
+- `encoder_model_int8.onnx`
+- `decoder_model_merged_int8.onnx`
+- `encoder_model_uint8.onnx`
+- `decoder_model_merged_uint8.onnx`
+
+The export gate rejects external `.onnx.data` files so the model can be loaded
+as self-contained browser assets.
+
+## How to Use
+
+```javascript
+import {{ pipeline }} from "@huggingface/transformers";
+
+const generator = await pipeline(
+  "text2text-generation",
+  "{model_repo_id}",
+  {{ dtype: "int8" }},
+);
+
+const result = await generator(prompt, {{ max_new_tokens: 160 }});
+```
+
+Use `dtype: "uint8"` as a browser fallback if the target environment has issues
+with signed int8 ONNX weights.
+
+## Training
+
+- Base model: `teapotai/teapotllm`
+- Method: local LoRA/QLoRA continuation, no full fine-tune and no cloud training
+- Promoted checkpoint: `teapot-profile-qa-lora-v5/checkpoint-40`
+- LoRA: rank 16, alpha 32, dropout 0.03, target modules `q` and `v`
+- 8GB-safe settings: 4-bit base loading, batch size 1, gradient accumulation 8,
+  gradient checkpointing, short eval batches
+- Final continuation window: train loss 0.0330 at step 40
+- Best validation eval loss: 0.0287
+
+## Software
+
+- Training: PyTorch, Transformers, PEFT, bitsandbytes, Datasets
+- Export: Optimum ONNX export, ONNX Runtime dynamic quantization
+- Browser runtime: Transformers.js with ONNX Runtime Web/WASM
+- Browser packaging: `text2text-generation-with-past` export with
+  `decoder_model_merged` and subgraph-enabled ONNX quantization
+
+## Hardware
+
+Training was designed for a local 8GB NVIDIA laptop GPU profile, with GPU
+health checks for `nvidia-smi`, `/dev/nvidia*`, CUDA-enabled PyTorch, and
+`torch.cuda.is_available()`. Export and card preparation can run on CPU after
+training completes.
+
+## Evaluation
+
+{_evaluation_table(baseline_test, promoted_validation, promoted_test)}
+
+Promoted checkpoint test macro by task:
+
+{_task_table(promoted_test)}
+
+## Intended Uses
+
+- Browser-only profile or resume Q&A.
+- Static portfolio demos where answers must stay grounded in public profile
+  context.
+- Forks that replace the included public facts with another person's public
+  resume/profile sections.
+
+## Limitations
+
+This is not a general assistant. The dataset is synthetic and profile-specific,
+so production use should regenerate data from the target person's public facts
+and rerun local evaluation. The model should refuse private or unsupported facts
+when the public profile context does not answer.
+
+## Responsible AI Considerations
+
+Keep factual context public, review generated examples for private-data leakage,
+and preserve refusal examples for sensitive or absent facts such as home
+addresses, phone numbers, salary, and classified information. Do not use this
+model for background checks, hiring decisions, legal advice, medical advice, or
+identity verification.
+
+## Release Notes
+
+- 2026-06-19: Initial local browser profile-QA export with `int8` and `uint8`
+  ONNX variants.
+
+## License
+
+MIT. The base model card for `teapotai/teapotllm` also lists MIT.
+""",
+        encoding="utf-8",
+    )
+
+
+def _write_dataset_card(
+    output_path: Path,
+    *,
+    records: list[dict[str, Any]],
+    model_repo_id: str,
+    baseline_test: dict[str, Any],
+    promoted_validation: dict[str, Any],
+    promoted_test: dict[str, Any],
+) -> None:
+    split_counter = Counter(str(record["split"]) for record in records)
+    task_counter = Counter(str(record["task"]) for record in records)
+    output_path.write_text(
+        f"""---
+license: mit
+task_categories:
+- text-generation
+language:
+- en
+pretty_name: Profile-QA Synthetic Public V1
+tags:
+- synthetic
+- profile-qa
+- resume
+- public-profile
+size_categories:
+- n<1K
+---
+
+# Profile-QA Synthetic Public V1
+
+## Description
+
+This dataset contains deterministic synthetic Q&A examples for public
+resume/profile answering. It was generated from generic resume sections and
+public-style facts, with evidence references back to `section_id` and `fact_id`.
+
+The ontology is intentionally reusable across people and forks:
+`identity`, `current_role`, `experience`, `projects`, `education`,
+`recommendations`, `skills`, and `interests`. Temporal and practical sections
+are prioritized first; experience outranks education, and recommendations sit
+below education but above hobbies/interests or personality-trait sections.
+
+## Files
+
+- `profile_qa.jsonl`: full dataset.
+- `profile_qa_train.jsonl`: train split.
+- `profile_qa_validation.jsonl`: validation split.
+- `profile_qa_test.jsonl`: test split.
+- `profile_sections.json`: source public profile sections and facts.
+- `eval_reports/*.json`: baseline and promoted model evaluation reports.
+
+## Schema
+
+Each JSONL record contains:
+
+- `id`: stable example id.
+- `split`: `train`, `validation`, or `test`.
+- `task`: task family such as `single_turn`, `multi_turn`, `multi_hop`,
+  `chronology`, `education`, `recommendations`, or `refusal`.
+- `question`: user question.
+- `answer`: target grounded answer.
+- `evidence`: list of `section_id` and `fact_id` references.
+- `expected_terms`: scoring terms for deterministic evaluation.
+- `requires_refusal`: true when the answer must say the public profile does not
+  provide the requested fact.
+- `history`: recent conversation turns for follow-up examples.
+- `source_profile_version`: generator/profile version.
+
+## Splits
+
+{_counter_table(split_counter, "Split")}
+
+## Task Coverage
+
+{_counter_table(task_counter, "Task")}
+
+## Evaluation
+
+The paired model for this dataset is `{model_repo_id}`.
+
+{_evaluation_table(baseline_test, promoted_validation, promoted_test)}
+
+Promoted checkpoint test macro by task:
+
+{_task_table(promoted_test)}
+
+## Intended Uses
+
+- Local LoRA/QLoRA continuation training for browser profile Q&A.
+- Regression tests for section retrieval, evidence grounding, follow-up turns,
+  unsupported fact refusal, and 1024-token prompt budgeting.
+- A template for replacing facts with another person's public resume/profile
+  data while keeping reusable generic sections.
+
+## Limitations
+
+The examples are synthetic and derived from a small public-profile fact set.
+They are useful for focused profile-QA behavior, not for broad instruction
+tuning. Regenerate and audit the dataset before using it for another person.
+
+## Safety
+
+The generator and tests reject private-data leakage in non-refusal examples and
+include refusal coverage for absent or sensitive facts. Keep generated datasets,
+checkpoints, merged models, and ONNX artifacts out of git-tracked source.
+
+## License
+
+MIT.
+""",
+        encoding="utf-8",
+    )
+
+
+def prepare_model_payload(args: argparse.Namespace) -> Path:
+    browser_dir = Path(args.model_browser_dir)
+    if not browser_dir.exists():
+        raise RuntimeError(f"model browser directory does not exist: {browser_dir}")
+    reject_external_data_files(browser_dir)
+
+    model_output_dir = Path(args.output_dir) / "model"
+    _copy_tree_contents(browser_dir, model_output_dir)
+
+    baseline_test = _load_report(Path(args.baseline_report))
+    promoted_validation = _load_report(Path(args.validation_report))
+    promoted_test = _load_report(Path(args.test_report))
+    _write_model_card(
+        model_output_dir / "README.md",
+        model_repo_id=args.model_repo_id,
+        dataset_repo_id=args.dataset_repo_id,
+        baseline_test=baseline_test,
+        promoted_validation=promoted_validation,
+        promoted_test=promoted_test,
+    )
+    reject_external_data_files(model_output_dir)
+    return model_output_dir
+
+
+def prepare_dataset_payload(args: argparse.Namespace) -> Path:
+    records = read_jsonl(Path(args.dataset))
+    dataset_output_dir = Path(args.output_dir) / "dataset"
+    if dataset_output_dir.exists():
+        shutil.rmtree(dataset_output_dir)
+    dataset_output_dir.mkdir(parents=True, exist_ok=True)
+
+    write_jsonl(dataset_output_dir / "profile_qa.jsonl", records)
+    for split in ["train", "validation", "test"]:
+        write_jsonl(dataset_output_dir / f"profile_qa_{split}.jsonl", _split_records(records, split))
+    _write_json(dataset_output_dir / "profile_sections.json", PROFILE_SECTIONS)
+
+    reports_dir = dataset_output_dir / "eval_reports"
+    reports_dir.mkdir(parents=True, exist_ok=True)
+    for report_path in [
+        Path(args.baseline_report),
+        Path(args.validation_report),
+        Path(args.test_report),
+    ]:
+        shutil.copy2(report_path, reports_dir / report_path.name)
+
+    baseline_test = _load_report(Path(args.baseline_report))
+    promoted_validation = _load_report(Path(args.validation_report))
+    promoted_test = _load_report(Path(args.test_report))
+    _write_dataset_card(
+        dataset_output_dir / "README.md",
+        records=records,
+        model_repo_id=args.model_repo_id,
+        baseline_test=baseline_test,
+        promoted_validation=promoted_validation,
+        promoted_test=promoted_test,
+    )
+    return dataset_output_dir
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--model-browser-dir",
+        default=str(ONNX_DIR / "candidate" / "browser"),
+    )
+    parser.add_argument("--dataset", default=str(DEFAULT_DATASET_PATH))
+    parser.add_argument("--output-dir", default=str(PACKAGE_ROOT / "hf"))
+    parser.add_argument("--model-repo-id", default=DEFAULT_MODEL_REPO_ID)
+    parser.add_argument("--dataset-repo-id", default=DEFAULT_DATASET_REPO_ID)
+    parser.add_argument(
+        "--baseline-report",
+        default=str(REPORT_DIR / "profile_qa_eval_baseline_test.json"),
+    )
+    parser.add_argument(
+        "--validation-report",
+        default=str(REPORT_DIR / "profile_qa_eval_v5_validation.json"),
+    )
+    parser.add_argument(
+        "--test-report",
+        default=str(REPORT_DIR / "profile_qa_eval_v5_test.json"),
+    )
+    args = parser.parse_args()
+
+    model_dir = prepare_model_payload(args)
+    dataset_dir = prepare_dataset_payload(args)
+    print(f"prepared model payload: {model_dir}")
+    print(f"prepared dataset payload: {dataset_dir}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ml/profile-qa/profile_qa/public_profile.py
+++ b/ml/profile-qa/profile_qa/public_profile.py
@@ -1,0 +1,256 @@
+"""Public profile facts used for deterministic synthetic data generation."""
+
+from __future__ import annotations
+
+from typing import Final
+
+ProfileFact = dict[str, object]
+ProfileSection = dict[str, object]
+
+PROFILE_SECTIONS: Final[list[ProfileSection]] = [
+    {
+        "id": "identity",
+        "title": "Identity",
+        "always_include": True,
+        "keywords": ["name", "identity", "location", "based", "who"],
+        "facts": [
+            {
+                "id": "identity_location",
+                "text": "Justin Law is based in New York, USA.",
+                "terms": ["New York", "USA"],
+            },
+        ],
+    },
+    {
+        "id": "current_role",
+        "title": "Current Role",
+        "keywords": [
+            "current role",
+            "current job",
+            "current work",
+            "employer",
+            "role",
+            "scope",
+            "impact",
+        ],
+        "facts": [
+            {
+                "id": "current_role_title",
+                "text": "At OpenAI, Justin is an AI Deployment Engineer.",
+                "terms": ["AI Deployment Engineer", "OpenAI"],
+            },
+            {
+                "id": "current_role_scope",
+                "text": (
+                    "Justin focuses on enterprise Codex adoption across CLI, SDK, "
+                    "MCP, app-server, observability, Kubernetes, and full-stack "
+                    "workflows."
+                ),
+                "terms": ["enterprise Codex adoption", "CLI", "SDK", "MCP"],
+            },
+            {
+                "id": "current_role_scale",
+                "text": (
+                    "He has led engagements across 11 organizations and about "
+                    "33,000 users."
+                ),
+                "terms": ["11 organizations", "33,000 users"],
+            },
+        ],
+    },
+    {
+        "id": "experience",
+        "title": "Experience",
+        "keywords": [
+            "experience",
+            "previous role",
+            "work history",
+            "chronology",
+            "before",
+            "veteran",
+            "career",
+        ],
+        "facts": [
+            {
+                "id": "experience_previous_role",
+                "text": (
+                    "Previously, Justin was a Senior Software Engineer at Defense "
+                    "Unicorns, working across 40+ Kubernetes, AI/ML, and full-stack "
+                    "repos."
+                ),
+                "terms": ["Senior Software Engineer", "Defense Unicorns", "40+"],
+            },
+            {
+                "id": "experience_veteran",
+                "text": (
+                    "Justin is a U.S. Air Force and Space Force veteran and one of "
+                    "the Space Force's first certified Supra Coders."
+                ),
+                "terms": ["Air Force", "Space Force", "Supra Coders"],
+            },
+        ],
+    },
+    {
+        "id": "projects",
+        "title": "Projects",
+        "keywords": [
+            "project",
+            "projects",
+            "built",
+            "developed",
+            "operator",
+            "product",
+            "tool",
+            "rag",
+            "metrics",
+        ],
+        "facts": [
+            {
+                "id": "projects_current_role",
+                "text": (
+                    "He built Codex packages, OpenInference observability, and a "
+                    "Kubernetes operator that diagnoses and remediates failing "
+                    "workloads."
+                ),
+                "terms": ["Codex packages", "OpenInference", "Kubernetes operator"],
+            },
+            {
+                "id": "projects_products",
+                "text": "He developed LeapfrogAI and UDS AI.",
+                "terms": ["LeapfrogAI", "UDS AI"],
+            },
+            {
+                "id": "projects_rag_system",
+                "text": (
+                    "He led a FIPS-compliant agentic RAG system for shipyard "
+                    "operations."
+                ),
+                "terms": ["FIPS-compliant", "agentic RAG", "shipyard operations"],
+            },
+            {
+                "id": "projects_metrics",
+                "text": (
+                    "His work improved model MRR by 15% and agentic retrieval by "
+                    "38%."
+                ),
+                "terms": ["MRR by 15%", "agentic retrieval by 38%"],
+            },
+            {
+                "id": "projects_service",
+                "text": (
+                    "He built RF deconfliction tools, orbital object OSINT apps, "
+                    "and acquisition strategies."
+                ),
+                "terms": ["RF deconfliction", "orbital object OSINT", "acquisition"],
+            },
+        ],
+    },
+    {
+        "id": "education",
+        "title": "Education",
+        "keywords": [
+            "education",
+            "degree",
+            "mechanical engineering",
+            "rit",
+            "johns hopkins",
+            "georgia tech",
+            "graduate",
+        ],
+        "facts": [
+            {
+                "id": "education_rit",
+                "text": "Justin earned a B.S. in Mechanical Engineering from RIT.",
+                "terms": ["B.S. in Mechanical Engineering", "RIT"],
+            },
+            {
+                "id": "education_graduate",
+                "text": (
+                    "He completed graduate CS studies at Johns Hopkins and Georgia "
+                    "Tech."
+                ),
+                "terms": ["graduate CS", "Johns Hopkins", "Georgia Tech"],
+            },
+        ],
+    },
+    {
+        "id": "recommendations",
+        "title": "Recommendations",
+        "keywords": [
+            "recommendation",
+            "recommendations",
+            "personable",
+            "collaborative",
+            "pressure",
+            "problem solver",
+        ],
+        "facts": [
+            {
+                "id": "recommendations_summary",
+                "text": (
+                    "Recommendations describe Justin as personable, collaborative, "
+                    "calm under pressure, technically deep, and a strong problem "
+                    "solver."
+                ),
+                "terms": [
+                    "personable",
+                    "collaborative",
+                    "calm under pressure",
+                    "strong problem solver",
+                ],
+            },
+        ],
+    },
+    {
+        "id": "skills",
+        "title": "Skills",
+        "keywords": [
+            "skills",
+            "leadership",
+            "public speaking",
+            "systems design",
+            "ai",
+            "ml",
+            "kubernetes",
+            "rag",
+            "observability",
+            "mlflow",
+        ],
+        "facts": [
+            {
+                "id": "skills_strengths",
+                "text": (
+                    "Strengths include leadership, public speaking, technical "
+                    "writing, pair programming, systems design, AI/ML, Kubernetes, "
+                    "secure deployment, RAG, observability, MLFlow, inference "
+                    "engines, and mission-critical delivery."
+                ),
+                "terms": ["leadership", "systems design", "AI/ML", "Kubernetes"],
+            },
+        ],
+    },
+    {
+        "id": "interests",
+        "title": "Interests",
+        "keywords": ["interests", "hobbies", "outside work", "personal interests"],
+        "facts": [
+            {
+                "id": "interests_personal",
+                "text": "Justin enjoys videogames, hiking, running, and cooking.",
+                "terms": ["videogames", "hiking", "running", "cooking"],
+            },
+        ],
+    },
+]
+
+
+def fact_index() -> dict[tuple[str, str], ProfileFact]:
+    """Return a lookup table keyed by section id and fact id."""
+
+    index: dict[tuple[str, str], ProfileFact] = {}
+    for section in PROFILE_SECTIONS:
+        section_id = str(section["id"])
+        for fact in section["facts"]:
+            if isinstance(fact, dict):
+                index[(section_id, str(fact["id"]))] = fact
+    return index

--- a/ml/profile-qa/profile_qa/publish.py
+++ b/ml/profile-qa/profile_qa/publish.py
@@ -1,0 +1,48 @@
+"""Publish promoted profile-QA artifacts to Hugging Face."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from .export_onnx import reject_external_data_files
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo-id", required=True)
+    parser.add_argument("--artifact-dir", required=True)
+    parser.add_argument("--repo-type", choices=["model", "dataset"], default="model")
+    parser.add_argument("--private", action="store_true")
+    parser.add_argument("--delete-pattern", action="append", default=[])
+    args = parser.parse_args()
+
+    artifact_dir = Path(args.artifact_dir)
+    reject_external_data_files(artifact_dir)
+
+    try:
+        from huggingface_hub import HfApi
+    except ImportError as exc:
+        raise RuntimeError("Install publish dependencies with pip install -r ml/profile-qa/requirements.txt") from exc
+
+    api = HfApi()
+    repo_type = None if args.repo_type == "model" else args.repo_type
+    api.create_repo(
+        repo_id=args.repo_id,
+        private=args.private,
+        repo_type=repo_type,
+        exist_ok=True,
+    )
+    api.upload_folder(
+        repo_id=args.repo_id,
+        folder_path=str(artifact_dir),
+        repo_type=repo_type,
+        commit_message="Publish promoted browser profile-QA artifacts",
+        delete_patterns=args.delete_pattern or None,
+    )
+    print(f"published {artifact_dir} to {args.repo_id}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ml/profile-qa/profile_qa/synthetic_data.py
+++ b/ml/profile-qa/profile_qa/synthetic_data.py
@@ -1,0 +1,931 @@
+"""Deterministic synthetic public-profile Q&A data generation."""
+
+from __future__ import annotations
+
+import argparse
+import random
+from collections.abc import Iterable
+from pathlib import Path
+from typing import Any
+
+from .config import DATASET_VERSION, DEFAULT_DATASET_PATH
+from .public_profile import PROFILE_SECTIONS, fact_index
+from .validation import validate_dataset, write_jsonl
+
+Evidence = dict[str, str]
+Record = dict[str, Any]
+SplitQuestions = dict[str, list[str]]
+
+SPLITS = ("train", "validation", "test")
+
+
+def _evidence(section_id: str, *fact_ids: str) -> list[Evidence]:
+    return [{"section_id": section_id, "fact_id": fact_id} for fact_id in fact_ids]
+
+
+def _record(
+    record_id: str,
+    split: str,
+    task: str,
+    question: str,
+    answer: str,
+    evidence: list[Evidence],
+    expected_terms: Iterable[str],
+    *,
+    requires_refusal: bool = False,
+    history: list[dict[str, str]] | None = None,
+) -> Record:
+    return {
+        "id": record_id,
+        "split": split,
+        "task": task,
+        "question": question,
+        "answer": answer,
+        "evidence": evidence,
+        "expected_terms": list(expected_terms),
+        "requires_refusal": requires_refusal,
+        "history": history or [],
+        "source_profile_version": DATASET_VERSION,
+    }
+
+
+def _fact_terms(section_id: str, fact_id: str) -> list[str]:
+    fact = fact_index()[(section_id, fact_id)]
+    terms = fact.get("terms", [])
+    return [str(term) for term in terms if isinstance(term, str)]
+
+
+def _fact_text(section_id: str, fact_id: str) -> str:
+    return str(fact_index()[(section_id, fact_id)]["text"])
+
+
+def _split_questions(
+    train: list[str],
+    validation: str,
+    test: str,
+) -> SplitQuestions:
+    return {
+        "train": train,
+        "validation": [validation],
+        "test": [test],
+    }
+
+
+FACT_QA: list[dict[str, object]] = [
+    {
+        "id": "identity-location",
+        "section": "identity",
+        "fact": "identity_location",
+        "task": "single_turn",
+        "questions": _split_questions(
+            [
+                "Where is Justin Law based?",
+                "What location is listed for Justin?",
+                "Which city and country does Justin work from?",
+                "Where does Justin live according to the profile?",
+            ],
+            "What is Justin's listed base location?",
+            "Where in the world is Justin based?",
+        ),
+    },
+    {
+        "id": "current-role-title",
+        "section": "current_role",
+        "fact": "current_role_title",
+        "task": "single_turn",
+        "questions": _split_questions(
+            [
+                "What is Justin's current role?",
+                "Which job title does Justin have at OpenAI?",
+                "What role is listed for Justin now?",
+                "Who employs Justin in his current AI role?",
+            ],
+            "What current title does the profile give Justin?",
+            "Where does Justin currently work and in what role?",
+        ),
+    },
+    {
+        "id": "current-role-scope",
+        "section": "current_role",
+        "fact": "current_role_scope",
+        "task": "single_turn",
+        "questions": _split_questions(
+            [
+                "What is Justin's OpenAI work focused on?",
+                "What areas does Justin cover for enterprise Codex adoption?",
+                "Which workflows does Justin support in his current role?",
+                "What does Justin help enterprises adopt at OpenAI?",
+            ],
+            "What current workstreams are listed for Justin?",
+            "What does Justin's current role cover beyond Codex?",
+        ),
+    },
+    {
+        "id": "current-role-scale",
+        "section": "current_role",
+        "fact": "current_role_scale",
+        "task": "single_turn",
+        "questions": _split_questions(
+            [
+                "How many organizations has Justin led engagements across?",
+                "What user scale is listed for Justin's engagements?",
+                "What is the scale of Justin's current customer work?",
+                "How broad are Justin's OpenAI engagements?",
+            ],
+            "What engagement scale does the profile mention?",
+            "How many organizations and users are tied to Justin's engagements?",
+        ),
+    },
+    {
+        "id": "experience-previous-role",
+        "section": "experience",
+        "fact": "experience_previous_role",
+        "task": "single_turn",
+        "questions": _split_questions(
+            [
+                "What prior software engineering role is listed for Justin?",
+                "Where did Justin work previously?",
+                "What previous software engineering role is listed for Justin?",
+                "Describe Justin's Defense Unicorns experience.",
+            ],
+            "What prior employer and role are in Justin's profile?",
+            "What was Justin's previous senior engineering work?",
+        ),
+    },
+    {
+        "id": "experience-veteran",
+        "section": "experience",
+        "fact": "experience_veteran",
+        "task": "single_turn",
+        "questions": _split_questions(
+            [
+                "What military background is listed for Justin?",
+                "Which military services did Justin serve in?",
+                "What does the profile say about Justin's Supra Coder background?",
+                "Is Justin a veteran?",
+            ],
+            "What service background does Justin's profile mention?",
+            "What veteran and Supra Coder context is public for Justin?",
+        ),
+    },
+    {
+        "id": "projects-current-role",
+        "section": "projects",
+        "fact": "projects_current_role",
+        "task": "single_turn",
+        "questions": _split_questions(
+            [
+                "What did Justin build around Codex and Kubernetes?",
+                "Which current-role projects are listed for Justin?",
+                "What did Justin build for OpenInference and failing workloads?",
+                "What Kubernetes operator project is described?",
+                "Which Codex, OpenInference, and Kubernetes tools did Justin build?",
+                "Name the current-role tooling across Codex, observability, and Kubernetes.",
+                "What should be included when describing Justin's current tooling work?",
+            ],
+            "What current projects did Justin build?",
+            "Which tools did Justin create around Codex, observability, and Kubernetes?",
+        ),
+    },
+    {
+        "id": "projects-products",
+        "section": "projects",
+        "fact": "projects_products",
+        "task": "single_turn",
+        "questions": _split_questions(
+            [
+                "Which AI products did Justin develop?",
+                "What products did Justin build at Defense Unicorns?",
+                "Name the AI products in Justin's project history.",
+                "What are LeapfrogAI and UDS AI in Justin's profile?",
+            ],
+            "Which product names are attached to Justin's prior work?",
+            "What AI product development is listed for Justin?",
+        ),
+    },
+    {
+        "id": "projects-rag-system",
+        "section": "projects",
+        "fact": "projects_rag_system",
+        "task": "single_turn",
+        "questions": _split_questions(
+            [
+                "What RAG system did Justin lead?",
+                "What shipyard operations project is in Justin's profile?",
+                "What kind of agentic RAG system did Justin lead?",
+                "Which FIPS-compliant project did Justin lead?",
+            ],
+            "What secure RAG project does the profile describe?",
+            "What project connected agentic RAG with shipyard operations?",
+        ),
+    },
+    {
+        "id": "projects-metrics",
+        "section": "projects",
+        "fact": "projects_metrics",
+        "task": "single_turn",
+        "questions": _split_questions(
+            [
+                "What metrics did Justin improve?",
+                "How much did Justin improve model MRR and retrieval?",
+                "What quantitative improvements are listed for Justin?",
+                "Which retrieval metrics improved in Justin's work?",
+            ],
+            "What MRR and retrieval gains does the profile mention?",
+            "Which performance improvements are public in Justin's profile?",
+        ),
+    },
+    {
+        "id": "projects-service",
+        "section": "projects",
+        "fact": "projects_service",
+        "task": "single_turn",
+        "questions": _split_questions(
+            [
+                "What military technology projects did Justin build?",
+                "What RF and orbital object tools are listed?",
+                "Which service-era technical projects are in Justin's profile?",
+                "What acquisition-related project work is described?",
+            ],
+            "What public service technology projects did Justin work on?",
+            "Which RF, orbital, and acquisition projects are listed?",
+        ),
+    },
+    {
+        "id": "education-rit",
+        "section": "education",
+        "fact": "education_rit",
+        "task": "education",
+        "questions": _split_questions(
+            [
+                "What undergraduate degree did Justin earn?",
+                "Where did Justin earn his mechanical engineering degree?",
+                "Which bachelor's degree is listed for Justin?",
+                "What is Justin's RIT education?",
+            ],
+            "What B.S. degree appears in Justin's profile?",
+            "Which school granted Justin's mechanical engineering degree?",
+        ),
+    },
+    {
+        "id": "education-graduate",
+        "section": "education",
+        "fact": "education_graduate",
+        "task": "education",
+        "questions": _split_questions(
+            [
+                "Where did Justin complete graduate CS studies?",
+                "Which graduate CS programs are listed for Justin?",
+                "What graduate computer science education does Justin have?",
+                "Name the schools in Justin's graduate CS background.",
+            ],
+            "What graduate CS studies are public for Justin?",
+            "Which institutions are named for Justin's graduate CS work?",
+        ),
+    },
+    {
+        "id": "recommendations-summary",
+        "section": "recommendations",
+        "fact": "recommendations_summary",
+        "task": "recommendations",
+        "questions": _split_questions(
+            [
+                "How do recommendations describe Justin?",
+                "What personality or work traits do recommendations mention?",
+                "Which recommendation themes are listed for Justin?",
+                "How is Justin described by recommendations?",
+            ],
+            "What public recommendation themes describe Justin?",
+            "What do recommendations say about Justin's collaboration style?",
+        ),
+    },
+    {
+        "id": "skills-strengths",
+        "section": "skills",
+        "fact": "skills_strengths",
+        "task": "single_turn",
+        "questions": _split_questions(
+            [
+                "What are Justin's technical strengths?",
+                "Which skills are listed for Justin?",
+                "What engineering capabilities does Justin's profile emphasize?",
+                "What does Justin know about AI, Kubernetes, and delivery?",
+            ],
+            "What skills does the public profile emphasize?",
+            "Which leadership and technical skills are listed for Justin?",
+        ),
+    },
+    {
+        "id": "interests-personal",
+        "section": "interests",
+        "fact": "interests_personal",
+        "task": "single_turn",
+        "questions": _split_questions(
+            [
+                "What does Justin enjoy outside work?",
+                "Which hobbies are listed for Justin?",
+                "What are Justin's personal interests?",
+                "What does Justin like doing when not working?",
+            ],
+            "What hobbies does the profile list for Justin?",
+            "Which outside-work interests are public for Justin?",
+        ),
+    },
+]
+
+TARGETED_COMPLETENESS_QA: list[dict[str, object]] = [
+    {
+        "id": "targeted-current-impact-projects",
+        "task": "multi_hop",
+        "evidence": _evidence("current_role", "current_role_scale")
+        + _evidence("projects", "projects_current_role"),
+        "answer": (
+            "Justin has led engagements across 11 organizations and about 33,000 "
+            "users, and he built Codex packages, OpenInference observability, and a "
+            "Kubernetes operator that diagnoses and remediates failing workloads."
+        ),
+        "terms": ["11 organizations", "33,000 users", "Codex packages", "Kubernetes operator"],
+        "questions": [
+            "What public current-work scale plus tooling are listed for Justin?",
+            "When asked for current scale and tools, what complete answer should be given?",
+            "What are Justin's current engagement numbers and the tooling he created?",
+            "Summarize both the organizations/users scale and the Codex/OpenInference/Kubernetes work.",
+            "What current impact details include both user scale and built tools?",
+            "Which current role facts cover scale as well as Codex, observability, and operator tooling?",
+        ],
+    },
+    {
+        "id": "targeted-rag-metrics",
+        "task": "multi_hop",
+        "evidence": _evidence("projects", "projects_rag_system")
+        + _evidence("projects", "projects_metrics"),
+        "answer": (
+            "Justin led a FIPS-compliant agentic RAG system for shipyard operations "
+            "and improved model MRR by 15% and agentic retrieval by 38%."
+        ),
+        "terms": ["FIPS-compliant", "shipyard operations", "MRR by 15%", "38%"],
+        "questions": [
+            "After the shipyard operations RAG work, what project and gains should be mentioned?",
+            "What complete answer pairs Justin's secure RAG project with the metrics?",
+            "Which shipyard RAG project and retrieval improvements are listed together?",
+            "What did Justin lead, and what MRR/retrieval gains are tied to that work?",
+            "Answer with both the FIPS-compliant RAG system and the measured improvements.",
+            "What public RAG accomplishment includes shipyard operations and two improvement metrics?",
+        ],
+    },
+    {
+        "id": "targeted-before-current",
+        "task": "chronology",
+        "evidence": _evidence("experience", "experience_previous_role")
+        + _evidence("experience", "experience_veteran"),
+        "answer": (
+            "Before his current OpenAI work, Justin was a Senior Software Engineer "
+            "at Defense Unicorns and served as a U.S. Air Force and Space Force "
+            "veteran."
+        ),
+        "terms": ["Defense Unicorns", "Air Force", "Space Force"],
+        "questions": [
+            "What preceded Justin's current role at OpenAI, including service background?",
+            "What complete pre-OpenAI career summary is listed for Justin?",
+            "Before the current OpenAI work, which employer and military services are public?",
+            "What prior Defense Unicorns and Air Force/Space Force experience should be included?",
+            "Which earlier civilian role and veteran background came before the current role?",
+            "Give the full before-OpenAI chronology from the public profile.",
+        ],
+    },
+    {
+        "id": "targeted-education-complete",
+        "task": "education",
+        "evidence": _evidence("education", "education_rit")
+        + _evidence("education", "education_graduate"),
+        "answer": (
+            "Justin earned a B.S. in Mechanical Engineering from RIT and completed "
+            "graduate CS studies at Johns Hopkins and Georgia Tech."
+        ),
+        "terms": ["Mechanical Engineering", "RIT", "Johns Hopkins", "Georgia Tech"],
+        "questions": [
+            "What complete degree and graduate school answer should be given?",
+            "Which undergraduate degree plus graduate CS institutions are public?",
+            "Name both Justin's RIT degree and the graduate CS schools.",
+            "What education answer includes Mechanical Engineering, RIT, Johns Hopkins, and Georgia Tech?",
+        ],
+    },
+]
+
+MULTI_HOP_QA: list[dict[str, object]] = [
+    {
+        "id": "current-impact-and-projects",
+        "task": "multi_hop",
+        "evidence": _evidence("current_role", "current_role_scale")
+        + _evidence("projects", "projects_current_role"),
+        "answer": (
+            "Justin has led engagements across 11 organizations and about 33,000 "
+            "users, and he built Codex packages, OpenInference observability, and a "
+            "Kubernetes operator that diagnoses and remediates failing workloads."
+        ),
+        "terms": ["11 organizations", "33,000 users", "Codex packages", "Kubernetes operator"],
+        "questions": _split_questions(
+            [
+                "Summarize Justin's current engagement scale and what he built.",
+                "What current impact and projects are listed for Justin?",
+                "Include both Justin's organization and user scale plus the tools he built.",
+                "What are both the engagement scale and current Codex/Kubernetes builds?",
+                "Answer with the current scale and the Codex, OpenInference, and operator work.",
+            ],
+            "How do Justin's engagement scale and current builds connect?",
+            "What scale and tooling are public for Justin's current work?",
+        ),
+    },
+    {
+        "id": "previous-role-and-products",
+        "task": "multi_hop",
+        "evidence": _evidence("experience", "experience_previous_role")
+        + _evidence("projects", "projects_products"),
+        "answer": (
+            "Previously, Justin was a Senior Software Engineer at Defense Unicorns "
+            "working across 40+ Kubernetes, AI/ML, and full-stack repos, where he "
+            "developed LeapfrogAI and UDS AI."
+        ),
+        "terms": ["Defense Unicorns", "40+", "LeapfrogAI", "UDS AI"],
+        "questions": _split_questions(
+            [
+                "What was Justin's prior role and which AI products did he develop?",
+                "Connect Justin's Defense Unicorns role with the products he built.",
+            ],
+            "What prior work and product names are listed together?",
+            "What did Justin do previously and what products came from it?",
+        ),
+    },
+    {
+        "id": "rag-and-metrics",
+        "task": "multi_hop",
+        "evidence": _evidence("projects", "projects_rag_system")
+        + _evidence("projects", "projects_metrics"),
+        "answer": (
+            "Justin led a FIPS-compliant agentic RAG system for shipyard operations "
+            "and improved model MRR by 15% and agentic retrieval by 38%."
+        ),
+        "terms": ["FIPS-compliant", "shipyard operations", "MRR by 15%", "38%"],
+        "questions": _split_questions(
+            [
+                "What RAG system did Justin lead and what improved?",
+                "Pair Justin's shipyard RAG work with the listed metrics.",
+                "Include both Justin's shipyard RAG system and the retrieval improvements.",
+                "What project did Justin lead, and what MRR and retrieval gains followed?",
+                "Answer with the secure RAG project plus both improvement metrics.",
+            ],
+            "What secure RAG project and improvements are public?",
+            "What did Justin improve after leading the shipyard RAG system?",
+        ),
+    },
+    {
+        "id": "education-complete",
+        "task": "education",
+        "evidence": _evidence("education", "education_rit")
+        + _evidence("education", "education_graduate"),
+        "answer": (
+            "Justin earned a B.S. in Mechanical Engineering from RIT and completed "
+            "graduate CS studies at Johns Hopkins and Georgia Tech."
+        ),
+        "terms": ["Mechanical Engineering", "RIT", "Johns Hopkins", "Georgia Tech"],
+        "questions": _split_questions(
+            [
+                "Summarize Justin's education background.",
+                "What undergraduate and graduate education does Justin list?",
+            ],
+            "What complete education path is public for Justin?",
+            "Which degree and graduate CS schools are listed?",
+        ),
+    },
+    {
+        "id": "experience-before-current",
+        "task": "chronology",
+        "evidence": _evidence("experience", "experience_previous_role")
+        + _evidence("experience", "experience_veteran"),
+        "answer": (
+            "Before his current OpenAI work, Justin was a Senior Software Engineer "
+            "at Defense Unicorns and served as a U.S. Air Force and Space Force "
+            "veteran."
+        ),
+        "terms": ["Defense Unicorns", "Air Force", "Space Force"],
+        "questions": _split_questions(
+            [
+                "What did Justin do before OpenAI?",
+                "Describe Justin's experience before his current role.",
+                "Include both Justin's Defense Unicorns role and military service before OpenAI.",
+                "What civilian and service experience came before Justin's current role?",
+                "Answer with both the prior employer and Air Force/Space Force background.",
+            ],
+            "What earlier career history does the profile give for Justin?",
+            "What came before Justin's current OpenAI role?",
+        ),
+    },
+    {
+        "id": "skills-and-recommendations",
+        "task": "recommendations",
+        "evidence": _evidence("skills", "skills_strengths")
+        + _evidence("recommendations", "recommendations_summary"),
+        "answer": (
+            "Justin's strengths include leadership, systems design, AI/ML, "
+            "Kubernetes, RAG, observability, and mission-critical delivery; "
+            "recommendations describe him as personable, collaborative, calm under "
+            "pressure, technically deep, and a strong problem solver."
+        ),
+        "terms": ["leadership", "systems design", "collaborative", "calm under pressure"],
+        "questions": _split_questions(
+            [
+                "Combine Justin's strengths with how recommendations describe him.",
+                "What skills and recommendation themes are listed together?",
+                "Include both Justin's technical strengths and recommendation traits.",
+                "What capabilities and collaboration traits are both listed?",
+                "Answer with systems skills plus the recommendation descriptors.",
+            ],
+            "How do Justin's skills compare with recommendation themes?",
+            "What public profile details cover both capabilities and recommendations?",
+        ),
+    },
+]
+
+FOLLOW_UP_QA: list[dict[str, object]] = [
+    {
+        "id": "followup-defense-metrics",
+        "evidence": _evidence("projects", "projects_metrics"),
+        "answer": "At Defense Unicorns, Justin improved model MRR by 15% and agentic retrieval by 38%.",
+        "terms": ["MRR by 15%", "agentic retrieval by 38%"],
+        "history": [
+            {"role": "user", "content": "Tell me about Justin's Defense Unicorns work."},
+            {
+                "role": "assistant",
+                "content": "Justin worked across Kubernetes, AI/ML, and full-stack repos there.",
+            },
+        ],
+        "questions": _split_questions(
+            [
+                "What did he improve there?",
+                "Which metrics improved in that role?",
+            ],
+            "What were the measurable improvements from that work?",
+            "What changed in MRR and retrieval there?",
+        ),
+    },
+    {
+        "id": "followup-operator-purpose",
+        "evidence": _evidence("projects", "projects_current_role"),
+        "answer": "The Kubernetes operator diagnoses and remediates failing workloads.",
+        "terms": ["diagnoses", "remediates", "failing workloads"],
+        "history": [
+            {"role": "user", "content": "What did Justin build in his current role?"},
+            {
+                "role": "assistant",
+                "content": "He built Codex packages, OpenInference observability, and a Kubernetes operator.",
+            },
+        ],
+        "questions": _split_questions(
+            [
+                "What did that operator do?",
+                "What problem did the operator handle?",
+            ],
+            "How did that Kubernetes operator help?",
+            "What workload issue did that operator address?",
+        ),
+    },
+    {
+        "id": "followup-graduate-schools",
+        "evidence": _evidence("education", "education_graduate"),
+        "answer": "Justin completed graduate CS studies at Johns Hopkins and Georgia Tech.",
+        "terms": ["Johns Hopkins", "Georgia Tech"],
+        "history": [
+            {"role": "user", "content": "Tell me about Justin's education."},
+            {
+                "role": "assistant",
+                "content": "He earned a B.S. in Mechanical Engineering from RIT.",
+            },
+        ],
+        "questions": _split_questions(
+            [
+                "Where did he study CS after that?",
+                "Which graduate schools are also listed?",
+            ],
+            "What graduate CS institutions came after the bachelor's degree?",
+            "Where else did he study computer science?",
+        ),
+    },
+    {
+        "id": "followup-recommendation-traits",
+        "evidence": _evidence("recommendations", "recommendations_summary"),
+        "answer": (
+            "Recommendations describe Justin as personable, collaborative, calm "
+            "under pressure, technically deep, and a strong problem solver."
+        ),
+        "terms": ["personable", "collaborative", "calm under pressure"],
+        "history": [
+            {"role": "user", "content": "What do people say about Justin?"},
+            {
+                "role": "assistant",
+                "content": "The public profile includes recommendation themes.",
+            },
+        ],
+        "questions": _split_questions(
+            [
+                "What traits do those recommendations mention?",
+                "How do those recommendations describe him?",
+            ],
+            "What are the public recommendation descriptors?",
+            "Which collaboration traits are mentioned?",
+        ),
+    },
+]
+
+REFUSAL_TOPICS = [
+    ("salary", "What is Justin's salary?"),
+    ("personal phone number", "What is Justin's personal phone number?"),
+    ("home address", "What is Justin's home address?"),
+    ("street address", "What street address does Justin live at?"),
+    ("personal email", "What is Justin's personal email?"),
+    ("compensation", "What compensation does Justin receive?"),
+    ("classified systems", "What classified systems did Justin work on?"),
+    ("secret clearance", "What is Justin's secret clearance status?"),
+    ("SSN", "What is Justin's SSN?"),
+    ("manager's private notes", "What do Justin's manager's private notes say?"),
+]
+
+SECTION_SUMMARY_QUESTIONS = {
+    "train": [
+        "Summarize the {section} section.",
+        "What does the profile say under {section}?",
+        "Give the candidate's {section} details.",
+    ],
+    "validation": [
+        "Which {section} details are listed for this person?",
+    ],
+    "test": [
+        "What should I know from the {section} section?",
+    ],
+}
+
+PROFILE_SUBJECT_ALIASES = {
+    "train": [
+        ("Justin's", "the profile owner's"),
+        ("Justin", "the candidate"),
+        ("Justin's", "this person's"),
+        ("Justin", "this person"),
+    ],
+    "validation": [
+        ("Justin's", "this person's"),
+        ("Justin", "this person"),
+    ],
+    "test": [
+        ("Justin's", "the candidate's"),
+        ("Justin", "the profile owner"),
+    ],
+}
+
+SECTION_TASKS = {
+    "experience": "chronology",
+    "education": "education",
+    "recommendations": "recommendations",
+}
+
+
+def _add_fact_records(records: list[Record]) -> None:
+    for spec in FACT_QA:
+        section_id = str(spec["section"])
+        fact_id = str(spec["fact"])
+        answer = _fact_text(section_id, fact_id)
+        evidence = _evidence(section_id, fact_id)
+        terms = _fact_terms(section_id, fact_id)
+        questions = spec["questions"]
+        if not isinstance(questions, dict):
+            continue
+        for split in SPLITS:
+            for index, question in enumerate(questions[split]):
+                records.append(
+                    _record(
+                        f"{spec['id']}-{split}-{index}",
+                        split,
+                        str(spec["task"]),
+                        question,
+                        answer,
+                        evidence,
+                        terms,
+                    )
+                )
+
+
+def _add_grouped_records(records: list[Record], specs: list[dict[str, object]], task: str | None = None) -> None:
+    for spec in specs:
+        questions = spec["questions"]
+        if not isinstance(questions, dict):
+            continue
+        for split in SPLITS:
+            for index, question in enumerate(questions[split]):
+                records.append(
+                    _record(
+                        f"{spec['id']}-{split}-{index}",
+                        split,
+                        str(task or spec["task"]),
+                        question,
+                        str(spec["answer"]),
+                        spec["evidence"],  # type: ignore[arg-type]
+                        spec["terms"],  # type: ignore[arg-type]
+                        history=spec.get("history") if isinstance(spec.get("history"), list) else None,
+                    )
+                )
+
+
+def _add_train_only_grouped_records(records: list[Record], specs: list[dict[str, object]]) -> None:
+    for spec in specs:
+        questions = spec["questions"]
+        if not isinstance(questions, list):
+            continue
+        for index, question in enumerate(questions):
+            records.append(
+                _record(
+                    f"{spec['id']}-train-{index}",
+                    "train",
+                    str(spec["task"]),
+                    str(question),
+                    str(spec["answer"]),
+                    spec["evidence"],  # type: ignore[arg-type]
+                    spec["terms"],  # type: ignore[arg-type]
+                )
+            )
+
+
+def _add_refusal_records(records: list[Record]) -> None:
+    for topic_index, (topic, canonical_question) in enumerate(REFUSAL_TOPICS):
+        split_questions = _split_questions(
+            [
+                canonical_question,
+                f"Can you tell me Justin's {topic}?",
+                f"Please provide Justin's {topic}.",
+            ],
+            f"Does the public profile reveal Justin's {topic}?",
+            f"What does the profile say about Justin's {topic}?",
+        )
+        for split in SPLITS:
+            for index, question in enumerate(split_questions[split]):
+                records.append(
+                    _record(
+                        f"refusal-{topic_index}-{split}-{index}",
+                        split,
+                        "refusal",
+                        question,
+                        f"The public profile context does not say Justin's {topic}.",
+                        [],
+                        [],
+                        requires_refusal=True,
+                    )
+                )
+
+
+def _section_task(section_id: str) -> str:
+    return SECTION_TASKS.get(section_id, "single_turn")
+
+
+def _section_evidence(section: dict[str, object]) -> list[Evidence]:
+    section_id = str(section["id"])
+    facts = section["facts"]
+    if not isinstance(facts, list):
+        return []
+    return [
+        {"section_id": section_id, "fact_id": str(fact["id"])}
+        for fact in facts
+        if isinstance(fact, dict)
+    ]
+
+
+def _section_answer(section: dict[str, object]) -> str:
+    facts = section["facts"]
+    if not isinstance(facts, list):
+        return ""
+    return " ".join(str(fact["text"]) for fact in facts if isinstance(fact, dict))
+
+
+def _section_terms(section: dict[str, object]) -> list[str]:
+    terms: list[str] = []
+    facts = section["facts"]
+    if not isinstance(facts, list):
+        return terms
+    for fact in facts:
+        if not isinstance(fact, dict):
+            continue
+        for term in fact.get("terms", []):
+            if isinstance(term, str) and term not in terms:
+                terms.append(term)
+    return terms
+
+
+def _add_section_summary_records(records: list[Record]) -> None:
+    for section in PROFILE_SECTIONS:
+        section_id = str(section["id"])
+        section_title = str(section["title"]).lower()
+        answer = _section_answer(section)
+        evidence = _section_evidence(section)
+        terms = _section_terms(section)
+        if not answer or not evidence:
+            continue
+        for split in SPLITS:
+            for index, template in enumerate(SECTION_SUMMARY_QUESTIONS[split]):
+                question = template.format(section=section_title)
+                records.append(
+                    _record(
+                        f"section-summary-{section_id}-{split}-{index}",
+                        split,
+                        _section_task(section_id),
+                        question,
+                        answer,
+                        evidence,
+                        terms,
+                    )
+                )
+
+
+def _replace_profile_subject(question: str, split: str) -> list[str]:
+    variants: list[str] = []
+    for source, replacement in PROFILE_SUBJECT_ALIASES[split]:
+        if source not in question:
+            continue
+        replaced = question.replace(source, replacement)
+        if replaced != question and replaced not in variants:
+            variants.append(replaced)
+    return variants
+
+
+def _add_profile_subject_alias_records(records: list[Record]) -> None:
+    normalized_questions = {" ".join(str(record["question"]).lower().split()) for record in records}
+    source_records = list(records)
+    for record in source_records:
+        split = str(record["split"])
+        for index, question in enumerate(_replace_profile_subject(str(record["question"]), split)):
+            normalized = " ".join(question.lower().split())
+            if normalized in normalized_questions:
+                continue
+            normalized_questions.add(normalized)
+            records.append(
+                _record(
+                    f"{record['id']}-subject-alias-{index}",
+                    split,
+                    str(record["task"]),
+                    question,
+                    str(record["answer"]),
+                    list(record["evidence"]),
+                    list(record.get("expected_terms", [])),
+                    requires_refusal=bool(record["requires_refusal"]),
+                    history=list(record.get("history", [])),
+                )
+            )
+
+
+def build_records(seed: int = 7) -> list[Record]:
+    """Build a deterministic dataset from public profile facts."""
+
+    records: list[Record] = []
+    _add_fact_records(records)
+    _add_grouped_records(records, MULTI_HOP_QA)
+    _add_grouped_records(records, FOLLOW_UP_QA, task="multi_turn")
+    _add_refusal_records(records)
+    _add_section_summary_records(records)
+    _add_train_only_grouped_records(records, TARGETED_COMPLETENESS_QA)
+    _add_profile_subject_alias_records(records)
+
+    rng = random.Random(seed)
+    rng.shuffle(records)
+    return records
+
+
+def profile_context_text() -> str:
+    """Return the public profile as a plain text context block."""
+
+    lines: list[str] = []
+    for section in PROFILE_SECTIONS:
+        title = str(section["title"])
+        facts = section["facts"]
+        if not isinstance(facts, list):
+            continue
+        fact_texts = [str(fact["text"]) for fact in facts if isinstance(fact, dict)]
+        lines.append(f"{title}: {' '.join(fact_texts)}")
+    return "\n".join(lines)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output", default=str(DEFAULT_DATASET_PATH))
+    parser.add_argument("--seed", type=int, default=7)
+    args = parser.parse_args()
+
+    records = build_records(seed=args.seed)
+    errors = validate_dataset(records)
+    if errors:
+        for error in errors:
+            print(error)
+        return 1
+
+    write_jsonl(Path(args.output), records)
+    split_counts = {split: sum(1 for record in records if record["split"] == split) for split in SPLITS}
+    print(f"wrote {len(records)} records to {args.output} ({split_counts})")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ml/profile-qa/profile_qa/train_lora.py
+++ b/ml/profile-qa/profile_qa/train_lora.py
@@ -1,0 +1,356 @@
+"""Local 8GB-safe LoRA/QLoRA continuation training for profile Q&A."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import Any
+
+from .config import (
+    DEFAULT_DATASET_PATH,
+    DEFAULT_TRAIN_OUTPUT_DIR,
+    EVAL_STEPS,
+    EVAL_BATCH_SIZE,
+    FALLBACK_BASE_MODEL_ID,
+    GRADIENT_ACCUMULATION_STEPS,
+    LEARNING_RATE,
+    LORA_ALPHA,
+    LORA_DROPOUT,
+    LORA_RANK,
+    MAX_STEPS,
+    MODEL_CONTEXT_LIMIT,
+    PRIMARY_BASE_MODEL_ID,
+    SAVE_STEPS,
+    TRAIN_BATCH_SIZE,
+    WARMUP_RATIO,
+    WEIGHT_DECAY,
+)
+from .gpu_health import assert_gpu_ready
+from .synthetic_data import profile_context_text
+from .validation import read_jsonl
+
+
+def _missing_dependency(name: str, install_hint: str) -> RuntimeError:
+    return RuntimeError(f"Missing optional dependency {name}. Install with: {install_hint}")
+
+
+def format_instruction(record: dict[str, Any]) -> str:
+    """Format a record as a profile-QA instruction prompt."""
+
+    history = record.get("history", [])
+    history_text = ""
+    if isinstance(history, list) and history:
+        turns = []
+        for turn in history:
+            if isinstance(turn, dict):
+                role = str(turn.get("role", "")).title()
+                content = str(turn.get("content", ""))
+                turns.append(f"{role}: {content}")
+        history_text = "\nRecent conversation:\n" + "\n".join(turns)
+
+    return (
+        "You are Justin Law's browser-only profile Q&A assistant. "
+        "Use only the public profile context. If the context does not answer, say so. "
+        "If a question asks for multiple facts, include each requested fact.\n\n"
+        f"Public profile context:\n{profile_context_text()}\n"
+        f"{history_text}\n\n"
+        f"Question: {record['question']}\n"
+        "Answer:"
+    )
+
+
+def _load_training_stack() -> dict[str, Any]:
+    try:
+        import torch
+    except ImportError as exc:
+        raise _missing_dependency("torch", "pip install -r ml/profile-qa/requirements.txt") from exc
+
+    try:
+        from datasets import Dataset
+        from peft import LoraConfig, PeftModel, get_peft_model, prepare_model_for_kbit_training
+        from transformers import (
+            AutoConfig,
+            AutoModelForCausalLM,
+            AutoModelForSeq2SeqLM,
+            AutoTokenizer,
+            BitsAndBytesConfig,
+            DataCollatorForLanguageModeling,
+            DataCollatorForSeq2Seq,
+            EarlyStoppingCallback,
+            Seq2SeqTrainer,
+            Seq2SeqTrainingArguments,
+            Trainer,
+            TrainingArguments,
+        )
+    except ImportError as exc:
+        raise _missing_dependency(
+            "training stack",
+            "pip install -r ml/profile-qa/requirements.txt",
+        ) from exc
+
+    return {
+        "torch": torch,
+        "Dataset": Dataset,
+        "LoraConfig": LoraConfig,
+        "PeftModel": PeftModel,
+        "get_peft_model": get_peft_model,
+        "prepare_model_for_kbit_training": prepare_model_for_kbit_training,
+        "AutoConfig": AutoConfig,
+        "AutoModelForCausalLM": AutoModelForCausalLM,
+        "AutoModelForSeq2SeqLM": AutoModelForSeq2SeqLM,
+        "AutoTokenizer": AutoTokenizer,
+        "BitsAndBytesConfig": BitsAndBytesConfig,
+        "DataCollatorForLanguageModeling": DataCollatorForLanguageModeling,
+        "DataCollatorForSeq2Seq": DataCollatorForSeq2Seq,
+        "EarlyStoppingCallback": EarlyStoppingCallback,
+        "Seq2SeqTrainer": Seq2SeqTrainer,
+        "Seq2SeqTrainingArguments": Seq2SeqTrainingArguments,
+        "Trainer": Trainer,
+        "TrainingArguments": TrainingArguments,
+    }
+
+
+def _target_modules(is_encoder_decoder: bool) -> list[str]:
+    if is_encoder_decoder:
+        return ["q", "v"]
+    return ["q_proj", "k_proj", "v_proj", "o_proj", "gate_proj", "up_proj", "down_proj"]
+
+
+def run_training(args: argparse.Namespace) -> None:
+    assert_gpu_ready(min_vram_gb=args.min_vram_gb)
+    stack = _load_training_stack()
+    torch = stack["torch"]
+
+    records = read_jsonl(Path(args.dataset))
+    train_records = [record for record in records if record.get("split") == "train"]
+    eval_records = [record for record in records if record.get("split") == "validation"]
+    if not train_records:
+        raise RuntimeError("dataset has no train records")
+    if not eval_records:
+        raise RuntimeError("dataset has no validation records")
+
+    model_id = args.model_id
+    config = stack["AutoConfig"].from_pretrained(model_id, trust_remote_code=True)
+    is_encoder_decoder = bool(getattr(config, "is_encoder_decoder", False))
+    tokenizer = stack["AutoTokenizer"].from_pretrained(model_id, trust_remote_code=True)
+    if tokenizer.pad_token is None and tokenizer.eos_token is not None:
+        tokenizer.pad_token = tokenizer.eos_token
+
+    compute_dtype = torch.bfloat16 if torch.cuda.is_bf16_supported() else torch.float16
+    quantization_config = stack["BitsAndBytesConfig"](
+        load_in_4bit=args.quantization == "4bit",
+        load_in_8bit=args.quantization == "8bit",
+        bnb_4bit_compute_dtype=compute_dtype,
+        bnb_4bit_quant_type="nf4",
+        bnb_4bit_use_double_quant=True,
+    )
+
+    model_cls = (
+        stack["AutoModelForSeq2SeqLM"] if is_encoder_decoder else stack["AutoModelForCausalLM"]
+    )
+    model = model_cls.from_pretrained(
+        model_id,
+        device_map="auto",
+        quantization_config=quantization_config,
+        trust_remote_code=True,
+    )
+    model.gradient_checkpointing_enable()
+    model = stack["prepare_model_for_kbit_training"](model)
+    if args.adapter_model_id:
+        model = stack["PeftModel"].from_pretrained(
+            model,
+            args.adapter_model_id,
+            is_trainable=True,
+        )
+    else:
+        lora_config = stack["LoraConfig"](
+            r=args.lora_rank,
+            lora_alpha=args.lora_alpha,
+            lora_dropout=args.lora_dropout,
+            bias="none",
+            task_type="SEQ_2_SEQ_LM" if is_encoder_decoder else "CAUSAL_LM",
+            target_modules=_target_modules(is_encoder_decoder),
+        )
+        model = stack["get_peft_model"](model, lora_config)
+
+    dataset_cls = stack["Dataset"]
+    train_dataset = dataset_cls.from_list(train_records)
+    eval_dataset = dataset_cls.from_list(eval_records)
+
+    if is_encoder_decoder:
+        def tokenize_seq2seq(batch: dict[str, list[Any]]) -> dict[str, Any]:
+            prompts = [format_instruction(record) for record in _batch_records(batch)]
+            answers = [str(answer) for answer in batch["answer"]]
+            model_inputs = tokenizer(
+                prompts,
+                max_length=MODEL_CONTEXT_LIMIT,
+                truncation=True,
+                padding=False,
+            )
+            labels = tokenizer(
+                text_target=answers,
+                max_length=160,
+                truncation=True,
+                padding=False,
+            )
+            model_inputs["labels"] = labels["input_ids"]
+            return model_inputs
+
+        tokenized_train = train_dataset.map(tokenize_seq2seq, batched=True, remove_columns=train_dataset.column_names)
+        tokenized_eval = eval_dataset.map(tokenize_seq2seq, batched=True, remove_columns=eval_dataset.column_names)
+        training_args = stack["Seq2SeqTrainingArguments"](
+            output_dir=args.output_dir,
+            per_device_train_batch_size=args.train_batch_size,
+            per_device_eval_batch_size=args.eval_batch_size,
+            gradient_accumulation_steps=args.gradient_accumulation_steps,
+            learning_rate=args.learning_rate,
+            max_steps=args.max_steps,
+            lr_scheduler_type=args.lr_scheduler_type,
+            warmup_ratio=args.warmup_ratio,
+            weight_decay=args.weight_decay,
+            optim=args.optim,
+            fp16=compute_dtype == torch.float16,
+            bf16=compute_dtype == torch.bfloat16,
+            gradient_checkpointing=True,
+            logging_steps=10,
+            eval_strategy="steps",
+            eval_steps=args.eval_steps,
+            save_strategy="steps",
+            save_steps=args.save_steps,
+            save_total_limit=3,
+            load_best_model_at_end=True,
+            metric_for_best_model="eval_loss",
+            greater_is_better=False,
+            predict_with_generate=False,
+            report_to="none",
+        )
+        callbacks = []
+        if args.early_stopping_patience > 0:
+            callbacks.append(
+                stack["EarlyStoppingCallback"](
+                    early_stopping_patience=args.early_stopping_patience
+                )
+            )
+        trainer = stack["Seq2SeqTrainer"](
+            model=model,
+            args=training_args,
+            train_dataset=tokenized_train,
+            eval_dataset=tokenized_eval,
+            tokenizer=tokenizer,
+            data_collator=stack["DataCollatorForSeq2Seq"](tokenizer=tokenizer, model=model),
+            callbacks=callbacks,
+        )
+    else:
+        def tokenize_causal(batch: dict[str, list[Any]]) -> dict[str, Any]:
+            texts = [
+                f"{format_instruction(record)} {record['answer']}{tokenizer.eos_token or ''}"
+                for record in _batch_records(batch)
+            ]
+            return tokenizer(
+                texts,
+                max_length=MODEL_CONTEXT_LIMIT,
+                truncation=True,
+                padding=False,
+            )
+
+        tokenized_train = train_dataset.map(tokenize_causal, batched=True, remove_columns=train_dataset.column_names)
+        tokenized_eval = eval_dataset.map(tokenize_causal, batched=True, remove_columns=eval_dataset.column_names)
+        training_args = stack["TrainingArguments"](
+            output_dir=args.output_dir,
+            per_device_train_batch_size=args.train_batch_size,
+            per_device_eval_batch_size=args.eval_batch_size,
+            gradient_accumulation_steps=args.gradient_accumulation_steps,
+            learning_rate=args.learning_rate,
+            max_steps=args.max_steps,
+            lr_scheduler_type=args.lr_scheduler_type,
+            warmup_ratio=args.warmup_ratio,
+            weight_decay=args.weight_decay,
+            optim=args.optim,
+            fp16=compute_dtype == torch.float16,
+            bf16=compute_dtype == torch.bfloat16,
+            gradient_checkpointing=True,
+            logging_steps=10,
+            eval_strategy="steps",
+            eval_steps=args.eval_steps,
+            save_strategy="steps",
+            save_steps=args.save_steps,
+            save_total_limit=3,
+            load_best_model_at_end=True,
+            metric_for_best_model="eval_loss",
+            greater_is_better=False,
+            report_to="none",
+        )
+        callbacks = []
+        if args.early_stopping_patience > 0:
+            callbacks.append(
+                stack["EarlyStoppingCallback"](
+                    early_stopping_patience=args.early_stopping_patience
+                )
+            )
+        trainer = stack["Trainer"](
+            model=model,
+            args=training_args,
+            train_dataset=tokenized_train,
+            eval_dataset=tokenized_eval,
+            tokenizer=tokenizer,
+            data_collator=stack["DataCollatorForLanguageModeling"](
+                tokenizer=tokenizer,
+                mlm=False,
+            ),
+            callbacks=callbacks,
+        )
+
+    trainer.train(resume_from_checkpoint=args.resume)
+    trainer.save_model(args.output_dir)
+    tokenizer.save_pretrained(args.output_dir)
+
+
+def _batch_records(batch: dict[str, list[Any]]) -> list[dict[str, Any]]:
+    keys = list(batch.keys())
+    size = len(batch[keys[0]]) if keys else 0
+    return [{key: batch[key][index] for key in keys} for index in range(size)]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--dataset", default=str(DEFAULT_DATASET_PATH))
+    parser.add_argument("--model-id", default=PRIMARY_BASE_MODEL_ID)
+    parser.add_argument("--adapter-model-id")
+    parser.add_argument("--fallback-model-id", default=FALLBACK_BASE_MODEL_ID)
+    parser.add_argument("--output-dir", default=str(DEFAULT_TRAIN_OUTPUT_DIR))
+    parser.add_argument("--quantization", choices=["4bit", "8bit"], default="4bit")
+    parser.add_argument("--max-steps", type=int, default=MAX_STEPS)
+    parser.add_argument("--learning-rate", type=float, default=LEARNING_RATE)
+    parser.add_argument("--weight-decay", type=float, default=WEIGHT_DECAY)
+    parser.add_argument("--warmup-ratio", type=float, default=WARMUP_RATIO)
+    parser.add_argument("--lr-scheduler-type", default="cosine")
+    parser.add_argument("--optim", default="paged_adamw_8bit")
+    parser.add_argument("--lora-rank", type=int, default=LORA_RANK)
+    parser.add_argument("--lora-alpha", type=int, default=LORA_ALPHA)
+    parser.add_argument("--lora-dropout", type=float, default=LORA_DROPOUT)
+    parser.add_argument("--eval-steps", type=int, default=EVAL_STEPS)
+    parser.add_argument("--save-steps", type=int, default=SAVE_STEPS)
+    parser.add_argument(
+        "--gradient-accumulation-steps",
+        type=int,
+        default=GRADIENT_ACCUMULATION_STEPS,
+    )
+    parser.add_argument("--train-batch-size", type=int, default=TRAIN_BATCH_SIZE)
+    parser.add_argument("--eval-batch-size", type=int, default=EVAL_BATCH_SIZE)
+    parser.add_argument("--early-stopping-patience", type=int, default=4)
+    parser.add_argument("--min-vram-gb", type=float, default=7.0)
+    parser.add_argument("--resume", action="store_true")
+    args = parser.parse_args()
+
+    try:
+        run_training(args)
+    except RuntimeError as exc:
+        if args.model_id == PRIMARY_BASE_MODEL_ID:
+            print(f"primary training failed: {exc}")
+            print(f"retry with --model-id {args.fallback_model_id} to use the fallback path")
+        raise
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ml/profile-qa/profile_qa/validation.py
+++ b/ml/profile-qa/profile_qa/validation.py
@@ -165,4 +165,3 @@ def validate_dataset(records: Iterable[dict[str, Any]]) -> list[str]:
             seen_questions_by_split[split].add(normalized)
 
     return errors
-

--- a/ml/profile-qa/profile_qa/validation.py
+++ b/ml/profile-qa/profile_qa/validation.py
@@ -1,0 +1,168 @@
+"""Dataset validation for local profile-QA examples."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterable
+from pathlib import Path
+from typing import Any
+
+from .public_profile import fact_index
+
+VALID_SPLITS = {"train", "validation", "test"}
+VALID_ROLES = {"user", "assistant"}
+PRIVATE_DATA_MARKERS = {
+    "ssn",
+    "social security",
+    "phone number",
+    "street address",
+    "home address",
+    "personal email",
+    "salary",
+    "compensation",
+    "classified",
+    "secret clearance",
+}
+
+
+def read_jsonl(path: Path) -> list[dict[str, Any]]:
+    """Read a JSONL file into a list of records."""
+
+    records: list[dict[str, Any]] = []
+    with path.open("r", encoding="utf-8") as handle:
+        for line_number, line in enumerate(handle, start=1):
+            if not line.strip():
+                continue
+            try:
+                value = json.loads(line)
+            except json.JSONDecodeError as exc:
+                raise ValueError(f"{path}:{line_number}: invalid JSON") from exc
+            if not isinstance(value, dict):
+                raise ValueError(f"{path}:{line_number}: record must be an object")
+            records.append(value)
+    return records
+
+
+def write_jsonl(path: Path, records: Iterable[dict[str, Any]]) -> None:
+    """Write records to a JSONL file."""
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as handle:
+        for record in records:
+            handle.write(json.dumps(record, sort_keys=True))
+            handle.write("\n")
+
+
+def validate_record(record: dict[str, Any]) -> list[str]:
+    """Return schema and safety errors for a single record."""
+
+    errors: list[str] = []
+    known_facts = fact_index()
+
+    for key in [
+        "id",
+        "split",
+        "task",
+        "question",
+        "answer",
+        "evidence",
+        "requires_refusal",
+        "source_profile_version",
+    ]:
+        if key not in record:
+            errors.append(f"missing {key}")
+
+    if record.get("split") not in VALID_SPLITS:
+        errors.append("split must be train, validation, or test")
+
+    for key in ["id", "task", "question", "answer", "source_profile_version"]:
+        if key in record and not isinstance(record[key], str):
+            errors.append(f"{key} must be a string")
+
+    if not isinstance(record.get("requires_refusal"), bool):
+        errors.append("requires_refusal must be a boolean")
+
+    evidence = record.get("evidence")
+    if not isinstance(evidence, list):
+        errors.append("evidence must be a list")
+    else:
+        if not record.get("requires_refusal") and len(evidence) == 0:
+            errors.append("non-refusal examples require evidence")
+        for index, item in enumerate(evidence):
+            if not isinstance(item, dict):
+                errors.append(f"evidence[{index}] must be an object")
+                continue
+            section_id = item.get("section_id")
+            fact_id = item.get("fact_id")
+            if not isinstance(section_id, str) or not isinstance(fact_id, str):
+                errors.append(f"evidence[{index}] requires string section_id and fact_id")
+                continue
+            if (section_id, fact_id) not in known_facts:
+                errors.append(f"evidence[{index}] references unknown fact")
+
+    history = record.get("history", [])
+    if not isinstance(history, list):
+        errors.append("history must be a list when present")
+    else:
+        for index, turn in enumerate(history):
+            if not isinstance(turn, dict):
+                errors.append(f"history[{index}] must be an object")
+                continue
+            if turn.get("role") not in VALID_ROLES:
+                errors.append(f"history[{index}].role must be user or assistant")
+            if not isinstance(turn.get("content"), str):
+                errors.append(f"history[{index}].content must be a string")
+
+    expected_terms = record.get("expected_terms", [])
+    if not isinstance(expected_terms, list) or not all(
+        isinstance(term, str) for term in expected_terms
+    ):
+        errors.append("expected_terms must be a list of strings when present")
+
+    text = f"{record.get('question', '')} {record.get('answer', '')}".lower()
+    for marker in PRIVATE_DATA_MARKERS:
+        if marker in text and not record.get("requires_refusal"):
+            errors.append(f"private-data marker leaked into non-refusal example: {marker}")
+
+    if record.get("requires_refusal"):
+        answer = str(record.get("answer", "")).lower()
+        if "does not say" not in answer and "not in the public profile" not in answer:
+            errors.append("refusal answer must state the public profile does not say")
+
+    return errors
+
+
+def validate_dataset(records: Iterable[dict[str, Any]]) -> list[str]:
+    """Return all validation errors for a dataset."""
+
+    errors: list[str] = []
+    seen_ids: set[str] = set()
+    seen_questions_by_split: dict[str, set[str]] = {
+        "train": set(),
+        "validation": set(),
+        "test": set(),
+    }
+
+    for index, record in enumerate(records):
+        record_id = record.get("id")
+        if isinstance(record_id, str):
+            if record_id in seen_ids:
+                errors.append(f"{record_id}: duplicate id")
+            seen_ids.add(record_id)
+
+        for error in validate_record(record):
+            errors.append(f"{record_id or index}: {error}")
+
+        question = record.get("question")
+        split = record.get("split")
+        if isinstance(question, str) and isinstance(split, str) and split in VALID_SPLITS:
+            normalized = " ".join(question.lower().split())
+            for other_split, questions in seen_questions_by_split.items():
+                if other_split != split and normalized in questions:
+                    errors.append(
+                        f"{record_id or index}: question appears in both {other_split} and {split}"
+                    )
+            seen_questions_by_split[split].add(normalized)
+
+    return errors
+

--- a/ml/profile-qa/requirements.txt
+++ b/ml/profile-qa/requirements.txt
@@ -1,0 +1,13 @@
+accelerate>=1.0
+bitsandbytes>=0.43
+datasets>=2.20
+huggingface-hub>=0.24
+onnx>=1.16
+onnxruntime>=1.18
+optimum[onnxruntime]>=1.21
+peft>=0.12
+pytest>=8.0
+safetensors>=0.4
+sentencepiece>=0.2
+torch>=2.4
+transformers>=4.44

--- a/ml/profile-qa/tests/test_gpu_health.py
+++ b/ml/profile-qa/tests/test_gpu_health.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from profile_qa.gpu_health import _check_nvidia_devices, _check_torch_cuda
+
+
+@dataclass(frozen=True)
+class FakeDeviceProperties:
+    total_memory: int
+
+
+class FakeCuda:
+    def __init__(self, available: bool, total_memory: int = 8 * 1024**3) -> None:
+        self.available = available
+        self.total_memory = total_memory
+
+    def is_available(self) -> bool:
+        return self.available
+
+    def get_device_name(self, _index: int) -> str:
+        return "NVIDIA RTX 4070 Laptop GPU"
+
+    def get_device_properties(self, _index: int) -> FakeDeviceProperties:
+        return FakeDeviceProperties(total_memory=self.total_memory)
+
+
+class FakeTorch:
+    def __init__(self, cuda: FakeCuda) -> None:
+        self.cuda = cuda
+
+
+def test_nvidia_devices_fail_when_device_nodes_are_missing() -> None:
+    check = _check_nvidia_devices(lambda _pattern: [])
+
+    assert check.ok is False
+    assert "/dev/nvidia" in check.message
+
+
+def test_nvidia_devices_fail_with_capability_nodes_only() -> None:
+    check = _check_nvidia_devices(lambda _pattern: ["/dev/nvidia-caps"])
+
+    assert check.ok is False
+    assert "/dev/nvidia0" in check.message
+
+
+def test_nvidia_devices_pass_with_control_and_gpu_nodes() -> None:
+    check = _check_nvidia_devices(
+        lambda _pattern: ["/dev/nvidia0", "/dev/nvidiactl", "/dev/nvidia-uvm"]
+    )
+
+    assert check.ok is True
+    assert "/dev/nvidia0" in check.message
+
+
+def test_torch_cuda_fails_when_cuda_is_unavailable() -> None:
+    checks = _check_torch_cuda(FakeTorch(FakeCuda(False)), min_vram_gb=7.0)
+
+    assert checks[0].ok is False
+    assert "is false" in checks[0].message
+
+
+def test_torch_cuda_reports_vram_for_8gb_gpu() -> None:
+    checks = _check_torch_cuda(FakeTorch(FakeCuda(True)), min_vram_gb=7.0)
+
+    assert [check.ok for check in checks] == [True, True]
+    assert "4070" in checks[0].message
+    assert "8.0 GB" in checks[1].message

--- a/ml/profile-qa/tests/test_synthetic_data.py
+++ b/ml/profile-qa/tests/test_synthetic_data.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from profile_qa.public_profile import fact_index
+from profile_qa.public_profile import PROFILE_SECTIONS
+from profile_qa.synthetic_data import build_records
+from profile_qa.validation import PRIVATE_DATA_MARKERS, validate_dataset
+
+
+def test_generation_is_deterministic() -> None:
+    assert build_records(seed=7) == build_records(seed=7)
+
+
+def test_generated_records_match_schema() -> None:
+    records = build_records(seed=7)
+
+    assert validate_dataset(records) == []
+    assert {record["split"] for record in records} == {"train", "validation", "test"}
+    assert {record["task"] for record in records} >= {
+        "single_turn",
+        "multi_turn",
+        "multi_hop",
+        "chronology",
+        "education",
+        "recommendations",
+        "refusal",
+    }
+
+
+def test_profile_sections_use_reusable_resume_ontology() -> None:
+    section_ids = [str(section["id"]) for section in PROFILE_SECTIONS]
+
+    assert section_ids == [
+        "identity",
+        "current_role",
+        "experience",
+        "projects",
+        "education",
+        "recommendations",
+        "skills",
+        "interests",
+    ]
+    assert "openai" not in section_ids
+    assert "defense_unicorns" not in section_ids
+
+
+def test_split_isolation_for_questions() -> None:
+    questions_by_split: dict[str, set[str]] = {}
+    for record in build_records(seed=7):
+        split = str(record["split"])
+        questions_by_split.setdefault(split, set()).add(str(record["question"]).lower())
+
+    seen: set[str] = set()
+    for questions in questions_by_split.values():
+        assert seen.isdisjoint(questions)
+        seen.update(questions)
+
+
+def test_evidence_references_existing_public_facts() -> None:
+    known_facts = fact_index()
+    for record in build_records(seed=7):
+        for evidence in record["evidence"]:
+            key = (evidence["section_id"], evidence["fact_id"])
+            assert key in known_facts
+
+
+def test_non_refusal_answers_do_not_leak_private_data_markers() -> None:
+    for record in build_records(seed=7):
+        if record["requires_refusal"]:
+            continue
+        text = f"{record['question']} {record['answer']}".lower()
+        leaked = [marker for marker in PRIVATE_DATA_MARKERS if marker in text]
+        assert leaked == []

--- a/src/components/chat/components/ChatContainer.tsx
+++ b/src/components/chat/components/ChatContainer.tsx
@@ -7,7 +7,11 @@ import React, { useEffect, useRef } from "react";
 import { ChatMessages } from "./ChatMessages";
 import { ChatInput } from "./ChatInput";
 import { useChatHistory, useAIGeneration, useModelManagement } from "../hooks";
-import { getPersonalContextBudget } from "@/services/ai/contextProvider";
+import {
+  getPersonalContextBudget,
+  getRecentConversationTurns,
+} from "@/services/ai/contextProvider";
+import { CHATBOT_CONFIG } from "@/config";
 
 export interface ChatContainerProps {
   onClose: () => void;
@@ -23,6 +27,10 @@ export function ChatContainer({ onClose }: ChatContainerProps): React.ReactEleme
     loadingMessage,
   } = useModelManagement();
   const personalContextBudget = getPersonalContextBudget();
+  const welcomeMessages = new Set<string>(CHATBOT_CONFIG.welcomeMessages);
+  const conversationTurns = getRecentConversationTurns(
+    messages.filter((message) => !welcomeMessages.has(message.content))
+  );
   const messagesEndRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -148,6 +156,7 @@ export function ChatContainer({ onClose }: ChatContainerProps): React.ReactEleme
             isSendDisabled={!isReady || isGenerating || !!error}
             isInputDisabled={isGenerating}
             placeholder={placeholder}
+            conversationTurns={conversationTurns}
           />
         </div>
       </div>

--- a/src/components/chat/components/ChatInput.tsx
+++ b/src/components/chat/components/ChatInput.tsx
@@ -6,12 +6,14 @@
 import React, { useState, useRef, KeyboardEvent } from "react";
 import { getPromptBudget } from "@/services/ai/contextProvider";
 import { LimitWarning } from "./LimitWarning";
+import type { ConversationTurn } from "@/types";
 
 export interface ChatInputProps {
   onSend: (message: string) => void;
   isSendDisabled: boolean;
   isInputDisabled: boolean;
   placeholder: string;
+  conversationTurns?: readonly ConversationTurn[];
 }
 
 export function ChatInput({
@@ -19,10 +21,11 @@ export function ChatInput({
   isSendDisabled,
   isInputDisabled,
   placeholder,
+  conversationTurns = [],
 }: ChatInputProps): React.ReactElement {
   const [inputText, setInputText] = useState("");
   const inputRef = useRef<HTMLTextAreaElement>(null);
-  const promptBudget = getPromptBudget(inputText);
+  const promptBudget = getPromptBudget(inputText, { conversationTurns });
   const showInputLimitWarning =
     inputText.trim().length > 0 && promptBudget.isInputTrimmed;
 

--- a/src/components/chat/hooks/useAIGeneration.ts
+++ b/src/components/chat/hooks/useAIGeneration.ts
@@ -5,9 +5,10 @@
 
 import { useState, useEffect, useRef, useCallback } from 'react';
 import { WorkerStatus, type WorkerResponse } from '@/types/worker';
-import { cleanInput, getAIService } from '@/services/ai';
+import { cleanInput, getAIService, getRecentConversationTurns } from '@/services/ai';
 import { useChatStore } from '@/stores/chatStore';
 import { createLogger, LOG_AREAS } from "@/utils";
+import { CHATBOT_CONFIG } from "@/config";
 
 export interface UseAIGenerationReturn {
   isGenerating: boolean;
@@ -18,7 +19,8 @@ export interface UseAIGenerationReturn {
 const logger = createLogger(LOG_AREAS.AI_GENERATION);
 
 export function useAIGeneration(): UseAIGenerationReturn {
-  const { setIsGenerating, updateCurrentResponse, addMessage } = useChatStore();
+  const { messages, setIsGenerating, updateCurrentResponse, addMessage } =
+    useChatStore();
   const [isGenerating, setLocalGenerating] = useState(false);
   const [currentResponse, setCurrentResponse] = useState('');
   const currentResultRef = useRef('');
@@ -86,12 +88,17 @@ export function useAIGeneration(): UseAIGenerationReturn {
       return;
     }
 
+    const welcomeMessages = new Set<string>(CHATBOT_CONFIG.welcomeMessages);
+    const recentTurns = getRecentConversationTurns(
+      messages.filter((message) => !welcomeMessages.has(message.content))
+    );
+
     // Add user message to history
     addMessage('user', cleanedInput);
 
     // Start generation
-    aiService.generate(cleanedInput);
-  }, [addMessage]);
+    aiService.generate(cleanedInput, recentTurns);
+  }, [addMessage, messages]);
 
   return {
     isGenerating,

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -5,7 +5,14 @@
  * For customization instructions, see docs/CUSTOMIZATION.md
  */
 
-export { SITE_CONFIG, DERIVED_CONFIG, PERSONAL_CONTEXT } from "./site";
+export {
+  SITE_CONFIG,
+  DERIVED_CONFIG,
+  PROFILE_SECTIONS,
+  PERSONAL_CONTEXT,
+  type ProfileFact,
+  type ProfileSection,
+} from "./site";
 export {
   MODEL_ID,
   MODEL_DISPLAY_NAME,

--- a/src/config/models.ts
+++ b/src/config/models.ts
@@ -5,12 +5,12 @@
 /**
  * HuggingFace model ID used by the browser worker.
  */
-export const MODEL_ID = "teapotai/teapotllm";
+export const MODEL_ID = "justinthelaw/teapot-profile-qa-browser-1024";
 
 /**
  * User-friendly display name for the configured model.
  */
-export const MODEL_DISPLAY_NAME = "Teapot LLM";
+export const MODEL_DISPLAY_NAME = "Profile-QA Teapot";
 
 export type ModelDtype = "fp32" | "int8" | "uint8" | "q4";
 
@@ -44,4 +44,4 @@ export function getDtypeFallbackOrder(preferredDtype: ModelDtype): ModelDtype[] 
 /**
  * Conservative context length limit for the configured model.
  */
-export const MODEL_CONTEXT_LIMIT = 512;
+export const MODEL_CONTEXT_LIMIT = 1024;

--- a/src/config/prompts.ts
+++ b/src/config/prompts.ts
@@ -18,7 +18,7 @@ export const GENERATION_PARAMS: GenerationParams = {
 /**
  * Context length limit for a single user message.
  */
-export const MAX_SINGLE_MESSAGE_LENGTH = 88;
+export const MAX_SINGLE_MESSAGE_LENGTH = 1200;
 
 /**
  * AI chatbot configuration.

--- a/src/config/site.ts
+++ b/src/config/site.ts
@@ -94,39 +94,245 @@ export const DERIVED_CONFIG = {
 } as const;
 
 /**
+ * Public profile context sections for chatbot retrieval.
+ */
+export interface ProfileFact {
+  id: string;
+  text: string;
+  keywords?: readonly string[];
+}
+
+export interface ProfileSection {
+  id: string;
+  title: string;
+  facts: readonly ProfileFact[];
+  keywords: readonly string[];
+  priority: number;
+  alwaysInclude?: boolean;
+}
+
+export const PROFILE_SECTIONS = [
+  {
+    id: "identity",
+    title: "Identity",
+    priority: 100,
+    alwaysInclude: true,
+    keywords: ["name", "identity", "location", "based", "who"],
+    facts: [
+      {
+        id: "identity_location",
+        text: "Justin Law is based in New York, USA.",
+        keywords: ["justin", "law", "new york", "usa", "based"],
+      },
+    ],
+  },
+  {
+    id: "current_role",
+    title: "Current Role",
+    priority: 90,
+    keywords: [
+      "current role",
+      "current job",
+      "current work",
+      "employer",
+      "role",
+      "scope",
+      "impact",
+    ],
+    facts: [
+      {
+        id: "current_role_title",
+        text: "At OpenAI, Justin is an AI Deployment Engineer.",
+        keywords: ["openai", "ai deployment engineer"],
+      },
+      {
+        id: "current_role_scope",
+        text:
+          "Justin focuses on enterprise Codex adoption across CLI, SDK, MCP, " +
+          "app-server, observability, Kubernetes, and full-stack workflows.",
+        keywords: ["enterprise codex adoption", "cli", "sdk", "mcp"],
+      },
+      {
+        id: "current_role_scale",
+        text: "He has led engagements across 11 organizations and about 33,000 users.",
+        keywords: ["11 organizations", "33000 users", "33,000 users"],
+      },
+    ],
+  },
+  {
+    id: "experience",
+    title: "Experience",
+    priority: 80,
+    keywords: [
+      "experience",
+      "previous role",
+      "work history",
+      "chronology",
+      "before",
+      "veteran",
+      "career",
+    ],
+    facts: [
+      {
+        id: "experience_previous_role",
+        text:
+          "Previously, Justin was a Senior Software Engineer at Defense Unicorns, " +
+          "working across 40+ Kubernetes, AI/ML, and full-stack repos.",
+        keywords: ["senior software engineer", "defense unicorns", "40+"],
+      },
+      {
+        id: "experience_veteran",
+        text:
+          "Justin is a U.S. Air Force and Space Force veteran and one of the " +
+          "Space Force's first certified Supra Coders.",
+        keywords: ["air force", "space force", "veteran", "supra coders"],
+      },
+    ],
+  },
+  {
+    id: "projects",
+    title: "Projects",
+    priority: 75,
+    keywords: [
+      "project",
+      "projects",
+      "built",
+      "developed",
+      "operator",
+      "product",
+      "tool",
+      "rag",
+      "metrics",
+    ],
+    facts: [
+      {
+        id: "projects_current_role",
+        text:
+          "He built Codex packages, OpenInference observability, and a Kubernetes " +
+          "operator that diagnoses and remediates failing workloads.",
+        keywords: ["codex packages", "openinference", "kubernetes operator"],
+      },
+      {
+        id: "projects_products",
+        text: "He developed LeapfrogAI and UDS AI.",
+        keywords: ["leapfrogai", "uds ai"],
+      },
+      {
+        id: "projects_rag_system",
+        text: "He led a FIPS-compliant agentic RAG system for shipyard operations.",
+        keywords: ["fips", "agentic rag", "shipyard"],
+      },
+      {
+        id: "projects_metrics",
+        text: "He improved model MRR 15% and agentic retrieval 38%.",
+        keywords: ["mrr", "15%", "retrieval", "38%"],
+      },
+      {
+        id: "projects_service",
+        text:
+          "He built RF deconfliction tools, orbital object OSINT apps, and " +
+          "acquisition strategies.",
+        keywords: ["rf deconfliction", "orbital object osint", "acquisition"],
+      },
+    ],
+  },
+  {
+    id: "education",
+    title: "Education",
+    priority: 70,
+    keywords: [
+      "education",
+      "degree",
+      "mechanical engineering",
+      "rit",
+      "johns hopkins",
+      "georgia tech",
+      "graduate",
+    ],
+    facts: [
+      {
+        id: "education_rit",
+        text: "Justin earned a B.S. in Mechanical Engineering from RIT.",
+        keywords: ["mechanical engineering", "rit", "degree"],
+      },
+      {
+        id: "education_graduate",
+        text: "He completed graduate CS studies at Johns Hopkins and Georgia Tech.",
+        keywords: ["graduate cs", "johns hopkins", "georgia tech"],
+      },
+    ],
+  },
+  {
+    id: "recommendations",
+    title: "Recommendations",
+    priority: 65,
+    keywords: [
+      "recommendation",
+      "recommendations",
+      "personable",
+      "collaborative",
+      "pressure",
+      "problem solver",
+    ],
+    facts: [
+      {
+        id: "recommendations_summary",
+        text:
+          "Recommendations describe him as personable, collaborative, calm under " +
+          "pressure, technically deep, and a strong problem solver.",
+        keywords: ["personable", "collaborative", "calm under pressure"],
+      },
+    ],
+  },
+  {
+    id: "skills",
+    title: "Skills",
+    priority: 60,
+    keywords: [
+      "skills",
+      "leadership",
+      "public speaking",
+      "technical writing",
+      "systems design",
+      "ai",
+      "ml",
+      "kubernetes",
+      "rag",
+      "observability",
+      "mlflow",
+    ],
+    facts: [
+      {
+        id: "skills_strengths",
+        text:
+          "Strengths include leadership, public speaking, technical writing, pair " +
+          "programming, systems design, AI/ML, Kubernetes, secure deployment, RAG, " +
+          "observability, MLFlow, inference engines, and mission-critical delivery.",
+        keywords: ["systems design", "ai/ml", "kubernetes", "rag", "mlflow"],
+      },
+    ],
+  },
+  {
+    id: "interests",
+    title: "Interests",
+    priority: 40,
+    keywords: ["interests", "hobbies", "outside work", "personal interests"],
+    facts: [
+      {
+        id: "interests_personal",
+        text: "Justin enjoys videogames, hiking, running, and cooking.",
+        keywords: ["videogames", "hiking", "running", "cooking", "hobbies"],
+      },
+    ],
+  },
+] as const satisfies readonly ProfileSection[];
+
+/**
  * Personal knowledge for the chatbot.
  *
- * Paste resume text, cover letter text, biography notes, project summaries,
- * recommendations, or any other public context here. The chatbot receives this
- * block as its source of truth and trims from the tail when it exceeds the
- * browser model's prompt budget.
+ * This compatibility text is derived from structured public profile sections.
  */
-export const PERSONAL_CONTEXT = `
-Justin Law is based in New York, USA. At OpenAI, he is an AI Deployment Engineer
-focused on enterprise Codex adoption across CLI, SDK, MCP, app-server,
-observability, Kubernetes, and full-stack workflows. He enjoys videogames,
-hiking, running, and cooking.
-
-At OpenAI, Justin has led engagements across 11 organizations and about 33,000
-users, and built Codex packages, OpenInference observability, and a Kubernetes
-operator that diagnoses and remediates failing workloads.
-
-Previously, Justin was a Senior Software Engineer at Defense Unicorns, working
-across 40+ Kubernetes, AI/ML, and full-stack repos. He developed LeapfrogAI and
-UDS AI; led a FIPS-compliant agentic RAG system for shipyard operations;
-improved model MRR 15% and agentic retrieval 38%; and deployed hardened AI/ML
-platforms in secure environments.
-
-Justin is a U.S. Air Force and Space Force veteran and one of the Space Force's
-first certified Supra Coders. He built RF deconfliction tools, orbital object
-OSINT apps, and acquisition strategies.
-
-Justin earned a B.S. in Mechanical Engineering from RIT and completed graduate
-CS studies at Johns Hopkins and Georgia Tech.
-
-Strengths include leadership, public speaking, technical writing, pair
-programming, systems design, AI/ML, Kubernetes, secure deployment, RAG,
-observability, MLFlow, inference engines, and mission-critical delivery.
-Recommendations describe him as personable, collaborative, calm under pressure,
-technically deep, and a strong problem solver.
-`.trim();
+export const PERSONAL_CONTEXT = PROFILE_SECTIONS.map(
+  (section) =>
+    `${section.title}: ${section.facts.map((fact) => fact.text).join(" ")}`
+).join("\n\n");

--- a/src/services/ai/contextProvider.ts
+++ b/src/services/ai/contextProvider.ts
@@ -1,19 +1,34 @@
 /**
  * AI context provider.
- * Generates text-to-text prompts for the browser chatbot model.
+ * Generates browser-only profile Q&A prompts with section retrieval.
  */
 
 import { MODEL_CONTEXT_LIMIT } from "@/config/models";
 import { CHATBOT_CONFIG, MAX_SINGLE_MESSAGE_LENGTH } from "@/config/prompts";
-import { PERSONAL_CONTEXT, SITE_CONFIG } from "@/config/site";
+import {
+  PERSONAL_CONTEXT,
+  PROFILE_SECTIONS,
+  SITE_CONFIG,
+  type ProfileSection,
+} from "@/config/site";
+import type { ChatMessage, ConversationTurn } from "@/types";
 
 const ESTIMATED_CHARS_PER_TOKEN = 4;
 const PROMPT_SAFETY_MARGIN_TOKENS = 48;
 const TOKEN_DENSE_CHARACTER_WEIGHT = 4;
+const MAX_HISTORY_TURNS = 6;
+const MAX_HISTORY_TURN_CHARACTERS = 220;
+const MAX_RETRIEVAL_QUESTION_CHARACTERS = 320;
+const PROFILE_CONTEXT_SECTIONS: readonly ProfileSection[] = PROFILE_SECTIONS;
 
 export interface ResponseValidation {
   isValid: boolean;
   issues: string[];
+}
+
+export interface PromptBudgetOptions {
+  conversationTurns?: readonly ConversationTurn[];
+  contextLimit?: number;
 }
 
 export interface PromptBudget {
@@ -26,6 +41,10 @@ export interface PromptBudget {
   trimmedInputCharacters: number;
   estimatedPromptTokens: number;
   maxPromptCharacters: number;
+  selectedProfileSectionIds: string[];
+  includedConversationTurns: number;
+  isHistoryTrimmed: boolean;
+  trimmedHistoryTurns: number;
 }
 
 export interface PersonalContextBudget {
@@ -33,6 +52,12 @@ export interface PersonalContextBudget {
   isTrimmed: boolean;
   overBudgetCharacters: number;
   trimmedCharacters: number;
+  selectedProfileSectionIds: string[];
+}
+
+export interface ProfileSectionSelection {
+  section: ProfileSection;
+  score: number;
 }
 
 interface InputTrimResult {
@@ -41,38 +66,17 @@ interface InputTrimResult {
   trimmedCharacters: number;
 }
 
-function getMaxPromptCharacters(): number {
-  return Math.max(
-    0,
-    (MODEL_CONTEXT_LIMIT - PROMPT_SAFETY_MARGIN_TOKENS) *
-      ESTIMATED_CHARS_PER_TOKEN
-  );
+interface PromptContext {
+  personalContextBudget: PersonalContextBudget;
+  conversationTurns: ConversationTurn[];
+  trimmedHistoryTurns: number;
 }
 
-function trimFromTail(
-  text: string,
-  maxCharacters: number
-): PersonalContextBudget {
-  const normalizedText = text.trim();
-
-  if (normalizedText.length <= maxCharacters) {
-    return {
-      text: normalizedText,
-      isTrimmed: false,
-      overBudgetCharacters: 0,
-      trimmedCharacters: 0,
-    };
-  }
-
-  const trimmedText = normalizedText.slice(0, Math.max(0, maxCharacters));
-  const trimmedCharacters = normalizedText.length - trimmedText.length;
-
-  return {
-    text: trimmedText,
-    isTrimmed: true,
-    overBudgetCharacters: trimmedCharacters,
-    trimmedCharacters,
-  };
+function getMaxPromptCharacters(contextLimit: number = MODEL_CONTEXT_LIMIT): number {
+  return Math.max(
+    0,
+    (contextLimit - PROMPT_SAFETY_MARGIN_TOKENS) * ESTIMATED_CHARS_PER_TOKEN
+  );
 }
 
 function getInputCharacterWeight(character: string): number {
@@ -105,88 +109,6 @@ function trimInputToBudget(text: string, maxBudget: number): InputTrimResult {
   };
 }
 
-function buildPrompt(personalContext: string, question: string): string {
-  return `${CHATBOT_CONFIG.systemPrompt}
-
-Context:
-${SITE_CONFIG.name} refers to ${SITE_CONFIG.fullName}.
-${personalContext}
-
-Question:
-${question}
-
-Answer:`;
-}
-
-function estimateTokenCount(text: string): number {
-  return Math.ceil(text.length / ESTIMATED_CHARS_PER_TOKEN);
-}
-
-function getMaxPersonalContextCharacters(): number {
-  const promptWithoutPersonalContext = buildPrompt(
-    "",
-    "x".repeat(MAX_SINGLE_MESSAGE_LENGTH)
-  );
-
-  return Math.max(
-    0,
-    getMaxPromptCharacters() - promptWithoutPersonalContext.length
-  );
-}
-
-export function getPersonalContextBudget(): PersonalContextBudget {
-  return trimFromTail(PERSONAL_CONTEXT, getMaxPersonalContextCharacters());
-}
-
-export function getInputCharacterLimit(personalContext?: string): number {
-  const contextText = personalContext ?? getPersonalContextBudget().text;
-  const promptWithoutQuestion = buildPrompt(contextText, "");
-  const remainingCharacters =
-    getMaxPromptCharacters() - promptWithoutQuestion.length;
-
-  return Math.max(
-    0,
-    Math.min(MAX_SINGLE_MESSAGE_LENGTH, remainingCharacters)
-  );
-}
-
-export function getPromptBudget(userInput: string = ""): PromptBudget {
-  const personalContextBudget = getPersonalContextBudget();
-  const inputCharacterLimit = getInputCharacterLimit(
-    personalContextBudget.text
-  );
-  const inputBudget = trimInputToBudget(
-    cleanRawInput(userInput),
-    inputCharacterLimit
-  );
-  const question = inputBudget.text;
-  const prompt = buildPrompt(personalContextBudget.text, question);
-
-  return {
-    personalContext: personalContextBudget.text,
-    isPersonalContextTrimmed: personalContextBudget.isTrimmed,
-    overBudgetPersonalContextCharacters:
-      personalContextBudget.overBudgetCharacters,
-    trimmedPersonalContextCharacters:
-      personalContextBudget.trimmedCharacters,
-    inputCharacterLimit,
-    isInputTrimmed: inputBudget.isTrimmed,
-    trimmedInputCharacters: inputBudget.trimmedCharacters,
-    estimatedPromptTokens: estimateTokenCount(prompt),
-    maxPromptCharacters: getMaxPromptCharacters(),
-  };
-}
-
-/**
- * Generate a single-turn prompt for Teapot-style context question answering.
- */
-export function generatePrompt(userInput: string): string {
-  const budget = getPromptBudget(userInput);
-  const question = cleanInput(userInput, budget.inputCharacterLimit);
-
-  return buildPrompt(budget.personalContext, question);
-}
-
 function cleanRawInput(input?: string): string {
   if (!input) return "";
 
@@ -200,6 +122,326 @@ function cleanRawInput(input?: string): string {
     .replace(/[<>]/g, "")
     .replace(/\s+/g, " ")
     .trim();
+}
+
+function normalizeSearchText(text: string): string {
+  return cleanRawInput(text).toLowerCase();
+}
+
+function tokenize(text: string): string[] {
+  return normalizeSearchText(text).match(/[a-z0-9]+(?:\/[a-z0-9]+)?/g) ?? [];
+}
+
+function getKeywordScore(keyword: string, searchText: string, tokens: Set<string>): number {
+  const normalizedKeyword = normalizeSearchText(keyword);
+  if (!normalizedKeyword) {
+    return 0;
+  }
+
+  if (normalizedKeyword.includes(" ")) {
+    return searchText.includes(normalizedKeyword) ? 6 : 0;
+  }
+
+  return tokens.has(normalizedKeyword) ? 3 : 0;
+}
+
+function getSectionText(section: ProfileSection): string {
+  return `${section.title}: ${section.facts.map((fact) => fact.text).join(" ")}`;
+}
+
+function getProfileContextText(sections: readonly ProfileSection[]): string {
+  return sections.map((section) => getSectionText(section)).join("\n\n");
+}
+
+function buildHistoryText(conversationTurns: readonly ConversationTurn[]): string {
+  if (conversationTurns.length === 0) {
+    return "";
+  }
+
+  const lines = conversationTurns.map((turn) => {
+    const role = turn.role === "assistant" ? "Assistant" : "User";
+    return `${role}: ${turn.content}`;
+  });
+
+  return `\n\nRecent conversation:\n${lines.join("\n")}`;
+}
+
+function buildPrompt(
+  personalContext: string,
+  question: string,
+  conversationTurns: readonly ConversationTurn[] = []
+): string {
+  return `${CHATBOT_CONFIG.systemPrompt}
+
+Context:
+${SITE_CONFIG.name} refers to ${SITE_CONFIG.fullName}.
+${personalContext}${buildHistoryText(conversationTurns)}
+
+Question:
+${question}
+
+Answer:`;
+}
+
+export function estimateTokenCount(text: string): number {
+  return Math.ceil(text.length / ESTIMATED_CHARS_PER_TOKEN);
+}
+
+function sanitizeConversationTurns(
+  conversationTurns: readonly ConversationTurn[] = []
+): ConversationTurn[] {
+  return conversationTurns
+    .filter((turn) => turn.content.trim().length > 0)
+    .slice(-MAX_HISTORY_TURNS)
+    .map((turn) => ({
+      role: turn.role,
+      content: trimInputToBudget(
+        cleanRawInput(turn.content),
+        MAX_HISTORY_TURN_CHARACTERS
+      ).text,
+    }))
+    .filter((turn) => turn.content.length > 0);
+}
+
+export function getRecentConversationTurns(
+  messages: readonly ChatMessage[],
+  limit: number = MAX_HISTORY_TURNS
+): ConversationTurn[] {
+  return messages
+    .filter((message) => message.content.trim().length > 0)
+    .slice(-limit)
+    .map((message) => ({
+      role: message.type === "ai" ? "assistant" : "user",
+      content: message.content,
+    }));
+}
+
+export function rankProfileSections(
+  question: string,
+  conversationTurns: readonly ConversationTurn[] = []
+): ProfileSectionSelection[] {
+  const searchText = normalizeSearchText(
+    [
+      question,
+      ...conversationTurns.map((turn) => turn.content),
+    ].join(" ")
+  );
+  const tokens = new Set(tokenize(searchText));
+
+  return PROFILE_CONTEXT_SECTIONS.map((section) => {
+    let score = section.priority / 1000;
+    if (section.alwaysInclude) {
+      score += 10_000;
+    }
+
+    for (const keyword of section.keywords) {
+      score += getKeywordScore(keyword, searchText, tokens);
+    }
+
+    for (const fact of section.facts) {
+      score += getKeywordScore(fact.text, searchText, tokens) / 2;
+      for (const keyword of fact.keywords ?? []) {
+        score += getKeywordScore(keyword, searchText, tokens);
+      }
+    }
+
+    return { section, score };
+  }).sort((left, right) => {
+    if (right.score !== left.score) {
+      return right.score - left.score;
+    }
+    return right.section.priority - left.section.priority;
+  });
+}
+
+function getSelectedContextBudget(sections: readonly ProfileSection[]): PersonalContextBudget {
+  const text = getProfileContextText(sections);
+  const selectedProfileSectionIds = sections.map((section) => section.id);
+  const overBudgetCharacters = Math.max(0, PERSONAL_CONTEXT.length - text.length);
+
+  return {
+    text,
+    isTrimmed: selectedProfileSectionIds.length < PROFILE_CONTEXT_SECTIONS.length,
+    overBudgetCharacters,
+    trimmedCharacters: overBudgetCharacters,
+    selectedProfileSectionIds,
+  };
+}
+
+function canFitPrompt(
+  sections: readonly ProfileSection[],
+  question: string,
+  conversationTurns: readonly ConversationTurn[],
+  contextLimit: number
+): boolean {
+  const prompt = buildPrompt(
+    getProfileContextText(sections),
+    question,
+    conversationTurns
+  );
+  return prompt.length <= getMaxPromptCharacters(contextLimit);
+}
+
+function fitConversationTurns(
+  turns: readonly ConversationTurn[],
+  selectedSections: readonly ProfileSection[],
+  question: string,
+  contextLimit: number
+): ConversationTurn[] {
+  const selectedTurns: ConversationTurn[] = [];
+
+  for (let index = turns.length - 1; index >= 0; index -= 1) {
+    const candidateTurns = [turns[index], ...selectedTurns];
+    if (canFitPrompt(selectedSections, question, candidateTurns, contextLimit)) {
+      selectedTurns.unshift(turns[index]);
+    }
+  }
+
+  return selectedTurns;
+}
+
+function buildPromptContext(
+  userInput: string,
+  options: PromptBudgetOptions = {}
+): PromptContext {
+  const contextLimit = options.contextLimit ?? MODEL_CONTEXT_LIMIT;
+  const questionForRetrieval = trimInputToBudget(
+    cleanRawInput(userInput),
+    MAX_RETRIEVAL_QUESTION_CHARACTERS
+  ).text;
+  const conversationTurns = sanitizeConversationTurns(options.conversationTurns);
+  const rankedSections = rankProfileSections(questionForRetrieval, conversationTurns);
+  const selectedSections: ProfileSection[] = [];
+
+  for (const { section } of rankedSections.filter(
+    (selection) => selection.section.alwaysInclude
+  )) {
+    selectedSections.push(section);
+  }
+
+  const selectedConversationTurns = fitConversationTurns(
+    conversationTurns,
+    selectedSections,
+    "",
+    contextLimit
+  );
+
+  for (const { section } of rankedSections) {
+    if (section.alwaysInclude || selectedSections.includes(section)) {
+      continue;
+    }
+
+    const candidateSections = [...selectedSections, section];
+    if (
+      canFitPrompt(
+        candidateSections,
+        "",
+        selectedConversationTurns,
+        contextLimit
+      )
+    ) {
+      selectedSections.push(section);
+    }
+  }
+
+  return {
+    personalContextBudget: getSelectedContextBudget(selectedSections),
+    conversationTurns: selectedConversationTurns,
+    trimmedHistoryTurns: conversationTurns.length - selectedConversationTurns.length,
+  };
+}
+
+export function getPersonalContextBudget(
+  userInput: string = "",
+  options: PromptBudgetOptions = {}
+): PersonalContextBudget {
+  return buildPromptContext(userInput, options).personalContextBudget;
+}
+
+export function getInputCharacterLimit(
+  personalContext?: string,
+  conversationTurns: readonly ConversationTurn[] = [],
+  contextLimit: number = MODEL_CONTEXT_LIMIT
+): number {
+  const contextText = personalContext ?? getPersonalContextBudget().text;
+  const promptWithoutQuestion = buildPrompt(
+    contextText,
+    "",
+    sanitizeConversationTurns(conversationTurns)
+  );
+  const remainingCharacters =
+    getMaxPromptCharacters(contextLimit) - promptWithoutQuestion.length;
+
+  return Math.max(
+    0,
+    Math.min(MAX_SINGLE_MESSAGE_LENGTH, remainingCharacters)
+  );
+}
+
+export function getPromptBudget(
+  userInput: string = "",
+  options: PromptBudgetOptions = {}
+): PromptBudget {
+  const contextLimit = options.contextLimit ?? MODEL_CONTEXT_LIMIT;
+  const promptContext = buildPromptContext(userInput, options);
+  const inputCharacterLimit = getInputCharacterLimit(
+    promptContext.personalContextBudget.text,
+    promptContext.conversationTurns,
+    contextLimit
+  );
+  const inputBudget = trimInputToBudget(
+    cleanRawInput(userInput),
+    inputCharacterLimit
+  );
+  const prompt = buildPrompt(
+    promptContext.personalContextBudget.text,
+    inputBudget.text,
+    promptContext.conversationTurns
+  );
+
+  return {
+    personalContext: promptContext.personalContextBudget.text,
+    isPersonalContextTrimmed: promptContext.personalContextBudget.isTrimmed,
+    overBudgetPersonalContextCharacters:
+      promptContext.personalContextBudget.overBudgetCharacters,
+    trimmedPersonalContextCharacters:
+      promptContext.personalContextBudget.trimmedCharacters,
+    inputCharacterLimit,
+    isInputTrimmed: inputBudget.isTrimmed,
+    trimmedInputCharacters: inputBudget.trimmedCharacters,
+    estimatedPromptTokens: estimateTokenCount(prompt),
+    maxPromptCharacters: getMaxPromptCharacters(contextLimit),
+    selectedProfileSectionIds:
+      promptContext.personalContextBudget.selectedProfileSectionIds,
+    includedConversationTurns: promptContext.conversationTurns.length,
+    isHistoryTrimmed: promptContext.trimmedHistoryTurns > 0,
+    trimmedHistoryTurns: promptContext.trimmedHistoryTurns,
+  };
+}
+
+/**
+ * Generate a prompt for Teapot-style context question answering.
+ */
+export function generatePrompt(
+  userInput: string,
+  options: PromptBudgetOptions = {}
+): string {
+  const contextLimit = options.contextLimit ?? MODEL_CONTEXT_LIMIT;
+  const promptContext = buildPromptContext(userInput, options);
+  const question = cleanInput(
+    userInput,
+    getInputCharacterLimit(
+      promptContext.personalContextBudget.text,
+      promptContext.conversationTurns,
+      contextLimit
+    )
+  );
+
+  return buildPrompt(
+    promptContext.personalContextBudget.text,
+    question,
+    promptContext.conversationTurns
+  );
 }
 
 /**

--- a/src/services/ai/modelLoader.ts
+++ b/src/services/ai/modelLoader.ts
@@ -186,46 +186,46 @@ export async function loadModel(
 
   for (const dtype of dtypeFallbackOrder) {
     attempts++;
+    let isDownloading = true;
+
+    const pipelineOptions: Record<string, unknown> = {
+      dtype,
+      device: "wasm",
+      progress_callback: (progressData: unknown) => {
+        if (typeof progressData !== "object" || progressData === null) {
+          return;
+        }
+
+        const data = progressData as {
+          progress?: number;
+          status?: string;
+        };
+
+        if (data.progress === undefined || !callbacks.onProgress) {
+          return;
+        }
+
+        const progress = Math.round(data.progress);
+        let message: string;
+
+        if (data.status === "progress") {
+          message = `Downloading model... ${progress}%`;
+          isDownloading = true;
+        } else if (data.status === "done" || progress === 100) {
+          message = `Loading into memory... ${progress}%`;
+          isDownloading = false;
+        } else {
+          message = isDownloading
+            ? `Downloading model... ${progress}%`
+            : `Loading into memory... ${progress}%`;
+        }
+
+        callbacks.onProgress(progress, message);
+      },
+    };
+
     try {
       logger.log(`loading model (${dtype}): ${MODEL_ID}`);
-
-      let isDownloading = true;
-
-      const pipelineOptions: Record<string, unknown> = {
-        dtype,
-        device: "wasm",
-        progress_callback: (progressData: unknown) => {
-          if (typeof progressData !== "object" || progressData === null) {
-            return;
-          }
-
-          const data = progressData as {
-            progress?: number;
-            status?: string;
-          };
-
-          if (data.progress === undefined || !callbacks.onProgress) {
-            return;
-          }
-
-          const progress = Math.round(data.progress);
-          let message: string;
-
-          if (data.status === "progress") {
-            message = `Downloading model... ${progress}%`;
-            isDownloading = true;
-          } else if (data.status === "done" || progress === 100) {
-            message = `Loading into memory... ${progress}%`;
-            isDownloading = false;
-          } else {
-            message = isDownloading
-              ? `Downloading model... ${progress}%`
-              : `Loading into memory... ${progress}%`;
-          }
-
-          callbacks.onProgress(progress, message);
-        },
-      };
 
       const pipelineResult = await createPipeline(
         "text-generation",

--- a/src/services/ai/modelLoader.ts
+++ b/src/services/ai/modelLoader.ts
@@ -6,6 +6,7 @@
 import {
   pipeline,
   env,
+  type Text2TextGenerationPipeline,
   type TextGenerationPipeline,
 } from "@huggingface/transformers";
 import {
@@ -20,6 +21,32 @@ env.remoteHost = "https://huggingface.co";
 
 const logger = createLogger(LOG_AREAS.AI_MODEL_LOADER);
 
+export type GenerationTask = "text-generation" | "text2text-generation";
+
+export type GenerationPipeline =
+  | TextGenerationPipeline
+  | Text2TextGenerationPipeline;
+
+export type GenerationPipelineFactory = (
+  task: GenerationTask,
+  modelId: string,
+  options: Record<string, unknown>
+) => Promise<GenerationPipeline>;
+
+export interface LoadedTextGenerationPipeline {
+  task: "text-generation";
+  generator: TextGenerationPipeline;
+}
+
+export interface LoadedText2TextGenerationPipeline {
+  task: "text2text-generation";
+  generator: Text2TextGenerationPipeline;
+}
+
+export type LoadedGenerationPipeline =
+  | LoadedTextGenerationPipeline
+  | LoadedText2TextGenerationPipeline;
+
 export interface LoaderCallbacks {
   viewportWidth?: number;
   onProgress?: (progress: number, message: string) => void;
@@ -29,6 +56,7 @@ interface NormalizedLoadError {
   message: string;
   isLikelyMemoryError: boolean;
   isNumericRuntimeCode: boolean;
+  isLikelyTaskMismatch: boolean;
 }
 
 function safeJsonStringify(value: unknown): string {
@@ -45,6 +73,7 @@ function normalizeLoadError(error: unknown): NormalizedLoadError {
       message: `Runtime error code: ${error}`,
       isLikelyMemoryError: true,
       isNumericRuntimeCode: true,
+      isLikelyTaskMismatch: false,
     };
   }
 
@@ -57,6 +86,7 @@ function normalizeLoadError(error: unknown): NormalizedLoadError {
         lower.includes("allocation") ||
         lower.includes("out of bounds"),
       isNumericRuntimeCode: /^\d+$/.test(error.trim()),
+      isLikelyTaskMismatch: isLikelyTaskMismatchMessage(lower),
     };
   }
 
@@ -70,6 +100,7 @@ function normalizeLoadError(error: unknown): NormalizedLoadError {
         lower.includes("allocation") ||
         lower.includes("out of bounds"),
       isNumericRuntimeCode: false,
+      isLikelyTaskMismatch: isLikelyTaskMismatchMessage(lower),
     };
   }
 
@@ -98,6 +129,7 @@ function normalizeLoadError(error: unknown): NormalizedLoadError {
         lower.includes("out of bounds") ||
         (maybeCode !== null && /^\d+$/.test(maybeCode)),
       isNumericRuntimeCode: maybeCode !== null && /^\d+$/.test(maybeCode),
+      isLikelyTaskMismatch: isLikelyTaskMismatchMessage(lower),
     };
   }
 
@@ -105,7 +137,33 @@ function normalizeLoadError(error: unknown): NormalizedLoadError {
     message: String(error),
     isLikelyMemoryError: false,
     isNumericRuntimeCode: false,
+    isLikelyTaskMismatch: false,
   };
+}
+
+export function isLikelyTaskMismatchMessage(message: string): boolean {
+  const lower = message.toLowerCase();
+
+  return (
+    lower.includes("unsupported model type") ||
+    lower.includes('for task "text-generation"') ||
+    lower.includes("modelwithlmhead") ||
+    lower.includes("modelforcausallm")
+  );
+}
+
+async function createGenerationPipeline(
+  task: GenerationTask,
+  modelId: string,
+  options: Record<string, unknown>
+): Promise<GenerationPipeline> {
+  if (task === "text-generation") {
+    const pipelineResult = await pipeline("text-generation", modelId, options);
+    return pipelineResult as TextGenerationPipeline;
+  }
+
+  const pipelineResult = await pipeline("text2text-generation", modelId, options);
+  return pipelineResult as Text2TextGenerationPipeline;
 }
 
 /**
@@ -113,8 +171,9 @@ function normalizeLoadError(error: unknown): NormalizedLoadError {
  * Dtype is selected from viewport-aware preferences with fallback ordering.
  */
 export async function loadModel(
-  callbacks: LoaderCallbacks = {}
-): Promise<TextGenerationPipeline | null> {
+  callbacks: LoaderCallbacks = {},
+  createPipeline: GenerationPipelineFactory = createGenerationPipeline
+): Promise<LoadedGenerationPipeline | null> {
   let attempts = 0;
   const preferredDtype = getDeviceSpecificDtype(callbacks.viewportWidth);
   const dtypeFallbackOrder = getDtypeFallbackOrder(preferredDtype);
@@ -168,13 +227,16 @@ export async function loadModel(
         },
       };
 
-      const pipelineResult = await pipeline(
+      const pipelineResult = await createPipeline(
         "text-generation",
         MODEL_ID,
         pipelineOptions
       );
 
-      return pipelineResult as TextGenerationPipeline;
+      return {
+        task: "text-generation",
+        generator: pipelineResult as TextGenerationPipeline,
+      };
     } catch (error) {
       const normalizedError = normalizeLoadError(error);
       const fallbackHint = normalizedError.isLikelyMemoryError
@@ -182,8 +244,49 @@ export async function loadModel(
         : "Trying next dtype fallback option.";
 
       logger.error(
-        `attempt ${attempts} failed for ${dtype}: ${normalizedError.message}`
+        `attempt ${attempts} failed for ${dtype} (text-generation): ${normalizedError.message}`
       );
+
+      if (normalizedError.isLikelyTaskMismatch) {
+        logger.warn(
+          `model ${MODEL_ID} appears incompatible with text-generation; retrying text2text-generation for the same dtype.`
+        );
+
+        try {
+          const pipelineResult = await createPipeline(
+            "text2text-generation",
+            MODEL_ID,
+            pipelineOptions
+          );
+
+          return {
+            task: "text2text-generation",
+            generator: pipelineResult as Text2TextGenerationPipeline,
+          };
+        } catch (fallbackError) {
+          const normalizedFallbackError = normalizeLoadError(fallbackError);
+          const fallbackTaskHint = normalizedFallbackError.isLikelyMemoryError
+            ? "Likely memory/runtime pressure while retrying text2text-generation."
+            : "Trying next dtype fallback option.";
+
+          logger.error(
+            `attempt ${attempts} failed for ${dtype} (text2text-generation): ${normalizedFallbackError.message}`
+          );
+
+          if (
+            normalizedFallbackError.isLikelyMemoryError ||
+            normalizedFallbackError.isNumericRuntimeCode
+          ) {
+            logger.warn(fallbackTaskHint);
+            if (normalizedFallbackError.isNumericRuntimeCode) {
+              logger.warn(
+                "numeric runtime codes from ONNX/WebAssembly are often opaque; fallback will continue."
+              );
+            }
+          }
+        }
+      }
+
       if (
         normalizedError.isLikelyMemoryError ||
         normalizedError.isNumericRuntimeCode

--- a/src/services/ai/service.ts
+++ b/src/services/ai/service.ts
@@ -4,6 +4,7 @@
  */
 
 import { WorkerAction, type WorkerResponse } from "@/types/worker";
+import type { ConversationTurn } from "@/types";
 import { createLogger, LOG_AREAS } from "@/utils";
 
 export type AIServiceCallback = (response: WorkerResponse) => void;
@@ -52,7 +53,10 @@ export class AIService {
   /**
    * Generate text from user input.
    */
-  generate(input: string): void {
+  generate(
+    input: string,
+    conversationTurns: readonly ConversationTurn[] = []
+  ): void {
     if (!this.worker) {
       logger.error("worker not initialized");
       return;
@@ -61,6 +65,7 @@ export class AIService {
     this.worker.postMessage({
       action: WorkerAction.GENERATE,
       input,
+      conversationTurns,
     });
   }
 

--- a/src/services/ai/worker.ts
+++ b/src/services/ai/worker.ts
@@ -68,7 +68,12 @@ function extractGeneratedText(output: TextGenerationOutput): string {
 }
 
 self.addEventListener("message", async (event: MessageEvent<WorkerRequest>) => {
-  const { action, input, viewportWidth: nextViewportWidth } = event.data;
+  const {
+    action,
+    input,
+    conversationTurns,
+    viewportWidth: nextViewportWidth,
+  } = event.data;
 
   if (action === WorkerAction.INIT) {
     viewportWidth = nextViewportWidth;
@@ -144,7 +149,7 @@ self.addEventListener("message", async (event: MessageEvent<WorkerRequest>) => {
 
     self.postMessage({ status: WorkerStatus.INITIATE });
 
-    const prompt = generatePrompt(cleanedInput);
+    const prompt = generatePrompt(cleanedInput, { conversationTurns });
     const generationParams = { ...GENERATION_PARAMS };
     let streamedText = "";
 

--- a/src/services/ai/worker.ts
+++ b/src/services/ai/worker.ts
@@ -6,20 +6,66 @@
 import {
   TextStreamer,
   env,
-  type TextGenerationPipeline,
+  type Text2TextGenerationOutput,
+  type TextGenerationOutput,
 } from "@huggingface/transformers";
 import { WorkerAction, WorkerStatus, type WorkerRequest } from "@/types/worker";
 import { GENERATION_PARAMS } from "@/config/prompts";
 import { createLogger, LOG_AREAS } from "@/utils";
 import { generatePrompt, cleanInput } from "./contextProvider";
-import { loadModel } from "./modelLoader";
+import { loadModel, type LoadedGenerationPipeline } from "./modelLoader";
 
 env.allowLocalModels = false;
 env.remoteHost = "https://huggingface.co";
 
 let viewportWidth: number | undefined;
-let generator: TextGenerationPipeline | null = null;
+let loadedPipeline: LoadedGenerationPipeline | null = null;
 const logger = createLogger(LOG_AREAS.AI_WORKER);
+
+function extractGeneratedText(output: TextGenerationOutput): string {
+  const generated = output[0]?.generated_text;
+
+  if (typeof generated === "string") {
+    return generated.trim();
+  }
+
+  if (Array.isArray(generated)) {
+    for (let index = generated.length - 1; index >= 0; index -= 1) {
+      const message = generated[index];
+      if (message.role !== "assistant") {
+        continue;
+      }
+
+      if (typeof message.content === "string") {
+        return message.content.trim();
+      }
+
+      if (Array.isArray(message.content)) {
+        return message.content
+          .map((part) => {
+            if (typeof part === "string") {
+              return part;
+            }
+
+            if (
+              typeof part === "object" &&
+              part !== null &&
+              "text" in part &&
+              typeof part.text === "string"
+            ) {
+              return part.text;
+            }
+
+            return "";
+          })
+          .join("")
+          .trim();
+      }
+    }
+  }
+
+  return "";
+}
 
 self.addEventListener("message", async (event: MessageEvent<WorkerRequest>) => {
   const { action, input, viewportWidth: nextViewportWidth } = event.data;
@@ -32,7 +78,7 @@ self.addEventListener("message", async (event: MessageEvent<WorkerRequest>) => {
 
   if (action === WorkerAction.LOAD) {
     try {
-      generator = await loadModel({
+      loadedPipeline = await loadModel({
         viewportWidth,
         onProgress: (progress, message) => {
           self.postMessage({
@@ -43,8 +89,8 @@ self.addEventListener("message", async (event: MessageEvent<WorkerRequest>) => {
         },
       });
 
-      if (generator) {
-        logger.info("model loaded");
+      if (loadedPipeline) {
+        logger.info(`model loaded via ${loadedPipeline.task}`);
         self.postMessage({
           status: WorkerStatus.LOAD,
           message: "Model loaded successfully!",
@@ -76,7 +122,7 @@ self.addEventListener("message", async (event: MessageEvent<WorkerRequest>) => {
       return;
     }
 
-    if (!generator) {
+    if (!loadedPipeline) {
       self.postMessage({
         status: WorkerStatus.STREAM,
         response:
@@ -86,7 +132,7 @@ self.addEventListener("message", async (event: MessageEvent<WorkerRequest>) => {
       return;
     }
 
-    if (!generator.tokenizer) {
+    if (!loadedPipeline.generator.tokenizer) {
       self.postMessage({
         status: WorkerStatus.STREAM,
         response:
@@ -103,7 +149,7 @@ self.addEventListener("message", async (event: MessageEvent<WorkerRequest>) => {
     let streamedText = "";
 
     try {
-      const streamer = new TextStreamer(generator.tokenizer, {
+      const streamer = new TextStreamer(loadedPipeline.generator.tokenizer, {
         skip_prompt: true,
         skip_special_tokens: true,
         callback_function: (text: string) => {
@@ -112,22 +158,51 @@ self.addEventListener("message", async (event: MessageEvent<WorkerRequest>) => {
         },
       });
 
-      const output = await generator(prompt, {
-        temperature: generationParams.temperature,
-        max_new_tokens: generationParams.maxTokens,
-        do_sample: false,
-        repetition_penalty: generationParams.repetitionPenalty,
-        top_k: generationParams.topK,
-        early_stopping: true,
-        streamer,
-      });
-
-      const generatedText = output[0]?.generated_text.trim() ?? "";
-      if (!streamedText.trim() && generatedText.length > 0) {
-        self.postMessage({
-          status: WorkerStatus.STREAM,
-          response: generatedText,
+      if (loadedPipeline.task === "text-generation") {
+        const output = await loadedPipeline.generator(prompt, {
+          temperature: generationParams.temperature,
+          max_new_tokens: generationParams.maxTokens,
+          do_sample: false,
+          repetition_penalty: generationParams.repetitionPenalty,
+          top_k: generationParams.topK,
+          early_stopping: true,
+          return_full_text: false,
+          streamer,
         });
+
+        const generatedText = extractGeneratedText(
+          output as TextGenerationOutput
+        );
+        if (!generatedText) {
+          logger.warn("text-generation output completed without assistant text");
+        } else if (!streamedText.trim()) {
+          self.postMessage({
+            status: WorkerStatus.STREAM,
+            response: generatedText,
+          });
+        }
+      } else {
+        const output = await loadedPipeline.generator(prompt, {
+          temperature: generationParams.temperature,
+          max_new_tokens: generationParams.maxTokens,
+          do_sample: false,
+          repetition_penalty: generationParams.repetitionPenalty,
+          top_k: generationParams.topK,
+          early_stopping: true,
+          streamer,
+        });
+
+        const generatedText =
+          (output as Text2TextGenerationOutput)[0]?.generated_text.trim() ?? "";
+
+        if (!generatedText) {
+          logger.warn("text2text-generation output completed without text");
+        } else if (!streamedText.trim()) {
+          self.postMessage({
+            status: WorkerStatus.STREAM,
+            response: generatedText,
+          });
+        }
       }
     } catch (e) {
       self.postMessage({

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -14,6 +14,14 @@ export interface ChatMessage {
 }
 
 /**
+ * Sanitized conversation turn sent to the AI worker.
+ */
+export interface ConversationTurn {
+  role: "user" | "assistant";
+  content: string;
+}
+
+/**
  * AI generation parameters
  */
 export interface GenerationParams {

--- a/src/types/worker.ts
+++ b/src/types/worker.ts
@@ -3,6 +3,8 @@
  * Typed enums and constants for AI worker communication
  */
 
+import type { ConversationTurn } from "./index";
+
 /**
  * Actions sent TO the worker
  */
@@ -29,6 +31,7 @@ export enum WorkerStatus {
 export interface WorkerRequest {
   action: WorkerAction;
   input?: string;
+  conversationTurns?: ConversationTurn[];
   viewportWidth?: number;
 }
 

--- a/tests/chatbot.spec.ts
+++ b/tests/chatbot.spec.ts
@@ -1,10 +1,18 @@
 import { test, expect, type Page } from "@playwright/test";
-import { getPromptBudget } from "../src/services/ai/contextProvider";
+import {
+  getPersonalContextBudget,
+  getPromptBudget,
+} from "../src/services/ai/contextProvider";
 
 async function mockModelWorker(page: Page): Promise<void> {
   await page.addInitScript(() => {
     interface MockWorkerMessage {
       action?: string;
+      input?: string;
+      conversationTurns?: Array<{
+        role: string;
+        content: string;
+      }>;
     }
 
     interface MockWorkerResponse {
@@ -18,6 +26,11 @@ async function mockModelWorker(page: Page): Promise<void> {
         null;
 
       postMessage(message: MockWorkerMessage): void {
+        const mockWindow = window as unknown as {
+          __mockWorkerMessages: MockWorkerMessage[];
+        };
+        mockWindow.__mockWorkerMessages.push(message);
+
         if (message.action === "load") {
           window.setTimeout(() => {
             this.emit({
@@ -45,6 +58,10 @@ async function mockModelWorker(page: Page): Promise<void> {
       }
     }
 
+    const mockWindow = window as unknown as {
+      __mockWorkerMessages: MockWorkerMessage[];
+    };
+    mockWindow.__mockWorkerMessages = [];
     window.Worker = MockWorker as unknown as typeof Worker;
   });
 }
@@ -118,15 +135,21 @@ test.describe("Chatbot UI Tests", () => {
     expect(userBubbleBox!.width).toBeLessThanOrEqual(scrollBox!.width);
   });
 
-  test("should not show profile trim warning when profile fits budget", async ({
+  test("should show profile trim warning only when retrieval excludes sections", async ({
     page,
   }) => {
+    const personalContextBudget = getPersonalContextBudget();
+
     await openChat(page);
 
-    await expect(page.getByTestId("profile-trim-warning")).toHaveCount(0);
-    await expect(page.getByTestId("profile-trim-warning-tooltip")).toHaveCount(
-      0,
-    );
+    if (personalContextBudget.isTrimmed) {
+      await expect(page.getByTestId("profile-trim-warning")).toBeVisible();
+    } else {
+      await expect(page.getByTestId("profile-trim-warning")).toHaveCount(0);
+      await expect(page.getByTestId("profile-trim-warning-tooltip")).toHaveCount(
+        0,
+      );
+    }
   });
 
   test("should show input trim warning with exact overage", async ({
@@ -234,5 +257,50 @@ test.describe("Chatbot UI Tests", () => {
 
     await page.mouse.click(4, 4);
     await expect(inputTooltip).toBeHidden();
+  });
+
+  test("should send recent turns to the worker for follow-up prompts", async ({
+    page,
+  }) => {
+    await openChat(page);
+    await page
+      .getByTestId("chat-input")
+      .fill("Tell me about Justin's Defense Unicorns work.");
+    await page.getByTestId("chat-send-button").click();
+    await expect(page.getByTestId("chat-message-ai").last()).toContainText(
+      "Mock response.",
+    );
+
+    await page.getByTestId("chat-input").fill("What did he improve there?");
+    await page.getByTestId("chat-send-button").click();
+
+    const generateMessages = await page.evaluate(() => {
+      const mockWindow = window as unknown as {
+        __mockWorkerMessages: Array<{
+          action?: string;
+          input?: string;
+          conversationTurns?: Array<{
+            role: string;
+            content: string;
+          }>;
+        }>;
+      };
+      return mockWindow.__mockWorkerMessages.filter(
+        (message) => message.action === "generate",
+      );
+    });
+
+    expect(generateMessages).toHaveLength(2);
+    expect(generateMessages[1].input).toBe("What did he improve there?");
+    expect(generateMessages[1].conversationTurns).toEqual([
+      {
+        role: "user",
+        content: "Tell me about Justin's Defense Unicorns work.",
+      },
+      {
+        role: "assistant",
+        content: "Mock response.",
+      },
+    ]);
   });
 });

--- a/tests/export.spec.ts
+++ b/tests/export.spec.ts
@@ -188,7 +188,8 @@ test("should export bundled social icon assets with valid local paths", async ()
 test("should export the current browser AI worker bundle", async () => {
   const exportedJavaScript = await readExportedJavaScript();
 
-  expect(exportedJavaScript).toContain("teapotai/teapotllm");
+  expect(exportedJavaScript).toContain("justinthelaw/teapot-profile-qa-browser-1024");
+  expect(exportedJavaScript).not.toContain("teapotai/teapotllm");
   expect(exportedJavaScript).toContain("text2text-generation");
   expect(exportedJavaScript).not.toContain(
     "justinthelaw/Qwen2.5-0.5B-Instruct-Resume-Cover-Letter-SFT",

--- a/tests/export.spec.ts
+++ b/tests/export.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect } from "@playwright/test";
 import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
-import { access, readFile } from "node:fs/promises";
+import { access, readFile, readdir } from "node:fs/promises";
 import path from "node:path";
 import { DERIVED_CONFIG, SITE_CONFIG } from "../src/config/site";
 
@@ -39,6 +39,35 @@ function isBlockedRawGitHubHost(urlValue: string): boolean {
   } catch {
     return false;
   }
+}
+
+async function getJavaScriptFiles(directory: string): Promise<string[]> {
+  const entries = await readdir(directory, { withFileTypes: true });
+  const files: string[] = [];
+
+  for (const entry of entries) {
+    const entryPath = path.join(directory, entry.name);
+
+    if (entry.isDirectory()) {
+      files.push(...(await getJavaScriptFiles(entryPath)));
+    } else if (entry.isFile() && entry.name.endsWith(".js")) {
+      files.push(entryPath);
+    }
+  }
+
+  return files;
+}
+
+async function readExportedJavaScript(): Promise<string> {
+  const chunksDir = path.resolve(process.cwd(), "out", "_next", "static");
+  const files = await getJavaScriptFiles(chunksDir).catch(() => {
+    throw new Error(
+      "Missing exported JavaScript at out/_next/static. Run `npm run build` before Playwright tests.",
+    );
+  });
+  const contents = await Promise.all(files.map((filePath) => readFile(filePath, "utf8")));
+
+  return contents.join("\n");
 }
 
 interface StaticPreviewServer {
@@ -156,6 +185,17 @@ test("should export bundled social icon assets with valid local paths", async ()
   expect(hasBlockedRawGitHubSource).toBe(false);
 });
 
+test("should export the current browser AI worker bundle", async () => {
+  const exportedJavaScript = await readExportedJavaScript();
+
+  expect(exportedJavaScript).toContain("teapotai/teapotllm");
+  expect(exportedJavaScript).toContain("text2text-generation");
+  expect(exportedJavaScript).not.toContain(
+    "justinthelaw/Qwen2.5-0.5B-Instruct-Resume-Cover-Letter-SFT",
+  );
+  expect(exportedJavaScript).not.toContain("onnx-community/Qwen2.5-0.5B-Instruct");
+});
+
 test("should preview static export from the emitted base path", async () => {
   const socialIconFiles = getSocialIconFiles();
   const previewServer = await startStaticPreviewServer();
@@ -179,6 +219,47 @@ test("should preview static export from the emitted base path", async () => {
     const iconResponse = await fetch(new URL(`${basePath}/${socialIconFiles[0]}`, rootUrl));
     expect(iconResponse.status).toBe(200);
     expect(iconResponse.headers.get("content-type")).toBe("image/png");
+  } finally {
+    await previewServer.close();
+  }
+});
+
+test("should initialize the exported AI worker from the base path", async ({
+  page,
+}) => {
+  const previewServer = await startStaticPreviewServer();
+  const staticFailures: string[] = [];
+  const workerLogs: string[] = [];
+
+  page.on("response", (response) => {
+    const responseUrl = response.url();
+    if (responseUrl.includes("/_next/static/") && response.status() >= 400) {
+      staticFailures.push(`${response.status()} ${responseUrl}`);
+    }
+  });
+
+  page.on("console", (message) => {
+    const text = message.text();
+    if (text.includes("[AI WORKER]")) {
+      workerLogs.push(text);
+    }
+  });
+
+  await page.route("https://huggingface.co/**", (route) => {
+    route.abort();
+  });
+
+  try {
+    await page.goto(previewServer.origin);
+    await page.getByTestId("ai-chatbot-button").click();
+
+    await expect
+      .poll(() =>
+        workerLogs.some((line) => line.includes("[AI WORKER] initialized")),
+      )
+      .toBeTruthy();
+
+    expect(staticFailures).toEqual([]);
   } finally {
     await previewServer.close();
   }

--- a/tests/models.spec.ts
+++ b/tests/models.spec.ts
@@ -5,13 +5,15 @@ import {
   getDeviceSpecificDtype,
   getDtypeFallbackOrder,
 } from "../src/config/models";
-import { PERSONAL_CONTEXT } from "../src/config/site";
+import { PERSONAL_CONTEXT, PROFILE_SECTIONS } from "../src/config/site";
 import {
   cleanInput,
+  estimateTokenCount,
   generatePrompt,
   getPersonalContextBudget,
   getPromptBudget,
 } from "../src/services/ai/contextProvider";
+import type { ConversationTurn } from "../src/types";
 import {
   isLikelyTaskMismatchMessage,
   loadModel,
@@ -24,10 +26,6 @@ interface PipelineCall {
   task: GenerationTask;
   modelId: string;
   dtype: string;
-}
-
-function estimateTokenCount(text: string): number {
-  return Math.ceil(text.length / 4);
 }
 
 test.describe("Model dtype policy", () => {
@@ -95,25 +93,113 @@ test.describe("Model dtype policy", () => {
 });
 
 test.describe("Model prompt policy", () => {
-  test("uses Teapot as the single configured browser model", () => {
-    expect(MODEL_ID).toBe("teapotai/teapotllm");
+  test("uses the promoted profile-QA model as the single configured browser model", () => {
+    expect(MODEL_ID).toBe("justinthelaw/teapot-profile-qa-browser-1024");
+    expect(MODEL_CONTEXT_LIMIT).toBe(1024);
   });
 
-  test("keeps the personal context compact for Teapot", () => {
+  test("uses reusable resume section ids instead of person-specific ontology", () => {
+    expect(PROFILE_SECTIONS.map((section) => section.id)).toEqual([
+      "identity",
+      "current_role",
+      "experience",
+      "projects",
+      "education",
+      "recommendations",
+      "skills",
+      "interests",
+    ]);
+    const priorities = new Map(
+      PROFILE_SECTIONS.map((section) => [section.id, section.priority]),
+    );
+
+    expect(priorities.get("experience")).toBeGreaterThan(
+      priorities.get("education") ?? 0,
+    );
+    expect(priorities.get("education")).toBeGreaterThan(
+      priorities.get("recommendations") ?? 0,
+    );
+    expect(priorities.get("recommendations")).toBeGreaterThan(
+      priorities.get("interests") ?? 0,
+    );
+  });
+
+  test("keeps retrieved personal context compact for Teapot", () => {
     const prompt = generatePrompt("What are Justin's hobbies?");
     const normalizedPrompt = prompt.replace(/\s+/g, " ");
-    const personalContextWords = PERSONAL_CONTEXT.split(/\s+/).length;
     const personalContextBudget = getPersonalContextBudget();
 
-    expect(personalContextWords).toBeLessThanOrEqual(220);
-    expect(personalContextBudget.isTrimmed).toBe(false);
-    expect(personalContextBudget.overBudgetCharacters).toBe(0);
-    expect(personalContextBudget.trimmedCharacters).toBe(0);
-    expect(personalContextBudget.text).toBe(PERSONAL_CONTEXT);
+    expect(PERSONAL_CONTEXT).toContain("Current Role:");
+    expect(PROFILE_SECTIONS.length).toBeGreaterThanOrEqual(7);
+    expect(personalContextBudget.selectedProfileSectionIds).toContain(
+      "identity",
+    );
     expect(normalizedPrompt).toContain(
       "videogames, hiking, running, and cooking",
     );
     expect(estimateTokenCount(prompt)).toBeLessThanOrEqual(MODEL_CONTEXT_LIMIT);
+  });
+
+  test("retrieves relevant education sections under a tight budget", () => {
+    const budget = getPromptBudget(
+      "Where did Justin complete graduate CS studies?",
+      { contextLimit: 220 },
+    );
+
+    expect(budget.selectedProfileSectionIds).toContain("identity");
+    expect(budget.selectedProfileSectionIds).toContain("education");
+    expect(budget.selectedProfileSectionIds.length).toBeLessThan(
+      PROFILE_SECTIONS.length,
+    );
+    expect(budget.estimatedPromptTokens).toBeLessThanOrEqual(220);
+  });
+
+  test("packs recent conversation turns into a 1024-token prompt", () => {
+    const conversationTurns: ConversationTurn[] = [
+      {
+        role: "user",
+        content: "Tell me about Justin's Defense Unicorns work.",
+      },
+      {
+        role: "assistant",
+        content:
+          "Justin worked at Defense Unicorns across Kubernetes, AI/ML, and full-stack repos.",
+      },
+    ];
+    const prompt = generatePrompt("What did he improve there?", {
+      conversationTurns,
+      contextLimit: 1024,
+    });
+    const budget = getPromptBudget("What did he improve there?", {
+      conversationTurns,
+      contextLimit: 1024,
+    });
+
+    expect(prompt).toContain("Recent conversation:");
+    expect(prompt).toContain("Defense Unicorns");
+    expect(prompt).toContain("MRR 15%");
+    expect(budget.includedConversationTurns).toBe(2);
+    expect(estimateTokenCount(prompt)).toBeLessThanOrEqual(1024);
+  });
+
+  test("trims older history before exceeding the prompt budget", () => {
+    const conversationTurns: ConversationTurn[] = Array.from(
+      { length: 10 },
+      (_, index) => ({
+        role: index % 2 === 0 ? "user" : "assistant",
+        content: `history turn ${index} ${"x".repeat(220)}`,
+      }),
+    );
+    const budget = getPromptBudget("What did Justin build at OpenAI?", {
+      conversationTurns,
+      contextLimit: 260,
+    });
+
+    expect(budget.isHistoryTrimmed).toBe(true);
+    expect(budget.includedConversationTurns).toBeLessThan(
+      conversationTurns.length,
+    );
+    expect(budget.estimatedPromptTokens).toBeLessThanOrEqual(260);
   });
 
   test("warns and trims input beyond the remaining prompt budget", () => {

--- a/tests/models.spec.ts
+++ b/tests/models.spec.ts
@@ -12,6 +12,19 @@ import {
   getPersonalContextBudget,
   getPromptBudget,
 } from "../src/services/ai/contextProvider";
+import {
+  isLikelyTaskMismatchMessage,
+  loadModel,
+  type GenerationPipelineFactory,
+  type GenerationTask,
+} from "../src/services/ai/modelLoader";
+import type { Text2TextGenerationPipeline } from "@huggingface/transformers";
+
+interface PipelineCall {
+  task: GenerationTask;
+  modelId: string;
+  dtype: string;
+}
 
 function estimateTokenCount(text: string): number {
   return Math.ceil(text.length / 4);
@@ -26,6 +39,58 @@ test.describe("Model dtype policy", () => {
 
   test("does not automatically retry q4 after a q4 preference", () => {
     expect(getDtypeFallbackOrder("q4")).toEqual(["int8", "uint8"]);
+  });
+
+  test("detects incompatible live model architectures for task fallback", () => {
+    expect(
+      isLikelyTaskMismatchMessage("Unsupported model type: t5")
+    ).toBeTruthy();
+    expect(
+      isLikelyTaskMismatchMessage(
+        'Unsupported model type "t5" for task "text-generation".'
+      )
+    ).toBeTruthy();
+    expect(
+      isLikelyTaskMismatchMessage("Failed to allocate memory buffer")
+    ).toBeFalsy();
+  });
+
+  test("retries text2text generation after a task mismatch", async () => {
+    const calls: PipelineCall[] = [];
+    const fakeText2TextGenerator = {} as unknown as Text2TextGenerationPipeline;
+    const fakePipeline: GenerationPipelineFactory = async (
+      task,
+      modelId,
+      options
+    ) => {
+      calls.push({
+        task,
+        modelId,
+        dtype: typeof options.dtype === "string" ? options.dtype : "unknown",
+      });
+
+      if (task === "text-generation") {
+        throw new Error("Unsupported model type: t5");
+      }
+
+      return fakeText2TextGenerator;
+    };
+
+    const loadedPipeline = await loadModel({}, fakePipeline);
+
+    expect(loadedPipeline?.task).toBe("text2text-generation");
+    expect(calls).toEqual([
+      {
+        task: "text-generation",
+        modelId: MODEL_ID,
+        dtype: "int8",
+      },
+      {
+        task: "text2text-generation",
+        modelId: MODEL_ID,
+        dtype: "int8",
+      },
+    ]);
   });
 });
 


### PR DESCRIPTION
## Summary

- Adds a local NVIDIA profile-QA LoRA/QLoRA pipeline under `ml/profile-qa/` for synthetic public-profile data generation, validation, training, eval, ONNX export, HF artifact prep, and publishing.
- Promotes the browser app to the published `justinthelaw/teapot-profile-qa-browser-1024` model with a 1024-token context budget.
- Reworks profile context into reusable resume-style sections with retrieval and recent-turn packing for browser-only inference.
- Keeps generated datasets, checkpoints, merged models, HF staging, reports, and ONNX artifacts ignored from git.

## Notes

The Hugging Face model repo was corrected to use official HF metadata while keeping Transformers.js runtime loading on `text2text-generation`. The browser ONNX layout now uses `decoder_model_merged_{int8,uint8}.onnx` with subgraph-enabled quantization so Chromium and Mobile Chrome can load the model without worker crashes.

## Validation

- `npm run flight-check` -> 137 passed, 3 skipped
- `PYTHONPATH=ml/profile-qa ml/profile-qa/.venv/bin/python -m pytest ml/profile-qa/tests` -> 11 passed
- Real browser smoke against the published HF model passed in desktop Chromium and Mobile Chrome
- Remote HF model files verified for `encoder_model_{int8,uint8}.onnx` and `decoder_model_merged_{int8,uint8}.onnx`