### PR TITLE
[codex] stabilize loading UX

### DIFF
--- a/src/components/chat/components/ChatMessages.tsx
+++ b/src/components/chat/components/ChatMessages.tsx
@@ -53,9 +53,15 @@ export function ChatMessages({
       {(isLoading || loadingMessage) &&
       !loadingMessage?.includes("Generating") ? (
         <div className="flex flex-col items-center gap-3 py-8">
-          <div className="flex items-center gap-2">
-            <div className="w-6 h-6 border-4 border-blue-200 border-t-blue-500 rounded-full animate-spin" />
-            <p className="text-gray-300">{loadingMessage || "Loading..."}</p>
+          <div className="grid grid-cols-[1.5rem_14rem_1.5rem] items-center gap-2 sm:grid-cols-[1.5rem_16rem_1.5rem]">
+            <div className="h-6 w-6 shrink-0 rounded-full border-4 border-blue-200 border-t-blue-500 animate-spin" />
+            <p
+              className="break-words text-center text-gray-300 tabular-nums"
+              data-testid="model-loading-status"
+            >
+              {loadingMessage || "Loading..."}
+            </p>
+            <span className="h-6 w-6" aria-hidden="true" />
           </div>
           {loadingMessage && loadingMessage.trim().toLowerCase().includes("error") && (
             <div className="mt-3 flex flex-col items-center gap-2">

--- a/src/components/resume/ResumeViewer.tsx
+++ b/src/components/resume/ResumeViewer.tsx
@@ -9,12 +9,8 @@ import React, { useEffect, useState, useRef, useCallback } from "react";
 import { SITE_CONFIG } from "@/config/site";
 import { createLogger, LOG_AREAS } from "@/utils";
 
-// Use Google Drive's direct download URL which works better for public PDFs
-const PDF_DOWNLOAD_URL = `https://drive.google.com/uc?export=download&id=${SITE_CONFIG.resumeFileId}`;
-// Use Google Docs Viewer as it handles authentication better
-const PDF_VIEWER_URL = `https://docs.google.com/viewer?url=${encodeURIComponent(
-  PDF_DOWNLOAD_URL
-)}&embedded=true`;
+const PDF_PREVIEW_URL = `https://drive.google.com/file/d/${SITE_CONFIG.resumeFileId}/preview`;
+const PDF_OPEN_URL = `https://drive.google.com/file/d/${SITE_CONFIG.resumeFileId}/view?usp=sharing`;
 const LOADING_TIMEOUT_MS = 15000; // Increased to 15s
 const MAX_RETRIES = 2;
 const logger = createLogger(LOG_AREAS.RESUME);
@@ -122,7 +118,7 @@ export function ResumeViewer(): React.ReactElement {
                   Try Again
                 </button>
                 <a
-                  href={`https://drive.google.com/file/d/${SITE_CONFIG.resumeFileId}/view?usp=sharing`}
+                  href={PDF_OPEN_URL}
                   target="_blank"
                   rel="noopener noreferrer"
                   className="px-4 py-2 border border-blue-600 text-blue-600 rounded hover:bg-blue-50 transition-colors text-sm"
@@ -135,7 +131,7 @@ export function ResumeViewer(): React.ReactElement {
         ) : (
           <iframe
             key={key}
-            src={PDF_VIEWER_URL}
+            src={PDF_PREVIEW_URL}
             title="Resume PDF"
             className="w-full h-full"
             onLoad={handleIframeLoad}

--- a/src/services/ai/modelLoader.ts
+++ b/src/services/ai/modelLoader.ts
@@ -52,12 +52,20 @@ export interface LoaderCallbacks {
   onProgress?: (progress: number, message: string) => void;
 }
 
+interface TransformerProgressData {
+  progress?: number;
+  status?: string;
+}
+
 interface NormalizedLoadError {
   message: string;
   isLikelyMemoryError: boolean;
   isNumericRuntimeCode: boolean;
   isLikelyTaskMismatch: boolean;
 }
+
+const DOWNLOAD_COMPLETE_PROGRESS = 100;
+const MEMORY_LOADING_MESSAGE = "Loading into memory...";
 
 function safeJsonStringify(value: unknown): string {
   try {
@@ -152,6 +160,10 @@ export function isLikelyTaskMismatchMessage(message: string): boolean {
   );
 }
 
+function normalizeProgress(progress: number): number {
+  return Math.min(DOWNLOAD_COMPLETE_PROGRESS, Math.max(0, Math.round(progress)));
+}
+
 async function createGenerationPipeline(
   task: GenerationTask,
   modelId: string,
@@ -186,7 +198,53 @@ export async function loadModel(
 
   for (const dtype of dtypeFallbackOrder) {
     attempts++;
-    let isDownloading = true;
+    let hasAggregateProgress = false;
+    let hasReportedMemoryLoad = false;
+    let lastDownloadProgress = 0;
+    let lastReportedProgress = -1;
+    let lastReportedMessage: string | null = null;
+
+    const reportProgress = (progress: number, message: string): void => {
+      if (!callbacks.onProgress) {
+        return;
+      }
+
+      if (
+        progress === lastReportedProgress &&
+        message === lastReportedMessage
+      ) {
+        return;
+      }
+
+      lastReportedProgress = progress;
+      lastReportedMessage = message;
+      callbacks.onProgress(progress, message);
+    };
+
+    const reportMemoryLoad = (): void => {
+      if (hasReportedMemoryLoad) {
+        return;
+      }
+
+      hasReportedMemoryLoad = true;
+      lastDownloadProgress = DOWNLOAD_COMPLETE_PROGRESS;
+      reportProgress(DOWNLOAD_COMPLETE_PROGRESS, MEMORY_LOADING_MESSAGE);
+    };
+
+    const reportDownloadProgress = (rawProgress: number): void => {
+      const progress = Math.max(
+        lastDownloadProgress,
+        normalizeProgress(rawProgress)
+      );
+      lastDownloadProgress = progress;
+
+      if (progress >= DOWNLOAD_COMPLETE_PROGRESS) {
+        reportMemoryLoad();
+        return;
+      }
+
+      reportProgress(progress, `Downloading model... ${progress}%`);
+    };
 
     const pipelineOptions: Record<string, unknown> = {
       dtype,
@@ -196,31 +254,40 @@ export async function loadModel(
           return;
         }
 
-        const data = progressData as {
-          progress?: number;
-          status?: string;
-        };
+        const data = progressData as TransformerProgressData;
 
-        if (data.progress === undefined || !callbacks.onProgress) {
+        if (!callbacks.onProgress) {
           return;
         }
 
-        const progress = Math.round(data.progress);
-        let message: string;
-
-        if (data.status === "progress") {
-          message = `Downloading model... ${progress}%`;
-          isDownloading = true;
-        } else if (data.status === "done" || progress === 100) {
-          message = `Loading into memory... ${progress}%`;
-          isDownloading = false;
-        } else {
-          message = isDownloading
-            ? `Downloading model... ${progress}%`
-            : `Loading into memory... ${progress}%`;
+        if (data.status === "ready") {
+          reportMemoryLoad();
+          return;
         }
 
-        callbacks.onProgress(progress, message);
+        if (data.status === "done") {
+          if (lastDownloadProgress >= DOWNLOAD_COMPLETE_PROGRESS) {
+            reportMemoryLoad();
+          }
+          return;
+        }
+
+        if (
+          typeof data.progress !== "number" ||
+          !Number.isFinite(data.progress)
+        ) {
+          return;
+        }
+
+        if (data.status === "progress_total") {
+          hasAggregateProgress = true;
+          reportDownloadProgress(data.progress);
+          return;
+        }
+
+        if (data.status === "progress" && !hasAggregateProgress) {
+          reportDownloadProgress(data.progress);
+        }
       },
     };
 

--- a/tests/export.spec.ts
+++ b/tests/export.spec.ts
@@ -197,6 +197,24 @@ test("should export the current browser AI worker bundle", async () => {
   expect(exportedJavaScript).not.toContain("onnx-community/Qwen2.5-0.5B-Instruct");
 });
 
+test("should embed the resume with Drive preview instead of a download viewer", async () => {
+  const outputDir = path.resolve(process.cwd(), "out");
+  const exportIndexPath = path.join(outputDir, "index.html");
+  const exportHtml = await readFile(exportIndexPath, "utf8").catch(() => {
+    throw new Error(
+      "Missing exported index HTML at out/index.html. Run `npm run build` before Playwright tests.",
+    );
+  });
+  const exportedJavaScript = await readExportedJavaScript();
+  const exportedAssets = `${exportHtml}\n${exportedJavaScript}`;
+
+  expect(exportHtml).toContain(
+    `src="https://drive.google.com/file/d/${SITE_CONFIG.resumeFileId}/preview"`,
+  );
+  expect(exportedAssets).not.toContain("docs.google.com/viewer");
+  expect(exportedAssets).not.toContain("uc?export=download");
+});
+
 test("should preview static export from the emitted base path", async () => {
   const socialIconFiles = getSocialIconFiles();
   const previewServer = await startStaticPreviewServer();

--- a/tests/models.spec.ts
+++ b/tests/models.spec.ts
@@ -20,12 +20,20 @@ import {
   type GenerationPipelineFactory,
   type GenerationTask,
 } from "../src/services/ai/modelLoader";
-import type { Text2TextGenerationPipeline } from "@huggingface/transformers";
+import type {
+  Text2TextGenerationPipeline,
+  TextGenerationPipeline,
+} from "@huggingface/transformers";
 
 interface PipelineCall {
   task: GenerationTask;
   modelId: string;
   dtype: string;
+}
+
+interface ProgressUpdate {
+  progress: number;
+  message: string;
 }
 
 test.describe("Model dtype policy", () => {
@@ -88,6 +96,47 @@ test.describe("Model dtype policy", () => {
         modelId: MODEL_ID,
         dtype: "int8",
       },
+    ]);
+  });
+
+  test("reports aggregate download progress before the memory loading phase", async () => {
+    const progressUpdates: ProgressUpdate[] = [];
+    const fakeTextGenerator = {} as unknown as TextGenerationPipeline;
+    const fakePipeline: GenerationPipelineFactory = async (
+      _task,
+      _modelId,
+      options
+    ) => {
+      const progressCallback = options.progress_callback;
+
+      if (typeof progressCallback !== "function") {
+        throw new Error("Missing progress callback");
+      }
+
+      const emitProgress = progressCallback as (progressData: unknown) => void;
+      emitProgress({ status: "progress_total", progress: 33.2 });
+      emitProgress({ status: "progress", progress: 99.8 });
+      emitProgress({ status: "progress_total", progress: 35.4 });
+      emitProgress({ status: "progress_total", progress: 34.1 });
+      emitProgress({ status: "progress_total", progress: 100 });
+      emitProgress({ status: "done" });
+
+      return fakeTextGenerator;
+    };
+
+    await loadModel(
+      {
+        onProgress: (progress, message) => {
+          progressUpdates.push({ progress, message });
+        },
+      },
+      fakePipeline
+    );
+
+    expect(progressUpdates).toEqual([
+      { progress: 33, message: "Downloading model... 33%" },
+      { progress: 35, message: "Downloading model... 35%" },
+      { progress: 100, message: "Loading into memory..." },
     ]);
   });
 });


### PR DESCRIPTION
## What changed
- Stabilized the model download status row so progress updates no longer re-center the spinner/text block.
- Switched the resume iframe from Google Docs Viewer plus download URL to the Drive preview embed.
- Added regression coverage for aggregate model progress and the exported resume iframe URL.

## Why
- The loading percent updates were causing visible jitter during model download.
- The previous resume embed path could surface a confusing `viewer` download behavior.

## Validation
- `npm run flight-check`
