### PR TITLE
[codex] add llm visualizer and harden teapot pipeline

### DIFF
--- a/docs/DIAGRAMS.md
+++ b/docs/DIAGRAMS.md
@@ -15,6 +15,7 @@ fit together.
 | Browser model and context limit | `src/config/models.ts` | Default is `int8` with `uint8` fallback |
 | Prompt retrieval and budget trimming | `src/services/ai/contextProvider.ts` | Ranks profile sections and fits prompt/history into budget |
 | Worker inference | `src/services/ai/worker.ts` | Runs Transformers.js off the main thread |
+| LLM Visualizer | `src/components/profile/ProfileVisualizerModal.tsx` | Lazy client-only Three.js modal for the browser AI architecture trace |
 | Local training defaults | `ml/profile-qa/profile_qa/config.py` | Holds model IDs, 1024-token budget, and LoRA defaults |
 | Pipeline commands | `ml/profile-qa/README.md` | Command-level training, eval, export, and publish guide |
 
@@ -29,9 +30,13 @@ flowchart TD
   page --> resume["ResumeViewer"]
   resume --> drive["Google Drive PDF preview"]
   page --> chat["ChatContainer, client only"]
+  page --> visualizer["LLM Visualizer modal, client only"]
   chat --> chatHooks["Chat hooks"]
   chatHooks --> chatStore["Zustand chat store"]
   chatHooks --> aiService["AIService"]
+  visualizer --> three["Three.js architecture scene"]
+  visualizer --> trace["Local trace controller"]
+  trace --> aiService
   aiService --> worker["Web Worker"]
   worker --> loader["modelLoader.ts"]
   loader --> hf["Hugging Face model files"]
@@ -122,9 +127,9 @@ does not train models and does not call a server.
 | --- | --- | --- |
 | Facts | `src/config/site.ts` and `ml/profile-qa/profile_qa/public_profile.py` | Keep public facts aligned before generating data |
 | Dataset | `python -m profile_qa.synthetic_data` | Generated data stays under ignored `ml/profile-qa/data/` |
-| Training | `ml/profile-qa/profile_qa/config.py` or CLI flags | Defaults target local 8GB NVIDIA LoRA/QLoRA runs |
-| Evaluation | `python -m profile_qa.evaluate` | Compare validation/test reports before promotion |
-| ONNX export | `python -m profile_qa.export_onnx` | Reject `.onnx.data`; publish `int8` and `uint8` |
+| Training | `ml/profile-qa/profile_qa/config.py` or CLI flags | Fixed `teapotai/teapotllm` base; local 8GB NVIDIA LoRA/QLoRA runs |
+| Evaluation | `python -m profile_qa.evaluate` | Seq2seq only; adapters must record `teapotai/teapotllm` as their base |
+| ONNX export | `python -m profile_qa.export_onnx` | Requires the merged Teapot lineage marker; rejects `.onnx.data`; publishes `int8` and `uint8` encoder/decoder artifacts |
 | App promotion | `src/config/models.ts` | Update `MODEL_ID` and keep `MODEL_CONTEXT_LIMIT` honest |
 
 Promotion should satisfy the gate in `ml/profile-qa/README.md` before changing

--- a/ml/profile-qa/README.md
+++ b/ml/profile-qa/README.md
@@ -41,11 +41,17 @@ python -m profile_qa.synthetic_data --output ml/profile-qa/data/profile_qa.jsonl
 python -m profile_qa.train_lora --dataset ml/profile-qa/data/profile_qa.jsonl
 python -m profile_qa.evaluate --dataset ml/profile-qa/data/profile_qa.jsonl --model-id teapotai/teapotllm
 python -m profile_qa.merge_adapter --adapter-model-id ml/profile-qa/checkpoints/teapot-profile-qa-lora/checkpoint-400 --output-dir ml/profile-qa/merged/teapot-profile-qa
-python -m profile_qa.export_onnx --model ml/profile-qa/merged/teapot-profile-qa --output-dir ml/profile-qa/onnx/candidate
+python -m profile_qa.export_onnx --output-dir ml/profile-qa/onnx/candidate
 python -m profile_qa.prepare_hf_artifacts --model-browser-dir ml/profile-qa/onnx/candidate/browser
 python -m profile_qa.publish --repo-id justinthelaw/teapot-profile-qa-browser-1024 --artifact-dir ml/profile-qa/hf/model
 python -m profile_qa.publish --repo-type dataset --repo-id justinthelaw/profile-qa-synthetic-public-v1 --artifact-dir ml/profile-qa/hf/dataset
 ```
+
+The training, continuation, merge, and export commands are Teapot-only. Training
+always starts from `teapotai/teapotllm`; adapter continuation and merge reject
+checkpoints whose PEFT metadata records a different base model; export expects
+the merged model directory produced by `profile_qa.merge_adapter` and publishes
+the encoder plus merged decoder ONNX files for the T5 browser runtime.
 
 For targeted continuation from an existing LoRA adapter:
 
@@ -59,12 +65,10 @@ python -m profile_qa.train_lora \
   --lr-scheduler-type constant_with_warmup
 ```
 
-If Teapot cannot pass the 1024-token promotion gate, keep the same pipeline and
-rerun training with:
-
-```bash
-python -m profile_qa.train_lora --model-id Qwen/Qwen2.5-0.5B-Instruct
-```
+If Teapot cannot pass the 1024-token promotion gate, keep the lineage on
+`teapotai/teapotllm` and fix the Teapot path directly: improve the public-profile
+dataset, adjust LoRA hyperparameters, continue from a stronger adapter checkpoint,
+or repair export/browser packaging issues. Do not switch base models.
 
 ## Promotion Gate
 

--- a/ml/profile-qa/profile_qa/config.py
+++ b/ml/profile-qa/profile_qa/config.py
@@ -9,7 +9,6 @@ PACKAGE_ROOT = Path(__file__).resolve().parents[1]
 
 MODEL_CONTEXT_LIMIT = 1024
 PRIMARY_BASE_MODEL_ID = "teapotai/teapotllm"
-FALLBACK_BASE_MODEL_ID = "Qwen/Qwen2.5-0.5B-Instruct"
 DATASET_VERSION = "public-profile-v1"
 
 DATA_DIR = PACKAGE_ROOT / "data"

--- a/ml/profile-qa/profile_qa/evaluate.py
+++ b/ml/profile-qa/profile_qa/evaluate.py
@@ -8,8 +8,17 @@ from collections import defaultdict
 from pathlib import Path
 from typing import Any
 
-from .config import DEFAULT_DATASET_PATH, DEFAULT_EVAL_REPORT_PATH, MODEL_CONTEXT_LIMIT
-from .train_lora import format_instruction
+from .config import (
+    DEFAULT_DATASET_PATH,
+    DEFAULT_EVAL_REPORT_PATH,
+    MODEL_CONTEXT_LIMIT,
+    PRIMARY_BASE_MODEL_ID,
+)
+from .train_lora import (
+    ensure_primary_base_model_id,
+    ensure_teapot_seq2seq_config,
+    format_instruction,
+)
 from .validation import read_jsonl
 
 
@@ -68,7 +77,6 @@ def _load_generation_stack() -> dict[str, Any]:
         from peft import PeftModel
         from transformers import (
             AutoConfig,
-            AutoModelForCausalLM,
             AutoModelForSeq2SeqLM,
             AutoTokenizer,
         )
@@ -77,7 +85,6 @@ def _load_generation_stack() -> dict[str, Any]:
     return {
         "torch": torch,
         "AutoConfig": AutoConfig,
-        "AutoModelForCausalLM": AutoModelForCausalLM,
         "AutoModelForSeq2SeqLM": AutoModelForSeq2SeqLM,
         "AutoTokenizer": AutoTokenizer,
         "PeftModel": PeftModel,
@@ -93,6 +100,22 @@ def _adapter_base_model_id(model_id: str) -> str | None:
     return str(base_model_id) if isinstance(base_model_id, str) else None
 
 
+def _ensure_generation_lineage(model_id: str, adapter_base_model_id: str | None, config: Any) -> None:
+    if adapter_base_model_id:
+        ensure_primary_base_model_id(adapter_base_model_id, source=f"{model_id} adapter base")
+        return
+
+    if model_id.rstrip("/") == PRIMARY_BASE_MODEL_ID:
+        ensure_primary_base_model_id(model_id, source="evaluation model")
+        return
+
+    config_source = str(getattr(config, "_name_or_path", ""))
+    ensure_primary_base_model_id(
+        config_source,
+        source=f"{model_id} config _name_or_path",
+    )
+
+
 def generate_predictions(model_id: str, records: list[dict[str, Any]]) -> dict[str, str]:
     """Generate answers locally for a model or adapter directory."""
 
@@ -100,14 +123,12 @@ def generate_predictions(model_id: str, records: list[dict[str, Any]]) -> dict[s
     adapter_base_model_id = _adapter_base_model_id(model_id)
     config_model_id = adapter_base_model_id or model_id
     config = stack["AutoConfig"].from_pretrained(config_model_id, trust_remote_code=True)
+    _ensure_generation_lineage(model_id, adapter_base_model_id, config)
+    ensure_teapot_seq2seq_config(config, config_model_id)
     tokenizer = stack["AutoTokenizer"].from_pretrained(model_id, trust_remote_code=True)
     if tokenizer.pad_token is None and tokenizer.eos_token is not None:
         tokenizer.pad_token = tokenizer.eos_token
-    is_encoder_decoder = bool(getattr(config, "is_encoder_decoder", False))
-    model_cls = (
-        stack["AutoModelForSeq2SeqLM"] if is_encoder_decoder else stack["AutoModelForCausalLM"]
-    )
-    model = model_cls.from_pretrained(
+    model = stack["AutoModelForSeq2SeqLM"].from_pretrained(
         config_model_id,
         device_map="auto",
         torch_dtype=stack["torch"].float16,
@@ -133,11 +154,7 @@ def generate_predictions(model_id: str, records: list[dict[str, Any]]) -> dict[s
                 max_new_tokens=160,
                 do_sample=False,
             )
-        if is_encoder_decoder:
-            generated_ids = output_ids[0]
-        else:
-            prompt_length = int(inputs["input_ids"].shape[-1])
-            generated_ids = output_ids[0][prompt_length:]
+        generated_ids = output_ids[0]
         generated = tokenizer.decode(generated_ids, skip_special_tokens=True)
         predictions[str(record["id"])] = str(generated).strip()
     return predictions

--- a/ml/profile-qa/profile_qa/export_onnx.py
+++ b/ml/profile-qa/profile_qa/export_onnx.py
@@ -3,12 +3,17 @@
 from __future__ import annotations
 
 import argparse
+import json
 import shutil
 import subprocess
 import sys
 from pathlib import Path
 
-from .config import ONNX_DIR
+from .config import MERGED_DIR, ONNX_DIR
+from .merge_adapter import LINEAGE_FILENAME
+from .train_lora import ensure_primary_base_model_id
+
+TEAPOT_EXPORT_TASK = "text2text-generation-with-past"
 
 
 def reject_external_data_files(output_dir: Path) -> None:
@@ -31,8 +36,25 @@ def venv_tool(name: str) -> str:
     return str(tool_path) if tool_path.exists() else name
 
 
-def export_onnx(model: str, output_dir: Path, task: str) -> None:
+def ensure_teapot_export_model(model: str) -> None:
+    """Require a merged model directory produced by the Teapot adapter merge step."""
+
+    lineage_path = Path(model) / LINEAGE_FILENAME
+    if not lineage_path.exists():
+        raise RuntimeError(
+            "ONNX export is TeapotLLM-only; pass a merged model directory produced by "
+            f"profile_qa.merge_adapter with {LINEAGE_FILENAME}"
+        )
+    lineage = json.loads(lineage_path.read_text(encoding="utf-8"))
+    base_model = lineage.get("base_model")
+    if not isinstance(base_model, str):
+        raise RuntimeError(f"{lineage_path} does not record a base_model")
+    ensure_primary_base_model_id(base_model, source=f"{lineage_path} base_model")
+
+
+def export_onnx(model: str, output_dir: Path) -> None:
     output_dir.mkdir(parents=True, exist_ok=True)
+    ensure_teapot_export_model(model)
     run_command(
         [
             venv_tool("optimum-cli"),
@@ -41,7 +63,7 @@ def export_onnx(model: str, output_dir: Path, task: str) -> None:
             "--model",
             model,
             "--task",
-            task,
+            TEAPOT_EXPORT_TASK,
             str(output_dir),
         ]
     )
@@ -77,13 +99,17 @@ def get_browser_model_paths(quantized_dir: Path) -> list[Path]:
 
     encoder_path = quantized_dir / "encoder_model.onnx"
     merged_decoder_path = quantized_dir / "decoder_model_merged.onnx"
-    decoder_only_path = quantized_dir / "model.onnx"
 
     if encoder_path.exists() and merged_decoder_path.exists():
         return [encoder_path, merged_decoder_path]
-    if decoder_only_path.exists():
-        return [decoder_only_path]
-    return sorted(quantized_dir.glob("*.onnx"))
+
+    missing_paths = [
+        str(path) for path in (encoder_path, merged_decoder_path) if not path.exists()
+    ]
+    raise RuntimeError(
+        "Teapot/T5 browser export requires encoder and merged decoder ONNX files; "
+        f"missing: {', '.join(missing_paths)}"
+    )
 
 
 def assemble_browser_artifact(fp_dir: Path, quantized_dirs: dict[str, Path], output_dir: Path) -> None:
@@ -102,8 +128,6 @@ def assemble_browser_artifact(fp_dir: Path, quantized_dirs: dict[str, Path], out
     for dtype, quantized_dir in quantized_dirs.items():
         suffix = f"_{dtype}"
         model_paths = get_browser_model_paths(quantized_dir)
-        if not model_paths:
-            raise RuntimeError(f"no quantized ONNX files found in {quantized_dir}")
         for model_path in model_paths:
             shutil.copy2(model_path, onnx_dir / f"{model_path.stem}{suffix}.onnx")
 
@@ -112,9 +136,8 @@ def assemble_browser_artifact(fp_dir: Path, quantized_dirs: dict[str, Path], out
 
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--model", required=True)
+    parser.add_argument("--model", default=str(MERGED_DIR / "teapot-profile-qa"))
     parser.add_argument("--output-dir", default=str(ONNX_DIR / "candidate"))
-    parser.add_argument("--task", default="text2text-generation-with-past")
     parser.add_argument("--skip-export", action="store_true")
     parser.add_argument("--skip-quantize", action="store_true")
     args = parser.parse_args()
@@ -124,7 +147,7 @@ def main() -> int:
     if args.skip_export:
         reject_external_data_files(fp_dir)
     else:
-        export_onnx(args.model, fp_dir, args.task)
+        export_onnx(args.model, fp_dir)
 
     quantized_dirs = {
         "int8": output_dir / "int8",

--- a/ml/profile-qa/profile_qa/merge_adapter.py
+++ b/ml/profile-qa/profile_qa/merge_adapter.py
@@ -3,21 +3,24 @@
 from __future__ import annotations
 
 import argparse
+import json
 from pathlib import Path
 
 from .config import MERGED_DIR, PRIMARY_BASE_MODEL_ID
+from .train_lora import ensure_primary_base_model_id
+
+LINEAGE_FILENAME = "teapot_profile_qa_lineage.json"
 
 
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--adapter-model-id", required=True)
-    parser.add_argument("--base-model-id", default=PRIMARY_BASE_MODEL_ID)
     parser.add_argument("--output-dir", default=str(MERGED_DIR / "teapot-profile-qa"))
     args = parser.parse_args()
 
     try:
         import torch
-        from peft import PeftModel
+        from peft import PeftConfig, PeftModel
         from transformers import AutoModelForSeq2SeqLM, AutoTokenizer
     except ImportError as exc:
         raise RuntimeError("Install merge dependencies with pip install -r ml/profile-qa/requirements.txt") from exc
@@ -25,9 +28,16 @@ def main() -> int:
     output_dir = Path(args.output_dir)
     output_dir.mkdir(parents=True, exist_ok=True)
 
+    adapter_config = PeftConfig.from_pretrained(args.adapter_model_id)
+    adapter_base_model_id = str(getattr(adapter_config, "base_model_name_or_path", ""))
+    ensure_primary_base_model_id(
+        adapter_base_model_id,
+        source=f"{args.adapter_model_id} adapter base",
+    )
+
     tokenizer = AutoTokenizer.from_pretrained(args.adapter_model_id, trust_remote_code=True)
     base_model = AutoModelForSeq2SeqLM.from_pretrained(
-        args.base_model_id,
+        PRIMARY_BASE_MODEL_ID,
         torch_dtype=torch.float16,
         device_map="auto",
         trust_remote_code=True,
@@ -37,6 +47,18 @@ def main() -> int:
 
     merged_model.save_pretrained(output_dir, safe_serialization=True)
     tokenizer.save_pretrained(output_dir)
+    (output_dir / LINEAGE_FILENAME).write_text(
+        json.dumps(
+            {
+                "adapter_model_id": args.adapter_model_id,
+                "base_model": PRIMARY_BASE_MODEL_ID,
+                "pipeline": "profile-qa-teapot-lora",
+            },
+            indent=2,
+            sort_keys=True,
+        ),
+        encoding="utf-8",
+    )
     print(f"merged adapter {args.adapter_model_id} into {output_dir}")
     return 0
 

--- a/ml/profile-qa/profile_qa/train_lora.py
+++ b/ml/profile-qa/profile_qa/train_lora.py
@@ -11,7 +11,6 @@ from .config import (
     DEFAULT_TRAIN_OUTPUT_DIR,
     EVAL_STEPS,
     EVAL_BATCH_SIZE,
-    FALLBACK_BASE_MODEL_ID,
     GRADIENT_ACCUMULATION_STEPS,
     LEARNING_RATE,
     LORA_ALPHA,
@@ -28,6 +27,22 @@ from .config import (
 from .gpu_health import assert_gpu_ready
 from .synthetic_data import profile_context_text
 from .validation import read_jsonl
+
+TEAPOT_MODEL_TYPE = "t5"
+TEAPOT_LORA_TARGET_MODULES = ["q", "v"]
+
+
+def ensure_primary_base_model_id(model_id: str, *, source: str) -> None:
+    """Reject alternate base models; this pipeline continues only TeapotLLM."""
+
+    normalized_model_id = model_id.rstrip("/")
+    if normalized_model_id == PRIMARY_BASE_MODEL_ID:
+        return
+
+    raise RuntimeError(
+        f"profile-QA is TeapotLLM-only; {source} must use {PRIMARY_BASE_MODEL_ID}, "
+        f"got {model_id}"
+    )
 
 
 def _missing_dependency(name: str, install_hint: str) -> RuntimeError:
@@ -67,20 +82,22 @@ def _load_training_stack() -> dict[str, Any]:
 
     try:
         from datasets import Dataset
-        from peft import LoraConfig, PeftModel, get_peft_model, prepare_model_for_kbit_training
+        from peft import (
+            LoraConfig,
+            PeftConfig,
+            PeftModel,
+            get_peft_model,
+            prepare_model_for_kbit_training,
+        )
         from transformers import (
             AutoConfig,
-            AutoModelForCausalLM,
             AutoModelForSeq2SeqLM,
             AutoTokenizer,
             BitsAndBytesConfig,
-            DataCollatorForLanguageModeling,
             DataCollatorForSeq2Seq,
             EarlyStoppingCallback,
             Seq2SeqTrainer,
             Seq2SeqTrainingArguments,
-            Trainer,
-            TrainingArguments,
         )
     except ImportError as exc:
         raise _missing_dependency(
@@ -92,28 +109,34 @@ def _load_training_stack() -> dict[str, Any]:
         "torch": torch,
         "Dataset": Dataset,
         "LoraConfig": LoraConfig,
+        "PeftConfig": PeftConfig,
         "PeftModel": PeftModel,
         "get_peft_model": get_peft_model,
         "prepare_model_for_kbit_training": prepare_model_for_kbit_training,
         "AutoConfig": AutoConfig,
-        "AutoModelForCausalLM": AutoModelForCausalLM,
         "AutoModelForSeq2SeqLM": AutoModelForSeq2SeqLM,
         "AutoTokenizer": AutoTokenizer,
         "BitsAndBytesConfig": BitsAndBytesConfig,
-        "DataCollatorForLanguageModeling": DataCollatorForLanguageModeling,
         "DataCollatorForSeq2Seq": DataCollatorForSeq2Seq,
         "EarlyStoppingCallback": EarlyStoppingCallback,
         "Seq2SeqTrainer": Seq2SeqTrainer,
         "Seq2SeqTrainingArguments": Seq2SeqTrainingArguments,
-        "Trainer": Trainer,
-        "TrainingArguments": TrainingArguments,
     }
 
 
-def _target_modules(is_encoder_decoder: bool) -> list[str]:
-    if is_encoder_decoder:
-        return ["q", "v"]
-    return ["q_proj", "k_proj", "v_proj", "o_proj", "gate_proj", "up_proj", "down_proj"]
+def ensure_teapot_seq2seq_config(config: Any, model_id: str) -> None:
+    """Reject non-Teapot/T5 configs before training or evaluation."""
+
+    model_type = str(getattr(config, "model_type", "")).lower()
+    is_encoder_decoder = bool(getattr(config, "is_encoder_decoder", False))
+    if is_encoder_decoder and model_type == TEAPOT_MODEL_TYPE:
+        return
+
+    raise RuntimeError(
+        "profile-QA is TeapotLLM-only; expected a T5 encoder-decoder config "
+        f"from {PRIMARY_BASE_MODEL_ID}, got model_type={model_type or 'unknown'} "
+        f"and is_encoder_decoder={is_encoder_decoder} for {model_id}"
+    )
 
 
 def run_training(args: argparse.Namespace) -> None:
@@ -129,9 +152,9 @@ def run_training(args: argparse.Namespace) -> None:
     if not eval_records:
         raise RuntimeError("dataset has no validation records")
 
-    model_id = args.model_id
+    model_id = PRIMARY_BASE_MODEL_ID
     config = stack["AutoConfig"].from_pretrained(model_id, trust_remote_code=True)
-    is_encoder_decoder = bool(getattr(config, "is_encoder_decoder", False))
+    ensure_teapot_seq2seq_config(config, model_id)
     tokenizer = stack["AutoTokenizer"].from_pretrained(model_id, trust_remote_code=True)
     if tokenizer.pad_token is None and tokenizer.eos_token is not None:
         tokenizer.pad_token = tokenizer.eos_token
@@ -145,10 +168,7 @@ def run_training(args: argparse.Namespace) -> None:
         bnb_4bit_use_double_quant=True,
     )
 
-    model_cls = (
-        stack["AutoModelForSeq2SeqLM"] if is_encoder_decoder else stack["AutoModelForCausalLM"]
-    )
-    model = model_cls.from_pretrained(
+    model = stack["AutoModelForSeq2SeqLM"].from_pretrained(
         model_id,
         device_map="auto",
         quantization_config=quantization_config,
@@ -157,6 +177,12 @@ def run_training(args: argparse.Namespace) -> None:
     model.gradient_checkpointing_enable()
     model = stack["prepare_model_for_kbit_training"](model)
     if args.adapter_model_id:
+        adapter_config = stack["PeftConfig"].from_pretrained(args.adapter_model_id)
+        adapter_base_model_id = str(getattr(adapter_config, "base_model_name_or_path", ""))
+        ensure_primary_base_model_id(
+            adapter_base_model_id,
+            source=f"{args.adapter_model_id} adapter base",
+        )
         model = stack["PeftModel"].from_pretrained(
             model,
             args.adapter_model_id,
@@ -168,8 +194,8 @@ def run_training(args: argparse.Namespace) -> None:
             lora_alpha=args.lora_alpha,
             lora_dropout=args.lora_dropout,
             bias="none",
-            task_type="SEQ_2_SEQ_LM" if is_encoder_decoder else "CAUSAL_LM",
-            target_modules=_target_modules(is_encoder_decoder),
+            task_type="SEQ_2_SEQ_LM",
+            target_modules=TEAPOT_LORA_TARGET_MODULES,
         )
         model = stack["get_peft_model"](model, lora_config)
 
@@ -177,128 +203,72 @@ def run_training(args: argparse.Namespace) -> None:
     train_dataset = dataset_cls.from_list(train_records)
     eval_dataset = dataset_cls.from_list(eval_records)
 
-    if is_encoder_decoder:
-        def tokenize_seq2seq(batch: dict[str, list[Any]]) -> dict[str, Any]:
-            prompts = [format_instruction(record) for record in _batch_records(batch)]
-            answers = [str(answer) for answer in batch["answer"]]
-            model_inputs = tokenizer(
-                prompts,
-                max_length=MODEL_CONTEXT_LIMIT,
-                truncation=True,
-                padding=False,
-            )
-            labels = tokenizer(
-                text_target=answers,
-                max_length=160,
-                truncation=True,
-                padding=False,
-            )
-            model_inputs["labels"] = labels["input_ids"]
-            return model_inputs
+    def tokenize_seq2seq(batch: dict[str, list[Any]]) -> dict[str, Any]:
+        prompts = [format_instruction(record) for record in _batch_records(batch)]
+        answers = [str(answer) for answer in batch["answer"]]
+        model_inputs = tokenizer(
+            prompts,
+            max_length=MODEL_CONTEXT_LIMIT,
+            truncation=True,
+            padding=False,
+        )
+        labels = tokenizer(
+            text_target=answers,
+            max_length=160,
+            truncation=True,
+            padding=False,
+        )
+        model_inputs["labels"] = labels["input_ids"]
+        return model_inputs
 
-        tokenized_train = train_dataset.map(tokenize_seq2seq, batched=True, remove_columns=train_dataset.column_names)
-        tokenized_eval = eval_dataset.map(tokenize_seq2seq, batched=True, remove_columns=eval_dataset.column_names)
-        training_args = stack["Seq2SeqTrainingArguments"](
-            output_dir=args.output_dir,
-            per_device_train_batch_size=args.train_batch_size,
-            per_device_eval_batch_size=args.eval_batch_size,
-            gradient_accumulation_steps=args.gradient_accumulation_steps,
-            learning_rate=args.learning_rate,
-            max_steps=args.max_steps,
-            lr_scheduler_type=args.lr_scheduler_type,
-            warmup_ratio=args.warmup_ratio,
-            weight_decay=args.weight_decay,
-            optim=args.optim,
-            fp16=compute_dtype == torch.float16,
-            bf16=compute_dtype == torch.bfloat16,
-            gradient_checkpointing=True,
-            logging_steps=10,
-            eval_strategy="steps",
-            eval_steps=args.eval_steps,
-            save_strategy="steps",
-            save_steps=args.save_steps,
-            save_total_limit=3,
-            load_best_model_at_end=True,
-            metric_for_best_model="eval_loss",
-            greater_is_better=False,
-            predict_with_generate=False,
-            report_to="none",
-        )
-        callbacks = []
-        if args.early_stopping_patience > 0:
-            callbacks.append(
-                stack["EarlyStoppingCallback"](
-                    early_stopping_patience=args.early_stopping_patience
-                )
+    tokenized_train = train_dataset.map(
+        tokenize_seq2seq, batched=True, remove_columns=train_dataset.column_names
+    )
+    tokenized_eval = eval_dataset.map(
+        tokenize_seq2seq, batched=True, remove_columns=eval_dataset.column_names
+    )
+    training_args = stack["Seq2SeqTrainingArguments"](
+        output_dir=args.output_dir,
+        per_device_train_batch_size=args.train_batch_size,
+        per_device_eval_batch_size=args.eval_batch_size,
+        gradient_accumulation_steps=args.gradient_accumulation_steps,
+        learning_rate=args.learning_rate,
+        max_steps=args.max_steps,
+        lr_scheduler_type=args.lr_scheduler_type,
+        warmup_ratio=args.warmup_ratio,
+        weight_decay=args.weight_decay,
+        optim=args.optim,
+        fp16=compute_dtype == torch.float16,
+        bf16=compute_dtype == torch.bfloat16,
+        gradient_checkpointing=True,
+        logging_steps=10,
+        eval_strategy="steps",
+        eval_steps=args.eval_steps,
+        save_strategy="steps",
+        save_steps=args.save_steps,
+        save_total_limit=3,
+        load_best_model_at_end=True,
+        metric_for_best_model="eval_loss",
+        greater_is_better=False,
+        predict_with_generate=False,
+        report_to="none",
+    )
+    callbacks = []
+    if args.early_stopping_patience > 0:
+        callbacks.append(
+            stack["EarlyStoppingCallback"](
+                early_stopping_patience=args.early_stopping_patience
             )
-        trainer = stack["Seq2SeqTrainer"](
-            model=model,
-            args=training_args,
-            train_dataset=tokenized_train,
-            eval_dataset=tokenized_eval,
-            tokenizer=tokenizer,
-            data_collator=stack["DataCollatorForSeq2Seq"](tokenizer=tokenizer, model=model),
-            callbacks=callbacks,
         )
-    else:
-        def tokenize_causal(batch: dict[str, list[Any]]) -> dict[str, Any]:
-            texts = [
-                f"{format_instruction(record)} {record['answer']}{tokenizer.eos_token or ''}"
-                for record in _batch_records(batch)
-            ]
-            return tokenizer(
-                texts,
-                max_length=MODEL_CONTEXT_LIMIT,
-                truncation=True,
-                padding=False,
-            )
-
-        tokenized_train = train_dataset.map(tokenize_causal, batched=True, remove_columns=train_dataset.column_names)
-        tokenized_eval = eval_dataset.map(tokenize_causal, batched=True, remove_columns=eval_dataset.column_names)
-        training_args = stack["TrainingArguments"](
-            output_dir=args.output_dir,
-            per_device_train_batch_size=args.train_batch_size,
-            per_device_eval_batch_size=args.eval_batch_size,
-            gradient_accumulation_steps=args.gradient_accumulation_steps,
-            learning_rate=args.learning_rate,
-            max_steps=args.max_steps,
-            lr_scheduler_type=args.lr_scheduler_type,
-            warmup_ratio=args.warmup_ratio,
-            weight_decay=args.weight_decay,
-            optim=args.optim,
-            fp16=compute_dtype == torch.float16,
-            bf16=compute_dtype == torch.bfloat16,
-            gradient_checkpointing=True,
-            logging_steps=10,
-            eval_strategy="steps",
-            eval_steps=args.eval_steps,
-            save_strategy="steps",
-            save_steps=args.save_steps,
-            save_total_limit=3,
-            load_best_model_at_end=True,
-            metric_for_best_model="eval_loss",
-            greater_is_better=False,
-            report_to="none",
-        )
-        callbacks = []
-        if args.early_stopping_patience > 0:
-            callbacks.append(
-                stack["EarlyStoppingCallback"](
-                    early_stopping_patience=args.early_stopping_patience
-                )
-            )
-        trainer = stack["Trainer"](
-            model=model,
-            args=training_args,
-            train_dataset=tokenized_train,
-            eval_dataset=tokenized_eval,
-            tokenizer=tokenizer,
-            data_collator=stack["DataCollatorForLanguageModeling"](
-                tokenizer=tokenizer,
-                mlm=False,
-            ),
-            callbacks=callbacks,
-        )
+    trainer = stack["Seq2SeqTrainer"](
+        model=model,
+        args=training_args,
+        train_dataset=tokenized_train,
+        eval_dataset=tokenized_eval,
+        tokenizer=tokenizer,
+        data_collator=stack["DataCollatorForSeq2Seq"](tokenizer=tokenizer, model=model),
+        callbacks=callbacks,
+    )
 
     trainer.train(resume_from_checkpoint=args.resume)
     trainer.save_model(args.output_dir)
@@ -314,9 +284,7 @@ def _batch_records(batch: dict[str, list[Any]]) -> list[dict[str, Any]]:
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--dataset", default=str(DEFAULT_DATASET_PATH))
-    parser.add_argument("--model-id", default=PRIMARY_BASE_MODEL_ID)
     parser.add_argument("--adapter-model-id")
-    parser.add_argument("--fallback-model-id", default=FALLBACK_BASE_MODEL_ID)
     parser.add_argument("--output-dir", default=str(DEFAULT_TRAIN_OUTPUT_DIR))
     parser.add_argument("--quantization", choices=["4bit", "8bit"], default="4bit")
     parser.add_argument("--max-steps", type=int, default=MAX_STEPS)
@@ -342,13 +310,7 @@ def main() -> int:
     parser.add_argument("--resume", action="store_true")
     args = parser.parse_args()
 
-    try:
-        run_training(args)
-    except RuntimeError as exc:
-        if args.model_id == PRIMARY_BASE_MODEL_ID:
-            print(f"primary training failed: {exc}")
-            print(f"retry with --model-id {args.fallback_model_id} to use the fallback path")
-        raise
+    run_training(args)
     return 0
 
 

--- a/next.config.ts
+++ b/next.config.ts
@@ -6,6 +6,7 @@ const nextConfig: NextConfig = {
   images: { unoptimized: true },
   basePath: DERIVED_CONFIG.basePath,
   assetPrefix: DERIVED_CONFIG.assetPrefix,
+  allowedDevOrigins: ["192.168.86.250"],
   webpack: (config, { isServer }) => {
     if (!isServer) {
       config.resolve.alias = {

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "next": "^16.3.0-preview.3",
         "react": "^19.2.7",
         "react-dom": "^19.2.7",
+        "three": "^0.184.0",
         "zustand": "^5.0.14"
       },
       "devDependencies": {
@@ -24,6 +25,7 @@
         "@types/node": "^25.9.3",
         "@types/react": "^19.2.17",
         "@types/react-dom": "^19.2.3",
+        "@types/three": "^0.184.1",
         "baseline-browser-mapping": "^2.10.38",
         "eslint": "^9.39.4",
         "eslint-config-next": "^16.3.0-preview.3",
@@ -298,6 +300,13 @@
         "framer-motion": "^12.0.0",
         "react": "^19.0.0"
       }
+    },
+    "node_modules/@dimforge/rapier3d-compat": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@dimforge/rapier3d-compat/-/rapier3d-compat-0.12.0.tgz",
+      "integrity": "sha512-uekIGetywIgopfD97oDL5PfeezkFpNhwlzlaEYNOA0N6ghdsOvh/HYjSMek5Q2O1PYvRSDFcqFVJl4r4ZBwOow==",
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/@emnapi/core": {
       "version": "1.8.1",
@@ -1835,6 +1844,13 @@
         "tailwindcss": "4.3.1"
       }
     },
+    "node_modules/@tweenjs/tween.js": {
+      "version": "23.1.3",
+      "resolved": "https://registry.npmjs.org/@tweenjs/tween.js/-/tween.js-23.1.3.tgz",
+      "integrity": "sha512-vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
@@ -1895,6 +1911,35 @@
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
+    },
+    "node_modules/@types/stats.js": {
+      "version": "0.17.4",
+      "resolved": "https://registry.npmjs.org/@types/stats.js/-/stats.js-0.17.4.tgz",
+      "integrity": "sha512-jIBvWWShCvlBqBNIZt0KAshWpvSjhkwkEu4ZUcASoAvhmrgAUI2t1dXrjSL4xXVLB4FznPrIsX3nKXFl/Dt4vA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/three": {
+      "version": "0.184.1",
+      "resolved": "https://registry.npmjs.org/@types/three/-/three-0.184.1.tgz",
+      "integrity": "sha512-6q4VdiqVsrTRqmk62/BnlcAvIrnDM0zf2ZDVKI5kZiniWrSaOHaQzmbp+BNzoggc/8tgW412pL//wZIxu2PPTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@dimforge/rapier3d-compat": "~0.12.0",
+        "@tweenjs/tween.js": "~23.1.3",
+        "@types/stats.js": "*",
+        "@types/webxr": ">=0.5.17",
+        "fflate": "~0.8.2",
+        "meshoptimizer": "~1.1.1"
+      }
+    },
+    "node_modules/@types/webxr": {
+      "version": "0.5.24",
+      "resolved": "https://registry.npmjs.org/@types/webxr/-/webxr-0.5.24.tgz",
+      "integrity": "sha512-h8fgEd/DpoS9CBrjEQXR+dIDraopAEfu4wYVNY2tEPwk60stPWhvZMf4Foo5FakuQ7HFZoa8WceaWFervK2Ovg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.61.1",
@@ -4022,6 +4067,13 @@
         "reusify": "^1.0.4"
       }
     },
+    "node_modules/fflate": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
+      "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
@@ -5640,6 +5692,13 @@
         "node": ">= 8"
       }
     },
+    "node_modules/meshoptimizer": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/meshoptimizer/-/meshoptimizer-1.1.1.tgz",
+      "integrity": "sha512-oRFNWJRDA/WTrVj7NWvqa5HqE1t9MYDj2VaWirQCzCCrAd2GHrqR/sQezCxiWATPNlKTcRaPRHPJwIRoPBAp5g==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/micromatch": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
@@ -7125,6 +7184,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
       }
+    },
+    "node_modules/three": {
+      "version": "0.184.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.184.0.tgz",
+      "integrity": "sha512-wtTRjG92pM5eUg/KuUnHsqSAlPM296brTOcLgMRqEeylYTh/CdtvKUvCyyCQTzFuStieWxvZb8mVTMvdPyUpxg==",
+      "license": "MIT"
     },
     "node_modules/tinyglobby": {
       "version": "0.2.15",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "next": "^16.3.0-preview.3",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",
+    "three": "^0.184.0",
     "zustand": "^5.0.14"
   },
   "devDependencies": {
@@ -31,6 +32,7 @@
     "@types/node": "^25.9.3",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",
+    "@types/three": "^0.184.1",
     "baseline-browser-mapping": "^2.10.38",
     "eslint": "^9.39.4",
     "eslint-config-next": "^16.3.0-preview.3",

--- a/src/components/chat/components/ChatContainer.tsx
+++ b/src/components/chat/components/ChatContainer.tsx
@@ -3,7 +3,8 @@
  * Main container orchestrating chat functionality with all hooks and child components
  */
 
-import React, { useEffect, useRef } from "react";
+import React, { useCallback, useEffect, useId, useRef } from "react";
+import { Layers } from "@deemlol/next-icons";
 import { ChatMessages } from "./ChatMessages";
 import { ChatInput } from "./ChatInput";
 import { useChatHistory, useAIGeneration, useModelManagement } from "../hooks";
@@ -15,9 +16,31 @@ import { CHATBOT_CONFIG } from "@/config";
 
 export interface ChatContainerProps {
   onClose: () => void;
+  onOpenVisualizer: () => void;
 }
 
-export function ChatContainer({ onClose }: ChatContainerProps): React.ReactElement {
+const FOCUSABLE_SELECTOR = [
+  "a[href]",
+  "button:not([disabled])",
+  "textarea:not([disabled])",
+  "input:not([disabled])",
+  "select:not([disabled])",
+  "[tabindex]:not([tabindex='-1'])",
+].join(",");
+
+function getFocusableElements(container: HTMLElement): HTMLElement[] {
+  return Array.from(container.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR))
+    .filter((element) => !element.hasAttribute("disabled"))
+    .filter(
+      (element) => element.offsetParent !== null || element === document.activeElement
+    );
+}
+
+export function ChatContainer({
+  onClose,
+  onOpenVisualizer,
+}: ChatContainerProps): React.ReactElement {
+  const titleId = useId();
   const { messages, clearHistory, canClear } = useChatHistory();
   const { isGenerating, currentResponse, generate } = useAIGeneration();
   const {
@@ -31,7 +54,67 @@ export function ChatContainer({ onClose }: ChatContainerProps): React.ReactEleme
   const conversationTurns = getRecentConversationTurns(
     messages.filter((message) => !welcomeMessages.has(message.content))
   );
+  const dialogRef = useRef<HTMLDivElement>(null);
+  const closeButtonRef = useRef<HTMLButtonElement>(null);
+  const previousFocusRef = useRef<HTMLElement | null>(null);
   const messagesEndRef = useRef<HTMLDivElement>(null);
+
+  const handleDialogKeyDown = useCallback(
+    (event: KeyboardEvent): void => {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        onClose();
+        return;
+      }
+
+      if (event.key !== "Tab" || !dialogRef.current) {
+        return;
+      }
+
+      const focusableElements = getFocusableElements(dialogRef.current);
+      if (focusableElements.length === 0) {
+        event.preventDefault();
+        dialogRef.current.focus();
+        return;
+      }
+
+      const firstElement = focusableElements[0];
+      const lastElement = focusableElements[focusableElements.length - 1];
+      if (!dialogRef.current.contains(document.activeElement)) {
+        event.preventDefault();
+        if (event.shiftKey) {
+          lastElement.focus();
+        } else {
+          firstElement.focus();
+        }
+        return;
+      }
+
+      if (event.shiftKey && document.activeElement === firstElement) {
+        event.preventDefault();
+        lastElement.focus();
+        return;
+      }
+
+      if (!event.shiftKey && document.activeElement === lastElement) {
+        event.preventDefault();
+        firstElement.focus();
+      }
+    },
+    [onClose]
+  );
+
+  useEffect(() => {
+    previousFocusRef.current =
+      document.activeElement instanceof HTMLElement ? document.activeElement : null;
+    document.addEventListener("keydown", handleDialogKeyDown);
+    closeButtonRef.current?.focus();
+
+    return () => {
+      document.removeEventListener("keydown", handleDialogKeyDown);
+      previousFocusRef.current?.focus();
+    };
+  }, [handleDialogKeyDown]);
 
   useEffect(() => {
     messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
@@ -67,46 +150,94 @@ export function ChatContainer({ onClose }: ChatContainerProps): React.ReactEleme
         : !isReady
           ? "Model not ready..."
           : "Type your message...";
+  const isVisualizerDisabled = !isReady || isGenerating || !!error;
+  const visualizerTooltip = error
+    ? "Model failed to load. Refresh before opening the visualizer."
+    : !isReady
+      ? "LLM Visualizer available after the model loads"
+      : isGenerating
+        ? "Cannot open visualizer while generating"
+        : "LLM Visualizer";
 
   return (
     <div className="fixed inset-0 z-40 pointer-events-none">
       <div className="pointer-events-auto fixed inset-0 flex items-center justify-center bg-black/80 p-4 lg:inset-auto lg:bottom-6 lg:right-6 lg:block lg:bg-transparent lg:p-0">
-        <div className="w-full max-w-md h-[80vh] bg-black border border-gray-700 rounded-lg shadow-2xl flex flex-col lg:w-96 lg:max-w-none lg:h-[600px]">
+        <div
+          ref={dialogRef}
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby={titleId}
+          tabIndex={-1}
+          className="w-full max-w-md h-[80vh] bg-black border border-gray-700 rounded-lg shadow-2xl flex flex-col lg:w-96 lg:max-w-none lg:h-[600px]"
+        >
           <div className="flex justify-between items-center p-4 border-b border-gray-700">
-            <h3 className="text-lg lg:text-xl font-bold text-white">
+            <h3 id={titleId} className="text-lg lg:text-xl font-bold text-white">
               AI Chatbot
             </h3>
             <div className="flex space-x-2 items-center">
-              <button
-                onClick={handleClearHistory}
-                disabled={isGenerating}
-                className={`${
-                  isGenerating
-                    ? "text-gray-600 bg-gray-900 cursor-not-allowed"
-                    : "text-gray-400 hover:text-white bg-gray-800 hover:bg-gray-700"
-                } rounded-md w-8 h-8 flex items-center justify-center transition-colors duration-200`}
-                aria-label="Clear chat history"
-                title={
-                  isGenerating
-                    ? "Cannot clear history while generating"
-                    : "Clear chat history"
-                }
-              >
-                <svg
-                  className="w-4 h-4"
-                  fill="none"
-                  stroke="currentColor"
-                  viewBox="0 0 24 24"
+              <div className="group relative">
+                <button
+                  onClick={handleClearHistory}
+                  disabled={isGenerating}
+                  className={`${
+                    isGenerating
+                      ? "text-gray-600 bg-gray-900 cursor-not-allowed"
+                      : "text-gray-400 hover:text-white bg-gray-800 hover:bg-gray-700"
+                  } rounded-md w-8 h-8 flex items-center justify-center transition-colors duration-200 focus:outline-none focus:ring-2 focus:ring-gray-300`}
+                  aria-label="Clear chat history"
+                  data-testid="chat-clear-button"
                 >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2}
-                    d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"
-                  />
-                </svg>
-              </button>
+                  <svg
+                    className="w-4 h-4"
+                    fill="none"
+                    stroke="currentColor"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={2}
+                      d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"
+                    />
+                  </svg>
+                </button>
+                <span
+                  id="chat-clear-tooltip"
+                  role="tooltip"
+                  className="pointer-events-none invisible absolute right-0 top-10 z-10 whitespace-nowrap rounded-md border border-gray-700 bg-black px-2 py-1 text-xs text-gray-200 opacity-0 shadow-lg transition-all duration-150 group-focus-within:visible group-focus-within:opacity-100 group-hover:visible group-hover:opacity-100"
+                  data-testid="chat-clear-tooltip"
+                >
+                  {isGenerating
+                    ? "Cannot clear history while generating"
+                    : "Clear chat history"}
+                </span>
+              </div>
+              <div className="group relative">
+                <button
+                  type="button"
+                  onClick={onOpenVisualizer}
+                  disabled={isVisualizerDisabled}
+                  className={`${
+                    isVisualizerDisabled
+                      ? "cursor-not-allowed bg-gray-900 text-gray-600"
+                      : "bg-gray-800 text-gray-400 hover:bg-gray-700 hover:text-white"
+                  } flex h-8 w-8 items-center justify-center rounded-md transition-colors duration-200 focus:outline-none focus:ring-2 focus:ring-gray-300`}
+                  aria-label="Open LLM Visualizer"
+                  data-testid="profile-visualizer-button"
+                >
+                  <Layers className="h-4 w-4" aria-hidden="true" />
+                </button>
+                <span
+                  id="llm-visualizer-tooltip"
+                  role="tooltip"
+                  className="pointer-events-none invisible absolute right-0 top-10 z-10 whitespace-nowrap rounded-md border border-gray-700 bg-black px-2 py-1 text-xs text-gray-200 opacity-0 shadow-lg transition-all duration-150 group-focus-within:visible group-focus-within:opacity-100 group-hover:visible group-hover:opacity-100"
+                  data-testid="profile-visualizer-tooltip"
+                >
+                  {visualizerTooltip}
+                </span>
+              </div>
               <button
+                ref={closeButtonRef}
                 onClick={onClose}
                 className="text-gray-400 hover:text-white bg-gray-800 hover:bg-gray-700 rounded-md w-8 h-8 flex items-center justify-center transition-colors duration-200"
                 aria-label="Close chat"

--- a/src/components/profile/ProfileVisualizerModal.tsx
+++ b/src/components/profile/ProfileVisualizerModal.tsx
@@ -1,0 +1,597 @@
+import { useCallback, useEffect, useId, useMemo, useRef, useState } from "react";
+import { Cpu, Layers, X } from "@deemlol/next-icons";
+import { MODEL_CONTEXT_LIMIT } from "@/config/models";
+import {
+  cleanInput,
+  generatePrompt,
+  getPromptBudget,
+} from "@/services/ai/contextProvider";
+import { ProfileVisualizerScene } from "./ProfileVisualizerScene";
+import {
+  VISUALIZER_QUESTION,
+  VISUALIZER_STAGES,
+  type VisualizerStageId,
+} from "./visualizerData";
+import {
+  useTeapotVisualizerTrace,
+  type TraceStageState,
+} from "./useTeapotVisualizerTrace";
+
+interface ProfileVisualizerModalProps {
+  onClose: () => void;
+}
+
+interface MessageTransform {
+  stageId: VisualizerStageId;
+  label: string;
+  value: string;
+}
+
+const FOCUSABLE_SELECTOR = [
+  "a[href]",
+  "button:not([disabled])",
+  "textarea:not([disabled])",
+  "input:not([disabled])",
+  "select:not([disabled])",
+  "[tabindex]:not([tabindex='-1'])",
+].join(",");
+const SUGGESTED_PROFILE_QUESTIONS = [
+  VISUALIZER_QUESTION,
+  "What is Justin building at OpenAI?",
+  "What did Justin work on at Defense Unicorns?",
+  "What is Justin's military background?",
+  "Where did Justin study computer science?",
+  "What AI projects has Justin led?",
+  "What are Justin's strongest technical skills?",
+  "What do recommendations say about Justin?",
+  "What are Justin's hobbies outside work?",
+] as const;
+const SUGGESTED_QUESTION_COUNT = 4;
+
+function getRandomSuggestedQuestions(): readonly string[] {
+  const shuffledQuestions = [...SUGGESTED_PROFILE_QUESTIONS];
+
+  for (let index = shuffledQuestions.length - 1; index > 0; index -= 1) {
+    const swapIndex = Math.floor(Math.random() * (index + 1));
+    [shuffledQuestions[index], shuffledQuestions[swapIndex]] = [
+      shuffledQuestions[swapIndex],
+      shuffledQuestions[index],
+    ];
+  }
+
+  return shuffledQuestions.slice(0, SUGGESTED_QUESTION_COUNT);
+}
+
+function getFocusableElements(container: HTMLElement): HTMLElement[] {
+  return Array.from(container.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR))
+    .filter((element) => !element.hasAttribute("disabled"))
+    .filter((element) => element.offsetParent !== null || element === document.activeElement);
+}
+
+function getStageDotClasses(state: TraceStageState): string {
+  if (state === "active") {
+    return "bg-blue-300 shadow-[0_0_16px_rgba(147,197,253,0.85)]";
+  }
+  if (state === "complete") {
+    return "bg-gray-300";
+  }
+  if (state === "error") {
+    return "bg-red-300";
+  }
+  return "bg-gray-700";
+}
+
+function normalizeTraceText(value: string): string {
+  return value.replace(/\s+/g, " ").trimStart();
+}
+
+function stateLabel(state: TraceStageState): string {
+  if (state === "active") return "active";
+  if (state === "complete") return "complete";
+  if (state === "error") return "error";
+  return "idle";
+}
+
+export default function ProfileVisualizerModal({
+  onClose,
+}: ProfileVisualizerModalProps): React.ReactElement {
+  const titleId = useId();
+  const descriptionId = useId();
+  const modalRef = useRef<HTMLDivElement>(null);
+  const closeButtonRef = useRef<HTMLButtonElement>(null);
+  const previousFocusRef = useRef<HTMLElement | null>(null);
+  const [question, setQuestion] = useState(VISUALIZER_QUESTION);
+  const [suggestedQuestions] = useState<readonly string[]>(
+    getRandomSuggestedQuestions
+  );
+  const resolvedQuestion = useMemo(
+    () => question.trim() || VISUALIZER_QUESTION,
+    [question]
+  );
+  const promptBudget = useMemo(
+    () => getPromptBudget(resolvedQuestion),
+    [resolvedQuestion]
+  );
+  const cleanedQuestion = useMemo(
+    () => cleanInput(resolvedQuestion, promptBudget.inputCharacterLimit),
+    [promptBudget.inputCharacterLimit, resolvedQuestion]
+  );
+  const {
+    activeStageId,
+    completedStageIds,
+    isRunning,
+    streamedAnswer,
+    loadingMessage,
+    progress,
+    runTrace,
+    getStageState,
+  } = useTeapotVisualizerTrace();
+  const [selectedStageId, setSelectedStageId] =
+    useState<VisualizerStageId>("question");
+  const traceListRef = useRef<HTMLOListElement>(null);
+  const streamOutputRef = useRef<HTMLOutputElement>(null);
+  const [traceEndSpacerHeight, setTraceEndSpacerHeight] = useState(96);
+  const orderedBlockRefs = useRef<
+    Partial<Record<VisualizerStageId, HTMLLIElement | null>>
+  >({});
+  const setOrderedBlockRef = useCallback(
+    (stageId: VisualizerStageId) =>
+      (element: HTMLLIElement | null): void => {
+        orderedBlockRefs.current[stageId] = element;
+      },
+    []
+  );
+  const updateTraceEndSpacer = useCallback((): void => {
+    const traceList = traceListRef.current;
+    const finalStageId = VISUALIZER_STAGES[VISUALIZER_STAGES.length - 1]?.id;
+    const finalCard = finalStageId ? orderedBlockRefs.current[finalStageId] : null;
+
+    if (!traceList || !finalCard) {
+      return;
+    }
+
+    const spacerHeight = Math.max(
+      28,
+      Math.min(168, traceList.clientHeight / 2 - finalCard.offsetHeight / 2)
+    );
+    setTraceEndSpacerHeight(Math.round(spacerHeight));
+  }, []);
+  const centerTraceCard = useCallback((stageId: VisualizerStageId): void => {
+    window.requestAnimationFrame(() => {
+      const traceList = traceListRef.current;
+      const traceCard = orderedBlockRefs.current[stageId];
+
+      if (!traceList || !traceCard) {
+        traceCard?.scrollIntoView({
+          behavior: "smooth",
+          block: "center",
+          inline: "nearest",
+        });
+        return;
+      }
+
+      const traceListRect = traceList.getBoundingClientRect();
+      const traceCardRect = traceCard.getBoundingClientRect();
+      const targetScrollTop =
+        traceList.scrollTop +
+        traceCardRect.top -
+        traceListRect.top -
+        traceList.clientHeight / 2 +
+        traceCardRect.height / 2;
+
+      traceList.scrollTo({
+        top: Math.max(0, targetScrollTop),
+        behavior: "smooth",
+      });
+    });
+  }, []);
+  const handleStageSelect = useCallback((stageId: VisualizerStageId): void => {
+    setSelectedStageId(stageId);
+    centerTraceCard(stageId);
+  }, [centerTraceCard]);
+  useEffect(() => {
+    centerTraceCard(activeStageId);
+  }, [activeStageId, centerTraceCard]);
+  const transformSteps = useMemo<readonly MessageTransform[]>(() => {
+    const selectedSections =
+      promptBudget.selectedProfileSectionIds.join(", ") || "no profile sections";
+    const packedPrompt = cleanedQuestion
+      ? generatePrompt(cleanedQuestion)
+      : "";
+
+    return [
+      {
+        stageId: "question",
+        label: "Question",
+        value: resolvedQuestion,
+      },
+      {
+        stageId: "cleaning",
+        label: "Clean input",
+        value: cleanedQuestion,
+      },
+      {
+        stageId: "retrieval",
+        label: "Select context",
+        value: `Sections: ${selectedSections}\nEmbedding lineage: teapotai/teapotembedding`,
+      },
+      {
+        stageId: "budgeting",
+        label: "Pack prompt",
+        value: `Estimated budget: ${promptBudget.estimatedPromptTokens}/${MODEL_CONTEXT_LIMIT} tokens\nSelected sections: ${selectedSections}`,
+      },
+      {
+        stageId: "worker",
+        label: "Send prompt to model",
+        value: packedPrompt,
+      },
+      {
+        stageId: "runtime",
+        label: "Load runtime",
+        value:
+          "Transformers.js loads the exported ONNX model in browser WASM, preferring int8 with a uint8 retry.",
+      },
+      {
+        stageId: "encoder",
+        label: "Encode prompt",
+        value:
+          "Tokenizer output and retrieved context become the T5 encoder state.",
+      },
+      {
+        stageId: "lora",
+        label: "Apply tuned attention",
+        value:
+          "Merged q/v LoRA behavior nudges the model toward public-profile grounding and unsupported-fact refusals.",
+      },
+      {
+        stageId: "decoder",
+        label: "Decode and render",
+        value:
+          normalizeTraceText(streamedAnswer) ||
+          loadingMessage ||
+          "The decoder emits answer tokens and renders the stream here.",
+      },
+    ];
+  }, [
+    cleanedQuestion,
+    loadingMessage,
+    promptBudget,
+    resolvedQuestion,
+    streamedAnswer,
+  ]);
+
+  useEffect(() => {
+    const frameId = window.requestAnimationFrame(updateTraceEndSpacer);
+    return () => {
+      window.cancelAnimationFrame(frameId);
+    };
+  }, [transformSteps, updateTraceEndSpacer]);
+
+  useEffect(() => {
+    function handleResize(): void {
+      updateTraceEndSpacer();
+    }
+
+    window.addEventListener("resize", handleResize);
+    return () => {
+      window.removeEventListener("resize", handleResize);
+    };
+  }, [updateTraceEndSpacer]);
+
+  useEffect(() => {
+    window.requestAnimationFrame(() => {
+      const streamOutput = streamOutputRef.current;
+      if (streamOutput) {
+        streamOutput.scrollTop = streamOutput.scrollHeight;
+      }
+
+      if (streamedAnswer && activeStageId === "decoder") {
+        centerTraceCard("decoder");
+      }
+    });
+  }, [activeStageId, centerTraceCard, streamedAnswer]);
+
+  const handleKeyDown = useCallback(
+    (event: KeyboardEvent): void => {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        onClose();
+        return;
+      }
+
+      if (event.key !== "Tab" || !modalRef.current) {
+        return;
+      }
+
+      const focusableElements = getFocusableElements(modalRef.current);
+      if (focusableElements.length === 0) {
+        event.preventDefault();
+        modalRef.current.focus();
+        return;
+      }
+
+      const firstElement = focusableElements[0];
+      const lastElement = focusableElements[focusableElements.length - 1];
+      if (!modalRef.current.contains(document.activeElement)) {
+        event.preventDefault();
+        if (event.shiftKey) {
+          lastElement.focus();
+        } else {
+          firstElement.focus();
+        }
+        return;
+      }
+
+      if (event.shiftKey && document.activeElement === firstElement) {
+        event.preventDefault();
+        lastElement.focus();
+        return;
+      }
+
+      if (!event.shiftKey && document.activeElement === lastElement) {
+        event.preventDefault();
+        firstElement.focus();
+      }
+    },
+    [onClose]
+  );
+
+  useEffect(() => {
+    previousFocusRef.current =
+      document.activeElement instanceof HTMLElement ? document.activeElement : null;
+    const previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    document.addEventListener("keydown", handleKeyDown);
+    closeButtonRef.current?.focus();
+
+    return () => {
+      document.body.style.overflow = previousOverflow;
+      document.removeEventListener("keydown", handleKeyDown);
+      previousFocusRef.current?.focus();
+    };
+  }, [handleKeyDown]);
+
+  function handleBackdropMouseDown(event: React.MouseEvent<HTMLDivElement>): void {
+    if (event.target === event.currentTarget) {
+      onClose();
+    }
+  }
+
+  function handleRunTrace(): void {
+    setQuestion(resolvedQuestion);
+    runTrace(resolvedQuestion);
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-50 bg-black/85 p-2 sm:p-4"
+      onMouseDown={handleBackdropMouseDown}
+    >
+      <div
+        ref={modalRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+        aria-describedby={descriptionId}
+        tabIndex={-1}
+        className="mx-auto flex h-[calc(100dvh-1rem)] max-h-[calc(100dvh-1rem)] w-full max-w-7xl flex-col overflow-hidden rounded-lg border border-gray-700 bg-black text-white shadow-2xl sm:h-[calc(100dvh-2rem)] sm:max-h-[calc(100dvh-2rem)]"
+        data-testid="profile-visualizer-modal"
+      >
+        <div className="flex items-start justify-between gap-3 border-b border-gray-800 px-4 py-3 sm:px-5">
+          <div className="min-w-0">
+            <div className="flex items-center gap-2 text-xs uppercase tracking-normal text-gray-500">
+              <Cpu className="h-4 w-4" aria-hidden="true" />
+              Browser architecture trace
+            </div>
+            <h2
+              id={titleId}
+              className="mt-1 text-xl font-semibold text-white sm:text-2xl"
+            >
+              LLM Visualizer
+            </h2>
+            <p
+              id={descriptionId}
+              className="mt-1 max-w-3xl text-sm leading-6 text-gray-400"
+            >
+              An illustrated trace of the profile-QA worker path with live
+              worker output: question cleanup, local context selection, ONNX
+              runtime loading, T5 encoder-decoder generation, and streamed
+              answer rendering.
+            </p>
+          </div>
+          <button
+            ref={closeButtonRef}
+            type="button"
+            className="flex h-9 w-9 shrink-0 items-center justify-center rounded-md bg-gray-900 text-gray-300 transition-colors hover:bg-gray-800 hover:text-white focus:outline-none focus:ring-2 focus:ring-gray-300"
+            aria-label="Close LLM Visualizer"
+            onClick={onClose}
+          >
+            <X className="h-4 w-4" aria-hidden="true" />
+          </button>
+        </div>
+
+        <div className="grid min-h-0 flex-1 gap-3 overflow-y-auto p-3 lg:grid-cols-[minmax(0,1.45fr)_minmax(340px,0.9fr)] lg:overflow-hidden lg:p-4">
+          <section className="flex min-h-0 flex-col overflow-hidden rounded-lg border border-gray-800 bg-black">
+            <div className="border-b border-gray-800 px-4 py-3">
+              <div className="min-w-0 flex-1">
+                <div className="flex items-center gap-2 text-xs uppercase tracking-normal text-gray-500">
+                  <span className="h-2 w-2 rounded-full bg-blue-300 shadow-[0_0_14px_rgba(147,197,253,0.8)]" />
+                  Question packet
+                </div>
+                <div className="mt-1 flex items-end gap-2">
+                  <div className="min-w-0 flex-1">
+                    <label
+                      className="block text-sm font-semibold text-white"
+                      htmlFor="profile-visualizer-question"
+                    >
+                      Ask a profile question to trace
+                    </label>
+                    <input
+                      id="profile-visualizer-question"
+                      className="mt-2 block h-11 w-full min-w-0 rounded-lg border border-gray-500 bg-gray-800 px-4 py-2 text-base text-gray-100 outline-none transition-colors placeholder:text-gray-500 focus:border-gray-200 focus:ring-2 focus:ring-blue-500 disabled:cursor-not-allowed disabled:opacity-50"
+                      value={question}
+                      onChange={(event) => setQuestion(event.target.value)}
+                      placeholder={VISUALIZER_QUESTION}
+                      disabled={isRunning}
+                      data-testid="profile-visualizer-question"
+                    />
+                  </div>
+                  <div className="relative flex h-11 w-20 shrink-0 items-end justify-center">
+                    <button
+                      type="button"
+                      className="h-11 w-full rounded-lg bg-blue-600 px-0 font-medium text-white transition-colors duration-200 hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:bg-blue-600"
+                      onClick={handleRunTrace}
+                      disabled={isRunning}
+                      data-testid="profile-visualizer-play"
+                    >
+                      Send
+                    </button>
+                  </div>
+                </div>
+                <div className="mt-2 flex flex-wrap items-center gap-2 text-xs text-gray-500">
+                  <span>Try:</span>
+                  {suggestedQuestions.map((example) => (
+                    <button
+                      key={example}
+                      type="button"
+                      className="rounded-md border border-gray-800 px-2 py-1 text-gray-300 transition-colors hover:border-gray-600 hover:bg-gray-900 disabled:cursor-not-allowed disabled:text-gray-600"
+                      onClick={() => setQuestion(example)}
+                      disabled={isRunning}
+                      data-testid="profile-visualizer-suggestion"
+                    >
+                      {example}
+                    </button>
+                  ))}
+                </div>
+              </div>
+            </div>
+            <div className="min-h-0 flex-1">
+              <ProfileVisualizerScene
+                activeStageId={activeStageId}
+                completedStageIds={completedStageIds}
+                onStageSelect={handleStageSelect}
+              />
+            </div>
+          </section>
+
+          <aside className="flex min-h-[320px] flex-col overflow-hidden rounded-lg border border-gray-800 bg-black lg:min-h-0">
+            <section className="flex min-h-0 flex-1 flex-col p-4">
+              <div className="flex items-center justify-between gap-3">
+                <div className="flex items-center gap-2 text-sm font-semibold text-gray-200">
+                  <Layers className="h-4 w-4" aria-hidden="true" />
+                  Trace
+                </div>
+                <span className="text-xs text-gray-500">
+                  {progress !== null ? `${progress}%` : loadingMessage}
+                </span>
+                <span
+                  className="sr-only"
+                  role="status"
+                  aria-live="polite"
+                  aria-atomic="true"
+                >
+                  {isRunning
+                    ? `Visualizer status: ${
+                        progress !== null
+                          ? `loading ${progress}%`
+                          : loadingMessage ?? "running"
+                      }`
+                    : "Visualizer idle"}
+                </span>
+              </div>
+
+              <ol
+                ref={traceListRef}
+                className="mt-3 min-h-0 flex-1 space-y-2 overflow-y-auto pr-1"
+                style={{ paddingBottom: traceEndSpacerHeight }}
+                data-testid="profile-visualizer-trace-list"
+              >
+                {transformSteps.map((step, index) => {
+                  const stage = VISUALIZER_STAGES[index];
+                  const state = getStageState(step.stageId);
+                  const isCurrent = activeStageId === step.stageId;
+                  const isSelected = selectedStageId === step.stageId;
+                  const stageNumber = String(index + 1).padStart(2, "0");
+                    const body =
+                      step.stageId === "decoder"
+                        ? normalizeTraceText(streamedAnswer) ||
+                          loadingMessage ||
+                          step.value
+                        : step.value;
+
+                  return (
+                    <li
+                      key={step.stageId}
+                      id={`profile-visualizer-block-${step.stageId}`}
+                      ref={setOrderedBlockRef(step.stageId)}
+                      data-testid={`profile-visualizer-transform-${step.stageId}`}
+                    >
+                      <button
+                        type="button"
+                        className={`w-full rounded-md border px-3 py-3 text-left transition-colors focus:outline-none focus:ring-2 focus:ring-gray-300 ${
+                          isCurrent
+                            ? "border-blue-300 bg-gray-950 text-white"
+                            : isSelected
+                              ? "border-gray-500 bg-black text-gray-200"
+                              : state === "complete"
+                                ? "border-gray-800 bg-black text-gray-300"
+                                : state === "error"
+                                  ? "border-red-400 bg-red-950/40 text-red-100"
+                                  : "border-gray-900 bg-black text-gray-500"
+                        }`}
+                        onClick={() => handleStageSelect(step.stageId)}
+                        aria-current={isCurrent ? "step" : undefined}
+                        data-testid={`profile-visualizer-stage-${step.stageId}`}
+                        data-stage-state={stateLabel(state)}
+                      >
+                        <span className="flex items-start gap-3">
+                          <span
+                            className={`mt-1 h-2.5 w-2.5 shrink-0 rounded-full ${getStageDotClasses(
+                              state
+                            )}`}
+                            aria-hidden="true"
+                          />
+                          <span className="min-w-0 flex-1">
+                            <span className="flex items-center justify-between gap-3">
+                              <span className="min-w-0">
+                                <span className="mr-2 text-[10px] text-gray-500">
+                                  {stageNumber}
+                                </span>
+                                <span className="text-sm font-semibold text-gray-100">
+                                  {step.label}
+                                </span>
+                              </span>
+                              <span className="shrink-0 text-xs text-gray-600">
+                                {isCurrent ? "now" : stateLabel(state)}
+                              </span>
+                            </span>
+                            <span className="mt-1 block text-xs text-gray-500">
+                              {stage?.label}
+                            </span>
+                            {step.stageId === "decoder" ? (
+                              <output
+                                ref={streamOutputRef}
+                                className="mt-2 block max-h-56 overflow-y-auto whitespace-pre-wrap break-words rounded-md border border-gray-900 bg-black/40 p-2 font-mono text-[11px] leading-5 text-gray-300"
+                                data-testid="profile-visualizer-stream"
+                              >
+                                {body}
+                              </output>
+                            ) : (
+                              <span className="mt-2 block max-h-56 overflow-y-auto whitespace-pre-wrap break-words rounded-md border border-gray-900 bg-black/40 p-2 font-mono text-[11px] leading-5 text-gray-300">
+                                {body}
+                              </span>
+                            )}
+                          </span>
+                        </span>
+                      </button>
+                    </li>
+                  );
+                })}
+              </ol>
+            </section>
+          </aside>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/profile/ProfileVisualizerScene.tsx
+++ b/src/components/profile/ProfileVisualizerScene.tsx
@@ -1,0 +1,842 @@
+import { useCallback, useEffect, useRef, useState, type RefObject } from "react";
+import * as THREE from "three";
+import { Minus, Plus, RotateCcw } from "@deemlol/next-icons";
+import {
+  VISUALIZER_STAGES,
+  type VisualizerStageId,
+} from "./visualizerData";
+
+interface ProfileVisualizerSceneProps {
+  activeStageId: VisualizerStageId;
+  completedStageIds: readonly VisualizerStageId[];
+  onStageSelect?: (stageId: VisualizerStageId) => void;
+}
+
+interface SceneNode {
+  group: THREE.Group;
+  materials: THREE.MeshStandardMaterial[];
+  basePosition: THREE.Vector3;
+}
+
+const NODE_POSITIONS: Record<VisualizerStageId, [number, number, number]> = {
+  question: [-2.45, 1.6, 0],
+  cleaning: [-1.88, 0.35, 0.25],
+  retrieval: [-1.16, -0.8, 0],
+  budgeting: [-0.45, -0.1, -0.2],
+  worker: [0.15, 1.15, 0],
+  runtime: [0.8, 0.45, 0],
+  encoder: [1.32, -0.2, -0.15],
+  lora: [1.82, -0.85, 0.25],
+  decoder: [2.48, 0.25, -0.1],
+};
+
+const IDLE_COLOR = new THREE.Color(0x3f3f46);
+const COMPLETE_COLOR = new THREE.Color(0x71717a);
+const ACTIVE_COLOR = new THREE.Color(0xe5e7eb);
+const ACCENT_COLOR = new THREE.Color(0x93c5fd);
+const GLASS_COLOR = new THREE.Color(0x1f2937);
+const CAMERA_DISTANCE = 5.85;
+const DEFAULT_ZOOM = 1;
+const MIN_ZOOM = 0.72;
+const MAX_ZOOM = 1.84;
+const ZOOM_STEP = 0.14;
+const ICON_CANVAS_SIZE = 256;
+const FALLBACK_GLYPH_SIZE = 72;
+const STAGE_SPRITE_SIZE = 1;
+const NODE_POSITION_VALUES = Object.values(NODE_POSITIONS);
+const NODE_BOUNDS = NODE_POSITION_VALUES.reduce(
+  (bounds, [x, y]) => ({
+    minX: Math.min(bounds.minX, x),
+    maxX: Math.max(bounds.maxX, x),
+    minY: Math.min(bounds.minY, y),
+    maxY: Math.max(bounds.maxY, y),
+  }),
+  {
+    minX: Number.POSITIVE_INFINITY,
+    maxX: Number.NEGATIVE_INFINITY,
+    minY: Number.POSITIVE_INFINITY,
+    maxY: Number.NEGATIVE_INFINITY,
+  }
+);
+const SCENE_CENTER = new THREE.Vector3(
+  (NODE_BOUNDS.minX + NODE_BOUNDS.maxX) / 2,
+  (NODE_BOUNDS.minY + NODE_BOUNDS.maxY) / 2 - 0.18,
+  0
+);
+
+function clampZoom(value: number): number {
+  return Math.min(MAX_ZOOM, Math.max(MIN_ZOOM, value));
+}
+
+function drawRoundRect(
+  context: CanvasRenderingContext2D,
+  x: number,
+  y: number,
+  width: number,
+  height: number,
+  radius: number
+): void {
+  context.beginPath();
+  context.roundRect(x, y, width, height, radius);
+}
+
+function strokeLine(
+  context: CanvasRenderingContext2D,
+  points: readonly [number, number][]
+): void {
+  context.beginPath();
+  points.forEach(([x, y], index) => {
+    if (index === 0) {
+      context.moveTo(x, y);
+    } else {
+      context.lineTo(x, y);
+    }
+  });
+  context.stroke();
+}
+
+function strokeRoundRect(
+  context: CanvasRenderingContext2D,
+  x: number,
+  y: number,
+  width: number,
+  height: number,
+  radius: number
+): void {
+  drawRoundRect(context, x, y, width, height, radius);
+  context.stroke();
+}
+
+function fillCircle(
+  context: CanvasRenderingContext2D,
+  x: number,
+  y: number,
+  radius: number,
+  color = "#93c5fd"
+): void {
+  context.beginPath();
+  context.arc(x, y, radius, 0, Math.PI * 2);
+  context.fillStyle = color;
+  context.fill();
+}
+
+function drawIconShell(context: CanvasRenderingContext2D): void {
+  const gradient = context.createLinearGradient(54, 48, 202, 208);
+  gradient.addColorStop(0, "#111113");
+  gradient.addColorStop(1, "#09090b");
+  drawRoundRect(context, 48, 48, 160, 160, 32);
+  context.fillStyle = gradient;
+  context.fill();
+  context.strokeStyle = "#27272a";
+  context.lineWidth = 4;
+  context.stroke();
+
+  drawRoundRect(context, 60, 60, 136, 136, 24);
+  context.strokeStyle = "rgba(255,255,255,0.06)";
+  context.lineWidth = 1.5;
+  context.stroke();
+}
+
+function prepareIconStroke(
+  context: CanvasRenderingContext2D,
+  color = "#e5e7eb",
+  width = 8
+): void {
+  context.strokeStyle = color;
+  context.lineWidth = width;
+  context.lineCap = "round";
+  context.lineJoin = "round";
+}
+
+function drawStageGlyph(
+  context: CanvasRenderingContext2D,
+  stageId: VisualizerStageId,
+  centerX: number,
+  centerY: number,
+  size: number
+): void {
+  context.save();
+  context.translate(centerX - size / 2, centerY - size / 2);
+  context.scale(size / ICON_CANVAS_SIZE, size / ICON_CANVAS_SIZE);
+  context.lineCap = "round";
+  context.lineJoin = "round";
+  drawIconShell(context);
+  prepareIconStroke(context);
+
+  switch (stageId) {
+    case "question": {
+      strokeRoundRect(context, 76, 82, 104, 66, 18);
+      strokeLine(context, [
+        [102, 148],
+        [116, 168],
+        [134, 148],
+      ]);
+      prepareIconStroke(context, "#a1a1aa", 7);
+      strokeLine(context, [
+        [102, 108],
+        [154, 108],
+      ]);
+      strokeLine(context, [
+        [102, 128],
+        [140, 128],
+      ]);
+      break;
+    }
+    case "cleaning": {
+      strokeLine(context, [
+        [74, 80],
+        [182, 80],
+        [142, 126],
+        [142, 166],
+        [114, 182],
+        [114, 126],
+        [74, 80],
+      ]);
+      prepareIconStroke(context, "#93c5fd", 6);
+      strokeLine(context, [
+        [176, 150],
+        [176, 174],
+      ]);
+      strokeLine(context, [
+        [164, 162],
+        [188, 162],
+      ]);
+      break;
+    }
+    case "retrieval": {
+      prepareIconStroke(context, "#a1a1aa", 7);
+      strokeRoundRect(context, 78, 76, 64, 86, 12);
+      prepareIconStroke(context);
+      strokeRoundRect(context, 100, 66, 70, 88, 12);
+      prepareIconStroke(context, "#93c5fd", 8);
+      context.beginPath();
+      context.arc(148, 150, 22, 0, Math.PI * 2);
+      context.stroke();
+      strokeLine(context, [
+        [164, 166],
+        [186, 188],
+      ]);
+      break;
+    }
+    case "budgeting": {
+      prepareIconStroke(context);
+      context.beginPath();
+      context.arc(128, 150, 54, Math.PI, Math.PI * 2);
+      context.stroke();
+      prepareIconStroke(context, "#a1a1aa", 6);
+      [82, 104, 152, 174].forEach((x) => {
+        strokeLine(context, [
+          [x, 150],
+          [x + (x < 128 ? 8 : -8), 132],
+        ]);
+      });
+      prepareIconStroke(context, "#93c5fd", 8);
+      strokeLine(context, [
+        [128, 150],
+        [158, 116],
+      ]);
+      fillCircle(context, 128, 150, 7, "#f4f4f5");
+      break;
+    }
+    case "worker": {
+      prepareIconStroke(context);
+      strokeRoundRect(context, 88, 78, 80, 100, 16);
+      prepareIconStroke(context, "#a1a1aa", 6);
+      strokeRoundRect(context, 108, 102, 40, 52, 10);
+      [72, 184].forEach((x) => {
+        strokeLine(context, [
+          [x, 100],
+          [x === 72 ? 88 : 168, 100],
+        ]);
+        strokeLine(context, [
+          [x, 156],
+          [x === 72 ? 88 : 168, 156],
+        ]);
+      });
+      break;
+    }
+    case "runtime": {
+      prepareIconStroke(context);
+      strokeRoundRect(context, 68, 78, 120, 92, 16);
+      prepareIconStroke(context, "#a1a1aa", 6);
+      strokeLine(context, [
+        [68, 104],
+        [188, 104],
+      ]);
+      [88, 106, 124].forEach((x, index) =>
+        fillCircle(context, x, 91, 4, index === 0 ? "#93c5fd" : "#71717a")
+      );
+      prepareIconStroke(context, "#93c5fd", 7);
+      strokeRoundRect(context, 108, 124, 40, 28, 8);
+      break;
+    }
+    case "encoder": {
+      prepareIconStroke(context);
+      [
+        [76, 86, 72],
+        [108, 118, 72],
+        [76, 150, 72],
+      ].forEach(([x, y, width]) => {
+        strokeRoundRect(context, x, y, width, 20, 8);
+      });
+      prepareIconStroke(context, "#93c5fd", 7);
+      strokeLine(context, [
+        [158, 96],
+        [184, 128],
+        [158, 160],
+      ]);
+      break;
+    }
+    case "lora": {
+      prepareIconStroke(context);
+      context.beginPath();
+      context.ellipse(108, 128, 42, 58, 0.35, 0, Math.PI * 2);
+      context.stroke();
+      prepareIconStroke(context, "#a1a1aa", 8);
+      context.beginPath();
+      context.ellipse(148, 128, 42, 58, -0.35, 0, Math.PI * 2);
+      context.stroke();
+      prepareIconStroke(context, "#93c5fd", 7);
+      context.beginPath();
+      context.arc(128, 128, 13, 0, Math.PI * 2);
+      context.stroke();
+      strokeLine(context, [
+        [128, 106],
+        [128, 150],
+      ]);
+      strokeLine(context, [
+        [106, 128],
+        [150, 128],
+      ]);
+      break;
+    }
+    case "decoder": {
+      prepareIconStroke(context);
+      strokeRoundRect(context, 76, 78, 104, 100, 16);
+      prepareIconStroke(context, "#a1a1aa", 7);
+      strokeLine(context, [
+        [98, 108],
+        [158, 108],
+      ]);
+      strokeLine(context, [
+        [98, 132],
+        [144, 132],
+      ]);
+      prepareIconStroke(context, "#93c5fd", 7);
+      strokeLine(context, [
+        [158, 132],
+        [158, 154],
+      ]);
+      break;
+    }
+  }
+
+  context.restore();
+}
+
+function drawFallback(
+  canvas: HTMLCanvasElement,
+  zoomLevelRef: RefObject<number>
+): () => void {
+  const context = canvas.getContext("2d");
+  let animationFrame = 0;
+
+  const render = (): void => {
+    const parent = canvas.parentElement;
+    const width = Math.max(320, parent?.clientWidth ?? canvas.clientWidth);
+    const height = Math.max(260, parent?.clientHeight ?? canvas.clientHeight);
+    canvas.width = width;
+    canvas.height = height;
+
+    if (!context) {
+      return;
+    }
+
+    context.fillStyle = "#050505";
+    context.fillRect(0, 0, width, height);
+    context.save();
+    context.translate(width / 2, height / 2);
+    context.scale(zoomLevelRef.current, zoomLevelRef.current);
+    context.translate(-width / 2, -height / 2);
+    context.strokeStyle = "#71717a";
+    context.lineWidth = 2;
+    context.beginPath();
+    context.moveTo(40, height * 0.5);
+    context.bezierCurveTo(width * 0.25, 40, width * 0.7, height - 40, width - 40, height * 0.5);
+    context.stroke();
+
+    VISUALIZER_STAGES.forEach((stage, index) => {
+      const ratio = index / (VISUALIZER_STAGES.length - 1);
+      const x = 64 + ratio * (width - 128);
+      const y = height * 0.5 + Math.sin(ratio * Math.PI * 2) * 52;
+      drawStageGlyph(context, stage.id, x, y - 16, FALLBACK_GLYPH_SIZE);
+      context.fillStyle = "#f4f4f5";
+      context.font = "600 11px Arial";
+      context.textAlign = "center";
+      context.fillText(stage.shortLabel, x, y + 52);
+    });
+    context.restore();
+    animationFrame = window.requestAnimationFrame(render);
+  };
+
+  render();
+
+  return () => {
+    window.cancelAnimationFrame(animationFrame);
+  };
+}
+
+function createLabel(text: string): THREE.Sprite {
+  const canvas = document.createElement("canvas");
+  canvas.width = 256;
+  canvas.height = 64;
+  const context = canvas.getContext("2d");
+  if (context) {
+    context.clearRect(0, 0, canvas.width, canvas.height);
+    context.fillStyle = "rgba(10, 10, 10, 0.88)";
+    context.beginPath();
+    context.roundRect(16, 8, canvas.width - 32, canvas.height - 16, 12);
+    context.fill();
+    context.strokeStyle = "rgba(113, 113, 122, 0.72)";
+    context.lineWidth = 2;
+    context.stroke();
+    context.fillStyle = "#f4f4f5";
+    context.font = "600 22px Arial";
+    context.textAlign = "center";
+    context.textBaseline = "middle";
+    context.fillText(text, canvas.width / 2, canvas.height / 2);
+  }
+
+  const texture = new THREE.CanvasTexture(canvas);
+  const material = new THREE.SpriteMaterial({
+    map: texture,
+    transparent: true,
+    depthWrite: false,
+    depthTest: false,
+  });
+  const sprite = new THREE.Sprite(material);
+  sprite.scale.set(1.02, 0.26, 1);
+  return sprite;
+}
+
+function createMaterial(
+  color: THREE.Color = IDLE_COLOR,
+  metalness: number = 0.18
+): THREE.MeshStandardMaterial {
+  return new THREE.MeshStandardMaterial({
+    color,
+    emissive: new THREE.Color(0x000000),
+    roughness: 0.42,
+    metalness,
+    flatShading: true,
+  });
+}
+
+function addMesh(
+  group: THREE.Group,
+  geometry: THREE.BufferGeometry,
+  materials: THREE.MeshStandardMaterial[],
+  configure?: (mesh: THREE.Mesh) => void,
+  color: THREE.Color = IDLE_COLOR,
+  metalness: number = 0.18
+): THREE.Mesh {
+  const material = createMaterial(color, metalness);
+  const mesh = new THREE.Mesh(geometry, material);
+  configure?.(mesh);
+  group.add(mesh);
+  materials.push(material);
+  return mesh;
+}
+
+function addNodeBase(
+  group: THREE.Group,
+  materials: THREE.MeshStandardMaterial[]
+): void {
+  addMesh(
+    group,
+    new THREE.CylinderGeometry(0.42, 0.46, 0.035, 40),
+    materials,
+    (mesh) => {
+      mesh.position.set(0, -0.34, -0.08);
+    },
+    GLASS_COLOR,
+    0.18
+  );
+  addMesh(
+    group,
+    new THREE.TorusGeometry(0.47, 0.012, 8, 56),
+    materials,
+    (mesh) => {
+      mesh.position.set(0, -0.32, -0.06);
+      mesh.rotation.x = Math.PI / 2;
+    },
+    ACCENT_COLOR,
+    0.08
+  );
+}
+
+function createStageIconTexture(stageId: VisualizerStageId): THREE.CanvasTexture {
+  const canvas = document.createElement("canvas");
+  canvas.width = ICON_CANVAS_SIZE;
+  canvas.height = ICON_CANVAS_SIZE;
+  const context = canvas.getContext("2d");
+  if (context) {
+    context.clearRect(0, 0, canvas.width, canvas.height);
+    drawStageGlyph(
+      context,
+      stageId,
+      ICON_CANVAS_SIZE / 2,
+      ICON_CANVAS_SIZE / 2,
+      ICON_CANVAS_SIZE
+    );
+  }
+
+  const texture = new THREE.CanvasTexture(canvas);
+  texture.colorSpace = THREE.SRGBColorSpace;
+  texture.minFilter = THREE.LinearFilter;
+  texture.magFilter = THREE.LinearFilter;
+  return texture;
+}
+
+function createStageSprite(stageId: VisualizerStageId): THREE.Sprite {
+  const texture = createStageIconTexture(stageId);
+
+  const material = new THREE.SpriteMaterial({
+    map: texture,
+    transparent: true,
+    depthWrite: false,
+    depthTest: false,
+  });
+  const sprite = new THREE.Sprite(material);
+  sprite.position.set(0, 0.12, 0.18);
+  sprite.scale.set(STAGE_SPRITE_SIZE, STAGE_SPRITE_SIZE, 1);
+  return sprite;
+}
+
+function createStageVisual(stageId: VisualizerStageId): {
+  group: THREE.Group;
+  materials: THREE.MeshStandardMaterial[];
+} {
+  const group = new THREE.Group();
+  const materials: THREE.MeshStandardMaterial[] = [];
+  addNodeBase(group, materials);
+  group.add(createStageSprite(stageId));
+  return { group, materials };
+}
+
+function disposeMaterial(material: THREE.Material): void {
+  const maybeMappedMaterial = material as THREE.Material & {
+    map?: THREE.Texture | null;
+  };
+  maybeMappedMaterial.map?.dispose();
+  material.dispose();
+}
+
+export function ProfileVisualizerScene({
+  activeStageId,
+  completedStageIds,
+  onStageSelect,
+}: ProfileVisualizerSceneProps): React.ReactElement {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const activeStageRef = useRef(activeStageId);
+  const completedStageIdsRef = useRef(new Set(completedStageIds));
+  const onStageSelectRef = useRef(onStageSelect);
+  const [zoomLevel, setZoomLevel] = useState(DEFAULT_ZOOM);
+  const zoomLevelRef = useRef(DEFAULT_ZOOM);
+  const zoomPercent = Math.round(zoomLevel * 100);
+  const isDefaultZoom = Math.abs(zoomLevel - DEFAULT_ZOOM) < 0.001;
+  const updateZoom = useCallback((nextZoom: number): void => {
+    setZoomLevel(clampZoom(nextZoom));
+  }, []);
+  const zoomOut = useCallback((): void => {
+    setZoomLevel((currentZoom) => clampZoom(currentZoom - ZOOM_STEP));
+  }, []);
+  const zoomIn = useCallback((): void => {
+    setZoomLevel((currentZoom) => clampZoom(currentZoom + ZOOM_STEP));
+  }, []);
+  const resetZoom = useCallback((): void => {
+    updateZoom(DEFAULT_ZOOM);
+  }, [updateZoom]);
+
+  useEffect(() => {
+    activeStageRef.current = activeStageId;
+  }, [activeStageId]);
+
+  useEffect(() => {
+    completedStageIdsRef.current = new Set(completedStageIds);
+  }, [completedStageIds]);
+
+  useEffect(() => {
+    onStageSelectRef.current = onStageSelect;
+  }, [onStageSelect]);
+
+  useEffect(() => {
+    zoomLevelRef.current = zoomLevel;
+  }, [zoomLevel]);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) {
+      return undefined;
+    }
+
+    let renderer: THREE.WebGLRenderer;
+    try {
+      renderer = new THREE.WebGLRenderer({
+        canvas,
+        antialias: true,
+        alpha: false,
+        preserveDrawingBuffer: true,
+      });
+    } catch {
+      return drawFallback(canvas, zoomLevelRef);
+    }
+
+    const scene = new THREE.Scene();
+    scene.background = new THREE.Color(0x050505);
+    const camera = new THREE.PerspectiveCamera(45, 1, 0.1, 100);
+    camera.position.set(SCENE_CENTER.x, SCENE_CENTER.y, CAMERA_DISTANCE);
+    camera.lookAt(SCENE_CENTER);
+
+    const ambientLight = new THREE.AmbientLight(0xffffff, 1.6);
+    const keyLight = new THREE.PointLight(0x93c5fd, 2.7, 14);
+    keyLight.position.set(-3, 4, 5);
+    const rimLight = new THREE.PointLight(0xffffff, 1.4, 12);
+    rimLight.position.set(4, -2, 4);
+    scene.add(ambientLight, keyLight, rimLight);
+
+    const root = new THREE.Group();
+    scene.add(root);
+
+    const nodeMap = new Map<VisualizerStageId, SceneNode>();
+    const pathPoints: THREE.Vector3[] = [];
+
+    VISUALIZER_STAGES.forEach((stage) => {
+      const group = new THREE.Group();
+      const [x, y, z] = NODE_POSITIONS[stage.id];
+      group.position.set(x, y, z);
+      const visual = createStageVisual(stage.id);
+      group.add(visual.group);
+
+      const label = createLabel(stage.shortLabel);
+      label.position.set(0, -0.78, 0);
+      group.add(label);
+      group.traverse((object) => {
+        object.userData.stageId = stage.id;
+      });
+
+      root.add(group);
+      pathPoints.push(group.position.clone());
+      nodeMap.set(stage.id, {
+        group,
+        materials: visual.materials,
+        basePosition: group.position.clone(),
+      });
+    });
+
+    const pathGeometry = new THREE.BufferGeometry().setFromPoints(pathPoints);
+    const pathMaterial = new THREE.LineBasicMaterial({
+      color: 0x71717a,
+      transparent: true,
+      opacity: 0.72,
+    });
+    const pathLine = new THREE.Line(pathGeometry, pathMaterial);
+    root.add(pathLine);
+
+    const packet = new THREE.Mesh(
+      new THREE.IcosahedronGeometry(0.13, 1),
+      new THREE.MeshStandardMaterial({
+        color: ACCENT_COLOR,
+        emissive: new THREE.Color(0x2563eb),
+        emissiveIntensity: 0.8,
+        roughness: 0.18,
+        metalness: 0.2,
+      })
+    );
+    packet.position.copy(pathPoints[0]);
+    root.add(packet);
+
+    const raycaster = new THREE.Raycaster();
+    const pointer = new THREE.Vector2();
+    const handlePointerDown = (event: PointerEvent): void => {
+      if (!onStageSelectRef.current) {
+        return;
+      }
+
+      const bounds = canvas.getBoundingClientRect();
+      pointer.x = ((event.clientX - bounds.left) / bounds.width) * 2 - 1;
+      pointer.y = -(((event.clientY - bounds.top) / bounds.height) * 2 - 1);
+      raycaster.setFromCamera(pointer, camera);
+
+      const selectedStageId = raycaster
+        .intersectObjects(root.children, true)
+        .map((intersection) => intersection.object.userData.stageId)
+        .find((stageId): stageId is VisualizerStageId =>
+          VISUALIZER_STAGES.some((stage) => stage.id === stageId)
+        );
+
+      if (selectedStageId) {
+        onStageSelectRef.current(selectedStageId);
+      }
+    };
+    canvas.addEventListener("pointerdown", handlePointerDown);
+
+    const resize = (): void => {
+      const parent = canvas.parentElement;
+      const width = Math.max(320, parent?.clientWidth ?? canvas.clientWidth);
+      const height = Math.max(260, parent?.clientHeight ?? canvas.clientHeight);
+      renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
+      renderer.setSize(width, height, false);
+      camera.aspect = width / height;
+      camera.updateProjectionMatrix();
+    };
+
+    const reducedMotionQuery = window.matchMedia(
+      "(prefers-reduced-motion: reduce)"
+    );
+    let shouldReduceMotion = reducedMotionQuery.matches;
+    const handleReducedMotionChange = (event: MediaQueryListEvent): void => {
+      shouldReduceMotion = event.matches;
+    };
+    reducedMotionQuery.addEventListener("change", handleReducedMotionChange);
+
+    let animationFrame = 0;
+    const startedAt = performance.now();
+    const animate = (): void => {
+      const elapsed = (performance.now() - startedAt) / 1000;
+      const activeId = activeStageRef.current;
+      const completedIds = completedStageIdsRef.current;
+
+      if (shouldReduceMotion) {
+        root.rotation.set(0, 0, 0);
+      } else {
+        root.rotation.y = Math.sin(elapsed * 0.18) * 0.08;
+        root.rotation.x = Math.sin(elapsed * 0.12) * 0.035;
+      }
+      camera.position.z +=
+        (CAMERA_DISTANCE / zoomLevelRef.current - camera.position.z) * 0.12;
+      camera.position.x += (SCENE_CENTER.x - camera.position.x) * 0.12;
+      camera.position.y += (SCENE_CENTER.y - camera.position.y) * 0.12;
+      camera.lookAt(SCENE_CENTER);
+
+      nodeMap.forEach((node, stageId) => {
+        const isActive = stageId === activeId;
+        const isComplete = completedIds.has(stageId);
+        const color = isActive
+          ? ACTIVE_COLOR
+          : isComplete
+            ? COMPLETE_COLOR
+            : IDLE_COLOR;
+        node.materials.forEach((material) => {
+          material.color.lerp(color, 0.14);
+          material.emissive.lerp(
+            isActive ? ACCENT_COLOR : new THREE.Color(0x000000),
+            0.12
+          );
+          material.emissiveIntensity = isActive ? 0.7 : 0.18;
+        });
+        const pulse =
+          isActive && !shouldReduceMotion
+            ? 1 + Math.sin(elapsed * 5.5) * 0.08
+            : 1;
+        node.group.scale.lerp(new THREE.Vector3(pulse, pulse, pulse), 0.16);
+        node.group.position.y =
+          node.basePosition.y +
+          (isActive && !shouldReduceMotion ? Math.sin(elapsed * 4) * 0.05 : 0);
+      });
+
+      const activeNode = nodeMap.get(activeId);
+      if (activeNode) {
+        packet.position.lerp(activeNode.group.position, 0.08);
+      }
+      if (!shouldReduceMotion) {
+        packet.rotation.x += 0.035;
+        packet.rotation.y += 0.05;
+      }
+
+      renderer.render(scene, camera);
+      animationFrame = window.requestAnimationFrame(animate);
+    };
+
+    resize();
+    window.addEventListener("resize", resize);
+    animate();
+
+    return () => {
+      window.cancelAnimationFrame(animationFrame);
+      window.removeEventListener("resize", resize);
+      canvas.removeEventListener("pointerdown", handlePointerDown);
+      reducedMotionQuery.removeEventListener("change", handleReducedMotionChange);
+      scene.traverse((object) => {
+        if (object instanceof THREE.Mesh) {
+          object.geometry.dispose();
+          const materials = Array.isArray(object.material)
+            ? object.material
+            : [object.material];
+          materials.forEach(disposeMaterial);
+        }
+        if (object instanceof THREE.Sprite) {
+          disposeMaterial(object.material);
+        }
+      });
+      pathGeometry.dispose();
+      pathMaterial.dispose();
+      renderer.dispose();
+    };
+  }, []);
+
+  return (
+    <div className="relative h-full min-h-[260px] w-full bg-black">
+      <canvas
+        ref={canvasRef}
+        className="h-full min-h-[260px] w-full cursor-pointer bg-black"
+        data-testid="profile-visualizer-canvas"
+        aria-label="Three-dimensional LLM architecture visualizer"
+      />
+      <div
+        className="absolute right-3 top-3 flex items-center gap-1 rounded-md border border-gray-800 bg-black/80 p-1 shadow-lg backdrop-blur"
+        aria-label="Visualizer zoom controls"
+      >
+        <button
+          type="button"
+          className="flex h-8 w-8 items-center justify-center rounded-md text-gray-300 transition-colors hover:bg-gray-900 hover:text-white disabled:cursor-not-allowed disabled:text-gray-700 disabled:hover:bg-transparent"
+          aria-label="Zoom out visualizer"
+          title="Zoom out"
+          onClick={zoomOut}
+          disabled={zoomLevel <= MIN_ZOOM}
+          data-testid="profile-visualizer-zoom-out"
+        >
+          <Minus className="h-4 w-4" aria-hidden="true" />
+        </button>
+        <span
+          className="min-w-12 text-center text-xs font-medium text-gray-400"
+          data-testid="profile-visualizer-zoom-value"
+        >
+          {zoomPercent}%
+        </span>
+        <button
+          type="button"
+          className="flex h-8 w-8 items-center justify-center rounded-md text-gray-300 transition-colors hover:bg-gray-900 hover:text-white disabled:cursor-not-allowed disabled:text-gray-700 disabled:hover:bg-transparent"
+          aria-label="Zoom in visualizer"
+          title="Zoom in"
+          onClick={zoomIn}
+          disabled={zoomLevel >= MAX_ZOOM}
+          data-testid="profile-visualizer-zoom-in"
+        >
+          <Plus className="h-4 w-4" aria-hidden="true" />
+        </button>
+        <button
+          type="button"
+          className="flex h-8 w-8 items-center justify-center rounded-md text-gray-300 transition-colors hover:bg-gray-900 hover:text-white disabled:cursor-not-allowed disabled:text-gray-700 disabled:hover:bg-transparent"
+          aria-label="Reset visualizer zoom"
+          title="Reset zoom"
+          onClick={resetZoom}
+          disabled={isDefaultZoom}
+          data-testid="profile-visualizer-zoom-reset"
+        >
+          <RotateCcw className="h-4 w-4" aria-hidden="true" />
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/profile/useTeapotVisualizerTrace.ts
+++ b/src/components/profile/useTeapotVisualizerTrace.ts
@@ -1,0 +1,307 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { WorkerStatus, type WorkerResponse } from "@/types/worker";
+import { getAIService } from "@/services/ai";
+import {
+  VISUALIZER_QUESTION,
+  VISUALIZER_STAGES,
+  type VisualizerStageId,
+} from "./visualizerData";
+
+type TracePhase = "idle" | "preparing" | "loading" | "generating";
+export type TraceStageState = "idle" | "active" | "complete" | "error";
+
+export interface TraceEvent {
+  id: string;
+  label: string;
+  detail: string;
+}
+
+export interface UseTeapotVisualizerTraceReturn {
+  activeStageId: VisualizerStageId;
+  completedStageIds: readonly VisualizerStageId[];
+  errorStageId: VisualizerStageId | null;
+  isRunning: boolean;
+  streamedAnswer: string;
+  loadingMessage: string | null;
+  progress: number | null;
+  traceEvents: readonly TraceEvent[];
+  runTrace: (question: string) => void;
+  getStageState: (stageId: VisualizerStageId) => TraceStageState;
+}
+
+const STAGE_ORDER = VISUALIZER_STAGES.map((stage) => stage.id);
+const PRE_WORKER_STAGE_DELAYS: readonly [VisualizerStageId, number][] = [
+  ["question", 0],
+  ["cleaning", 320],
+  ["retrieval", 660],
+  ["budgeting", 980],
+  ["worker", 1_320],
+];
+const GENERATION_STAGE_DELAYS: readonly [VisualizerStageId, number][] = [
+  ["lora", 360],
+  ["decoder", 760],
+];
+const RUNTIME_START_DELAY = 520;
+const GENERATE_AFTER_LOAD_DELAY = 420;
+const FINISH_AFTER_DONE_DELAY = 1_060;
+
+function getCompletedBefore(stageId: VisualizerStageId): VisualizerStageId[] {
+  const stageIndex = STAGE_ORDER.indexOf(stageId);
+  return stageIndex <= 0 ? [] : STAGE_ORDER.slice(0, stageIndex);
+}
+
+function eventId(): string {
+  return `${Date.now()}-${Math.random().toString(36).slice(2, 9)}`;
+}
+
+export function useTeapotVisualizerTrace(): UseTeapotVisualizerTraceReturn {
+  const [activeStageId, setActiveStageId] =
+    useState<VisualizerStageId>("question");
+  const [completedStageIds, setCompletedStageIds] = useState<
+    readonly VisualizerStageId[]
+  >([]);
+  const [errorStageId, setErrorStageId] = useState<VisualizerStageId | null>(
+    null
+  );
+  const [isRunning, setIsRunning] = useState(false);
+  const [streamedAnswer, setStreamedAnswer] = useState("");
+  const [loadingMessage, setLoadingMessage] = useState<string | null>(null);
+  const [progress, setProgress] = useState<number | null>(null);
+  const [traceEvents, setTraceEvents] = useState<readonly TraceEvent[]>([]);
+  const activeStageIdRef = useRef<VisualizerStageId>("question");
+  const questionRef = useRef(VISUALIZER_QUESTION);
+  const phaseRef = useRef<TracePhase>("idle");
+  const timersRef = useRef<number[]>([]);
+  const loadFailedRef = useRef(false);
+  const hasGeneratedRef = useRef(false);
+
+  const clearTimers = useCallback((): void => {
+    timersRef.current.forEach((timerId) => window.clearTimeout(timerId));
+    timersRef.current = [];
+  }, []);
+
+  const pushEvent = useCallback((label: string, detail: string): void => {
+    setTraceEvents((events) => [
+      ...events,
+      {
+        id: eventId(),
+        label,
+        detail,
+      },
+    ]);
+  }, []);
+
+  const activateStage = useCallback((stageId: VisualizerStageId): void => {
+    activeStageIdRef.current = stageId;
+    setActiveStageId(stageId);
+    setCompletedStageIds(getCompletedBefore(stageId));
+  }, []);
+
+  const scheduleStage = useCallback(
+    (stageId: VisualizerStageId, delay: number, onActivate?: () => void): void => {
+      const timerId = window.setTimeout(() => {
+        if (phaseRef.current === "idle") {
+          return;
+        }
+        if (
+          STAGE_ORDER.indexOf(stageId) <=
+          STAGE_ORDER.indexOf(activeStageIdRef.current)
+        ) {
+          return;
+        }
+        activateStage(stageId);
+        onActivate?.();
+      }, delay);
+      timersRef.current.push(timerId);
+    },
+    [activateStage]
+  );
+
+  const finishTrace = useCallback((): void => {
+    clearTimers();
+    phaseRef.current = "idle";
+    setIsRunning(false);
+    setErrorStageId(null);
+    setActiveStageId("decoder");
+    setCompletedStageIds(STAGE_ORDER);
+    pushEvent("done", "The worker reported completion for this trace.");
+  }, [clearTimers, pushEvent]);
+
+  const handleWorkerResponse = useCallback(
+    (response: WorkerResponse): void => {
+      if (phaseRef.current === "idle") {
+        return;
+      }
+
+      switch (response.status) {
+        case WorkerStatus.LOAD: {
+          const message = response.message ?? "Loading model...";
+          activateStage("runtime");
+          setLoadingMessage(message);
+          setProgress(response.progress ?? null);
+          pushEvent("load", message);
+          return;
+        }
+
+        case WorkerStatus.INITIATE:
+          phaseRef.current = "generating";
+          activateStage("encoder");
+          pushEvent("initiate", "The worker accepted the prompt and began generation.");
+          GENERATION_STAGE_DELAYS.forEach(([stageId, delay]) => {
+            scheduleStage(stageId, delay);
+          });
+          return;
+
+        case WorkerStatus.STREAM:
+          if (response.response) {
+            setStreamedAnswer((answer) => `${answer}${response.response}`);
+            pushEvent("stream", response.response);
+          }
+          return;
+
+        case WorkerStatus.ERROR:
+          loadFailedRef.current = true;
+          phaseRef.current = "idle";
+          setIsRunning(false);
+          setErrorStageId(activeStageIdRef.current);
+          setLoadingMessage(response.message ?? null);
+          pushEvent("error", response.error ?? "Unknown worker error");
+          return;
+
+        case WorkerStatus.DONE:
+          if (phaseRef.current === "loading") {
+            if (loadFailedRef.current) {
+              return;
+            }
+            const timerId = window.setTimeout(() => {
+              if (phaseRef.current !== "loading" || loadFailedRef.current) {
+                return;
+              }
+
+              phaseRef.current = "generating";
+              pushEvent("generate", `Sending: ${questionRef.current}`);
+              getAIService().generate(questionRef.current);
+            }, GENERATE_AFTER_LOAD_DELAY);
+            timersRef.current.push(timerId);
+            return;
+          }
+
+          if (phaseRef.current === "generating") {
+            const timerId = window.setTimeout(() => {
+              if (phaseRef.current === "generating") {
+                finishTrace();
+              }
+            }, FINISH_AFTER_DONE_DELAY);
+            timersRef.current.push(timerId);
+          }
+          return;
+
+        default:
+          return;
+      }
+    },
+    [activateStage, finishTrace, pushEvent, scheduleStage]
+  );
+
+  useEffect(() => {
+    const aiService = getAIService();
+    const unsubscribe = aiService.subscribe(handleWorkerResponse);
+
+    return () => {
+      unsubscribe();
+      clearTimers();
+    };
+  }, [clearTimers, handleWorkerResponse]);
+
+  const runTrace = useCallback((question: string): void => {
+    if (isRunning) {
+      return;
+    }
+
+    const nextQuestion = question.trim() || VISUALIZER_QUESTION;
+    questionRef.current = nextQuestion;
+    clearTimers();
+    loadFailedRef.current = false;
+    hasGeneratedRef.current = false;
+    phaseRef.current = "preparing";
+    setIsRunning(true);
+    setStreamedAnswer("");
+    setLoadingMessage("Preparing worker trace...");
+    setProgress(null);
+    setTraceEvents([]);
+    setErrorStageId(null);
+    activateStage("question");
+    pushEvent("question", nextQuestion);
+
+    PRE_WORKER_STAGE_DELAYS.forEach(([stageId, delay]) => {
+      scheduleStage(stageId, delay, () => {
+        if (stageId !== "worker" || hasGeneratedRef.current) {
+          return;
+        }
+
+        hasGeneratedRef.current = true;
+        phaseRef.current = "loading";
+        setLoadingMessage("Starting browser worker...");
+
+        const timerId = window.setTimeout(() => {
+          if (phaseRef.current !== "loading" || loadFailedRef.current) {
+            return;
+          }
+
+          activateStage("runtime");
+          const aiService = getAIService();
+          if (aiService.isModelReady()) {
+            setLoadingMessage("Using loaded ONNX runtime...");
+            setProgress(100);
+            pushEvent("load", "Using the model already loaded by the chat window.");
+
+            const generateTimerId = window.setTimeout(() => {
+              if (phaseRef.current !== "loading" || loadFailedRef.current) {
+                return;
+              }
+
+              phaseRef.current = "generating";
+              pushEvent("generate", `Sending: ${questionRef.current}`);
+              aiService.generate(questionRef.current);
+            }, GENERATE_AFTER_LOAD_DELAY);
+            timersRef.current.push(generateTimerId);
+            return;
+          }
+
+          setLoadingMessage("Loading ONNX runtime...");
+          if (!aiService.isInitialized()) {
+            aiService.initialize();
+          }
+          aiService.loadModel();
+        }, RUNTIME_START_DELAY);
+        timersRef.current.push(timerId);
+      });
+    });
+  }, [activateStage, clearTimers, isRunning, pushEvent, scheduleStage]);
+
+  const getStageState = useCallback(
+    (stageId: VisualizerStageId): TraceStageState => {
+      if (errorStageId === stageId) {
+        return "error";
+      }
+      if (activeStageId === stageId && isRunning) {
+        return "active";
+      }
+      return completedStageIds.includes(stageId) ? "complete" : "idle";
+    },
+    [activeStageId, completedStageIds, errorStageId, isRunning]
+  );
+
+  return {
+    activeStageId,
+    completedStageIds,
+    errorStageId,
+    isRunning,
+    streamedAnswer,
+    loadingMessage,
+    progress,
+    traceEvents,
+    runTrace,
+    getStageState,
+  };
+}

--- a/src/components/profile/visualizerData.ts
+++ b/src/components/profile/visualizerData.ts
@@ -1,0 +1,121 @@
+import { MODEL_CONTEXT_LIMIT, MODEL_ID } from "@/config/models";
+
+export const VISUALIZER_QUESTION = "What is Justin's current job at OpenAI?";
+export const TEAPOT_BASE_MODEL_ID = "teapotai/teapotllm";
+export const TEAPOT_EMBEDDING_MODEL_ID = "teapotai/teapotembedding";
+
+export type VisualizerStageId =
+  | "question"
+  | "cleaning"
+  | "retrieval"
+  | "budgeting"
+  | "worker"
+  | "runtime"
+  | "encoder"
+  | "lora"
+  | "decoder";
+
+export interface VisualizerStage {
+  id: VisualizerStageId;
+  label: string;
+  shortLabel: string;
+  detail: string;
+}
+
+export const VISUALIZER_STAGES: readonly VisualizerStage[] = [
+  {
+    id: "question",
+    label: "User question",
+    shortLabel: "Question",
+    detail: "The trace starts with the exact prompt sent by the play button.",
+  },
+  {
+    id: "cleaning",
+    label: "Input cleaning",
+    shortLabel: "Clean",
+    detail: "The worker normalizes punctuation, removes risky brackets, and trims whitespace.",
+  },
+  {
+    id: "retrieval",
+    label: "Profile retrieval",
+    shortLabel: "RAG",
+    detail:
+      "The browser path ranks local profile sections; Teapot's model card reports upstream RAG tuning across multiple documents with its embedding model.",
+  },
+  {
+    id: "budgeting",
+    label: "Prompt budgeting",
+    shortLabel: "Budget",
+    detail: `The prompt is packed for the ${MODEL_CONTEXT_LIMIT}-token browser budget.`,
+  },
+  {
+    id: "worker",
+    label: "Browser worker",
+    shortLabel: "Worker",
+    detail: "Generation runs off the main thread through the shared AI worker service.",
+  },
+  {
+    id: "runtime",
+    label: "ONNX browser runtime",
+    shortLabel: "ONNX",
+    detail:
+      "Transformers.js loads the promoted ONNX artifact in WASM before generation starts.",
+  },
+  {
+    id: "encoder",
+    label: "T5 encoder",
+    shortLabel: "Encoder",
+    detail:
+      "TeapotLLM uses a T5 encoder-decoder config, so the packed context is encoded before answer decoding.",
+  },
+  {
+    id: "lora",
+    label: "LoRA-trained attention",
+    shortLabel: "q/v trained",
+    detail:
+      "The profile continuation trained q and v attention adapters, then merged that behavior into the exported model.",
+  },
+  {
+    id: "decoder",
+    label: "Decode and render",
+    shortLabel: "Answer",
+    detail:
+      "The decoder produces grounded answer tokens and renders the stream in one final trace step.",
+  },
+];
+
+export interface ModelFact {
+  label: string;
+  value: string;
+}
+
+export const MODEL_FACTS: readonly ModelFact[] = [
+  {
+    label: "Browser model",
+    value: MODEL_ID,
+  },
+  {
+    label: "Upstream base",
+    value: TEAPOT_BASE_MODEL_ID,
+  },
+  {
+    label: "Architecture",
+    value: "T5 encoder-decoder via seq2seq generation",
+  },
+  {
+    label: "Upstream RAG",
+    value: `model-card reported ${TEAPOT_EMBEDDING_MODEL_ID} multi-document RAG tuning`,
+  },
+  {
+    label: "Browser dtype",
+    value: "int8 preferred, uint8 fallback",
+  },
+  {
+    label: "LoRA targets",
+    value: "q and v attention projections",
+  },
+  {
+    label: "LoRA settings",
+    value: "rank 16, alpha 32, dropout 0.03",
+  },
+];

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,6 +1,7 @@
-import { Fragment, useState } from "react";
+import { Fragment, useRef, useState } from "react";
 import dynamic from "next/dynamic";
 import Head from "next/head";
+import { Bot } from "@deemlol/next-icons";
 import { SITE_CONFIG } from "@/config/site";
 import { LinkIconButton } from "@/components/links";
 import { GitHubProfile } from "@/components/profile";
@@ -8,6 +9,11 @@ import { ResumeViewer } from "@/components/resume";
 
 const ChatContainer = dynamic(
   () => import("@/components/chat").then((mod) => ({ default: mod.ChatContainer })),
+  { ssr: false }
+);
+
+const ProfileVisualizerModal = dynamic(
+  () => import("@/components/profile/ProfileVisualizerModal"),
   { ssr: false }
 );
 
@@ -19,6 +25,19 @@ interface SocialLinkItem {
 
 export default function Home(): React.ReactElement {
   const [showChatBox, setShowChatBox] = useState(false);
+  const [showProfileVisualizer, setShowProfileVisualizer] = useState(false);
+  const chatButtonRef = useRef<HTMLButtonElement>(null);
+
+  function focusChatButtonSoon(): void {
+    window.requestAnimationFrame(() => {
+      chatButtonRef.current?.focus();
+    });
+  }
+
+  function closeChatBox(): void {
+    setShowChatBox(false);
+    focusChatButtonSoon();
+  }
 
   const socialLinks: SocialLinkItem[] = [
     {
@@ -80,20 +99,38 @@ export default function Home(): React.ReactElement {
           ))}
         </footer>
 
-        {!showChatBox && (
+        {!showChatBox && !showProfileVisualizer && (
           <button
-            className="fixed border bottom-4 right-4 bg-black text-white p-3 rounded-lg shadow-lg hover:bg-gray-800 transition-colors duration-200 flex items-center gap-2"
+            ref={chatButtonRef}
+            type="button"
+            className="fixed bottom-4 right-4 z-40 flex items-center gap-2 rounded-lg border border-gray-700 bg-black px-3 py-3 text-white shadow-lg transition-colors duration-200 hover:border-gray-500 hover:bg-gray-900 focus:outline-none focus:ring-2 focus:ring-gray-300"
             onClick={() => setShowChatBox(true)}
+            aria-label="Open AI chatbot"
             data-testid="ai-chatbot-button"
           >
+            <Bot className="h-5 w-5" aria-hidden="true" />
             <span className="text-lg hidden sm:inline">AI Chatbot</span>
-            <svg className="w-5 h-5" fill="currentColor" viewBox="2 0 20 26">
-              <path d="M12 2C6.477 2 2 6.477 2 12c0 1.89.525 3.66 1.438 5.168L2.546 20.2A1 1 0 003.8 21.454l3.032-.892A9.958 9.958 0 0012 22c5.523 0 10-4.477 10-10S17.523 2 12 2zm-3 9a1 1 0 100-2 1 1 0 000 2zm3 0a1 1 0 100-2 1 1 0 000 2zm3 0a1 1 0 100-2 1 1 0 000 2z" />
-            </svg>
           </button>
         )}
 
-        {showChatBox && <ChatContainer onClose={() => setShowChatBox(false)} />}
+        {showChatBox && !showProfileVisualizer && (
+          <ChatContainer
+            onClose={closeChatBox}
+            onOpenVisualizer={() => {
+              setShowChatBox(false);
+              setShowProfileVisualizer(true);
+            }}
+          />
+        )}
+
+        {showProfileVisualizer && (
+          <ProfileVisualizerModal
+            onClose={() => {
+              setShowProfileVisualizer(false);
+              focusChatButtonSoon();
+            }}
+          />
+        )}
       </div>
     </Fragment>
   );

--- a/src/services/ai/service.ts
+++ b/src/services/ai/service.ts
@@ -3,7 +3,7 @@
  * Clean API for interacting with the AI worker.
  */
 
-import { WorkerAction, type WorkerResponse } from "@/types/worker";
+import { WorkerAction, WorkerStatus, type WorkerResponse } from "@/types/worker";
 import type { ConversationTurn } from "@/types";
 import { createLogger, LOG_AREAS } from "@/utils";
 
@@ -12,6 +12,7 @@ const logger = createLogger(LOG_AREAS.AI_SERVICE);
 
 export class AIService {
   private worker: Worker | null = null;
+  private modelLoaded = false;
   private callbacks: Set<AIServiceCallback> = new Set();
 
   /**
@@ -29,7 +30,18 @@ export class AIService {
     });
 
     this.worker.onmessage = (event: MessageEvent<WorkerResponse>) => {
-      this.callbacks.forEach((callback) => callback(event.data));
+      const response = event.data;
+      if (
+        response.status === WorkerStatus.LOAD &&
+        response.message?.includes("successfully")
+      ) {
+        this.modelLoaded = true;
+      }
+      if (response.status === WorkerStatus.ERROR) {
+        this.modelLoaded = false;
+      }
+
+      this.callbacks.forEach((callback) => callback(response));
     };
 
     this.worker.postMessage({
@@ -88,6 +100,7 @@ export class AIService {
       this.worker.terminate();
       this.worker = null;
     }
+    this.modelLoaded = false;
   }
 
   /**
@@ -95,6 +108,13 @@ export class AIService {
    */
   isInitialized(): boolean {
     return this.worker !== null;
+  }
+
+  /**
+   * Check if the current worker has completed model loading.
+   */
+  isModelReady(): boolean {
+    return this.modelLoaded;
   }
 }
 

--- a/tests/export.spec.ts
+++ b/tests/export.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect, type Page } from "@playwright/test";
 import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
 import { access, readFile, readdir } from "node:fs/promises";
 import path from "node:path";
@@ -73,6 +73,45 @@ async function readExportedJavaScript(): Promise<string> {
 interface StaticPreviewServer {
   origin: string;
   close: () => Promise<void>;
+}
+
+async function mockReadyModelWorker(page: Page): Promise<void> {
+  await page.addInitScript(() => {
+    interface MockWorkerMessage {
+      action?: string;
+    }
+
+    interface MockWorkerResponse {
+      status: string;
+      message?: string;
+      response?: string;
+    }
+
+    class MockWorker {
+      onmessage: ((event: MessageEvent<MockWorkerResponse>) => void) | null =
+        null;
+
+      postMessage(message: MockWorkerMessage): void {
+        if (message.action === "load") {
+          window.setTimeout(() => {
+            this.emit({
+              status: "load",
+              message: "Model loaded successfully!",
+            });
+            this.emit({ status: "done" });
+          }, 0);
+        }
+      }
+
+      terminate(): void {}
+
+      private emit(response: MockWorkerResponse): void {
+        this.onmessage?.(new MessageEvent("message", { data: response }));
+      }
+    }
+
+    window.Worker = MockWorker as unknown as typeof Worker;
+  });
 }
 
 async function startStaticPreviewServer(): Promise<StaticPreviewServer> {
@@ -189,12 +228,7 @@ test("should export the current browser AI worker bundle", async () => {
   const exportedJavaScript = await readExportedJavaScript();
 
   expect(exportedJavaScript).toContain("justinthelaw/teapot-profile-qa-browser-1024");
-  expect(exportedJavaScript).not.toContain("teapotai/teapotllm");
   expect(exportedJavaScript).toContain("text2text-generation");
-  expect(exportedJavaScript).not.toContain(
-    "justinthelaw/Qwen2.5-0.5B-Instruct-Resume-Cover-Letter-SFT",
-  );
-  expect(exportedJavaScript).not.toContain("onnx-community/Qwen2.5-0.5B-Instruct");
 });
 
 test("should embed the resume with Drive preview instead of a download viewer", async () => {
@@ -278,6 +312,39 @@ test("should initialize the exported AI worker from the base path", async ({
       )
       .toBeTruthy();
 
+    expect(staticFailures).toEqual([]);
+  } finally {
+    await previewServer.close();
+  }
+});
+
+test("should load the exported LLM Visualizer from the base path", async ({
+  page,
+}) => {
+  const previewServer = await startStaticPreviewServer();
+  const staticFailures: string[] = [];
+
+  page.on("response", (response) => {
+    const responseUrl = response.url();
+    if (responseUrl.includes("/_next/static/") && response.status() >= 400) {
+      staticFailures.push(`${response.status()} ${responseUrl}`);
+    }
+  });
+
+  try {
+    await mockReadyModelWorker(page);
+    await page.goto(previewServer.origin);
+    await page.getByTestId("ai-chatbot-button").click();
+    await expect(page.getByTestId("chat-input")).toBeVisible({
+      timeout: 10_000,
+    });
+    await expect(page.getByTestId("profile-visualizer-button")).toBeEnabled({
+      timeout: 10_000,
+    });
+    await page.getByTestId("profile-visualizer-button").click();
+
+    await expect(page.getByTestId("profile-visualizer-modal")).toBeVisible();
+    await expect(page.getByTestId("profile-visualizer-canvas")).toBeVisible();
     expect(staticFailures).toEqual([]);
   } finally {
     await previewServer.close();

--- a/tests/visualizer.spec.ts
+++ b/tests/visualizer.spec.ts
@@ -1,0 +1,444 @@
+import { test, expect, type Page } from "@playwright/test";
+
+const VISUALIZER_QUESTION = "What role does Justin have at OpenAI?";
+const MOCK_ANSWER = "Justin currently works at OpenAI.";
+const HELD_LOADING_MESSAGE = "Downloading model... 42%";
+const HOLD_MODEL_LOADING_SESSION_KEY = "__holdVisualizerModelLoading";
+
+interface MockWorkerMessage {
+  action?: string;
+  input?: string;
+  conversationTurns?: Array<{
+    role: string;
+    content: string;
+  }>;
+}
+
+interface MockWorkerInitOptions {
+  answer: string;
+  heldLoadingMessage: string;
+  holdModelLoadingSessionKey: string;
+}
+
+async function mockModelWorker(page: Page): Promise<void> {
+  await page.addInitScript((options: MockWorkerInitOptions) => {
+    interface LocalMockWorkerMessage {
+      action?: string;
+      input?: string;
+      conversationTurns?: Array<{
+        role: string;
+        content: string;
+      }>;
+    }
+
+    interface LocalMockWorkerResponse {
+      status: string;
+      message?: string;
+      response?: string;
+      progress?: number;
+    }
+
+    class MockWorker {
+      onmessage: ((event: MessageEvent<LocalMockWorkerResponse>) => void) | null =
+        null;
+
+      postMessage(message: LocalMockWorkerMessage): void {
+        const mockWindow = window as unknown as {
+          __mockWorkerMessages: LocalMockWorkerMessage[];
+        };
+        mockWindow.__mockWorkerMessages.push(message);
+
+        if (message.action === "load") {
+          if (
+            window.sessionStorage.getItem(options.holdModelLoadingSessionKey) ===
+            "true"
+          ) {
+            window.setTimeout(() => {
+              this.emit({
+                status: "load",
+                message: options.heldLoadingMessage,
+                progress: 42,
+              });
+            }, 10);
+            return;
+          }
+
+          window.setTimeout(() => {
+            this.emit({
+              status: "load",
+              message: "Downloading model... 42%",
+              progress: 42,
+            });
+            this.emit({
+              status: "load",
+              message: "Model loaded successfully!",
+              progress: 100,
+            });
+            this.emit({ status: "done" });
+          }, 10);
+          return;
+        }
+
+        if (message.action === "generate") {
+          window.setTimeout(() => {
+            this.emit({ status: "initiate" });
+            this.emit({ status: "stream", response: "Justin currently " });
+            this.emit({ status: "stream", response: "works at OpenAI." });
+            this.emit({ status: "done" });
+          }, 10);
+        }
+      }
+
+      terminate(): void {}
+
+      private emit(response: LocalMockWorkerResponse): void {
+        this.onmessage?.(new MessageEvent("message", { data: response }));
+      }
+    }
+
+    const mockWindow = window as unknown as {
+      __mockWorkerMessages: LocalMockWorkerMessage[];
+      __mockAnswer: string;
+    };
+    mockWindow.__mockWorkerMessages = [];
+    mockWindow.__mockAnswer = options.answer;
+    window.Worker = MockWorker as unknown as typeof Worker;
+  }, {
+    answer: MOCK_ANSWER,
+    heldLoadingMessage: HELD_LOADING_MESSAGE,
+    holdModelLoadingSessionKey: HOLD_MODEL_LOADING_SESSION_KEY,
+  });
+}
+
+async function openVisualizer(page: Page): Promise<void> {
+  await page.getByTestId("ai-chatbot-button").click();
+  await expect(page.getByTestId("chat-input")).toBeVisible({
+    timeout: 10_000,
+  });
+  await expect(page.getByTestId("profile-visualizer-button")).toBeEnabled({
+    timeout: 10_000,
+  });
+  await page.getByTestId("profile-visualizer-button").click();
+  await expect(page.getByTestId("profile-visualizer-modal")).toBeVisible();
+}
+
+async function getTraceCardCenterDelta(
+  page: Page,
+  stageId: string
+): Promise<number> {
+  return page.evaluate((nextStageId) => {
+    const traceList = document.querySelector(
+      '[data-testid="profile-visualizer-trace-list"]'
+    );
+    const traceCard = document.querySelector(
+      `[data-testid="profile-visualizer-transform-${nextStageId}"]`
+    );
+
+    if (!traceList || !traceCard) {
+      return Number.POSITIVE_INFINITY;
+    }
+
+    const traceListRect = traceList.getBoundingClientRect();
+    const traceCardRect = traceCard.getBoundingClientRect();
+    const traceListCenter = traceListRect.top + traceListRect.height / 2;
+    const traceCardCenter = traceCardRect.top + traceCardRect.height / 2;
+
+    return Math.abs(traceCardCenter - traceListCenter);
+  }, stageId);
+}
+
+test.describe("LLM Visualizer", () => {
+  test.beforeEach(async ({ page }) => {
+    await mockModelWorker(page);
+    await page.goto("/");
+  });
+
+  test("opens, closes with Escape, and returns focus to the trigger", async ({
+    page,
+  }) => {
+    const chatButton = page.getByTestId("ai-chatbot-button");
+    await chatButton.click();
+    await expect(page.getByTestId("chat-input")).toBeVisible({
+      timeout: 10_000,
+    });
+    const trigger = page.getByTestId("profile-visualizer-button");
+    await expect(trigger).toBeEnabled({
+      timeout: 10_000,
+    });
+    await trigger.focus();
+    await page.keyboard.press("Enter");
+
+    const modal = page.getByTestId("profile-visualizer-modal");
+    await expect(modal).toBeVisible();
+    await expect(modal).toHaveAttribute("role", "dialog");
+    await expect(modal).toHaveAttribute("aria-modal", "true");
+
+    await page.keyboard.press("Escape");
+    await expect(modal).toHaveCount(0);
+    await expect(chatButton).toBeFocused();
+  });
+
+  test("keeps tab focus contained inside the modal", async ({ page }) => {
+    await openVisualizer(page);
+
+    for (let index = 0; index < 14; index += 1) {
+      await page.keyboard.press("Tab");
+      const isFocusInsideModal = await page.evaluate(() => {
+        return Boolean(
+          document.activeElement?.closest(
+            '[data-testid="profile-visualizer-modal"]'
+          )
+        );
+      });
+      expect(isFocusInsideModal).toBe(true);
+    }
+  });
+
+  test("shows header icon tooltips beside the clear button", async ({
+    page,
+  }) => {
+    await page.getByTestId("ai-chatbot-button").click();
+    await expect(page.getByTestId("chat-input")).toBeVisible({
+      timeout: 10_000,
+    });
+
+    const clearButtonBox = await page.getByTestId("chat-clear-button").boundingBox();
+    const visualizerButton = page.getByTestId("profile-visualizer-button");
+    await expect(visualizerButton).toBeEnabled({
+      timeout: 10_000,
+    });
+    const visualizerButtonBox = await visualizerButton.boundingBox();
+
+    expect(clearButtonBox).not.toBeNull();
+    expect(visualizerButtonBox).not.toBeNull();
+    expect(
+      Math.abs(clearButtonBox!.y - visualizerButtonBox!.y)
+    ).toBeLessThanOrEqual(2);
+    expect(visualizerButtonBox!.x).toBeGreaterThan(clearButtonBox!.x);
+
+    await expect(page.getByTestId("profile-visualizer-tooltip")).toBeHidden();
+    await visualizerButton.focus();
+    await expect(page.getByTestId("profile-visualizer-tooltip")).toBeVisible();
+    await expect(page.getByTestId("profile-visualizer-tooltip")).toHaveText(
+      "LLM Visualizer"
+    );
+
+    await visualizerButton.blur();
+    await expect(page.getByTestId("chat-clear-tooltip")).toBeHidden();
+    await page.getByTestId("chat-clear-button").focus();
+    await expect(page.getByTestId("chat-clear-tooltip")).toBeVisible();
+    await expect(page.getByTestId("chat-clear-tooltip")).toHaveText(
+      "Clear chat history"
+    );
+  });
+
+  test("shows randomized profile question suggestions", async ({ page }) => {
+    await openVisualizer(page);
+
+    const suggestionTexts = await page
+      .getByTestId("profile-visualizer-suggestion")
+      .allTextContents();
+
+    expect(suggestionTexts).toHaveLength(4);
+    expect(new Set(suggestionTexts).size).toBe(suggestionTexts.length);
+    suggestionTexts.forEach((suggestion) => {
+      expect(suggestion).toMatch(/Justin|OpenAI|Defense Unicorns|recommendations/i);
+    });
+  });
+
+  test("aligns the send button with the question input", async ({ page }) => {
+    await openVisualizer(page);
+
+    const alignment = await page.evaluate(() => {
+      const input = document.querySelector(
+        '[data-testid="profile-visualizer-question"]'
+      );
+      const sendButton = document.querySelector(
+        '[data-testid="profile-visualizer-play"]'
+      );
+
+      if (!input || !sendButton) {
+        return {
+          bottomDelta: Number.POSITIVE_INFINITY,
+          heightDelta: Number.POSITIVE_INFINITY,
+        };
+      }
+
+      const inputRect = input.getBoundingClientRect();
+      const sendButtonRect = sendButton.getBoundingClientRect();
+
+      return {
+        bottomDelta: Math.abs(inputRect.bottom - sendButtonRect.bottom),
+        heightDelta: Math.abs(inputRect.height - sendButtonRect.height),
+      };
+    });
+
+    await expect(page.getByTestId("profile-visualizer-play")).toHaveClass(
+      "h-11 w-full rounded-lg bg-blue-600 px-0 font-medium text-white transition-colors duration-200 hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:bg-blue-600"
+    );
+    await expect(page.getByTestId("profile-visualizer-play")).toHaveText("Send");
+    expect(alignment.bottomDelta).toBeLessThanOrEqual(1);
+    expect(alignment.heightDelta).toBeLessThanOrEqual(1);
+  });
+
+  test("keeps the launcher disabled until the chat model is loaded", async ({
+    page,
+  }) => {
+    await page.evaluate((sessionKey) => {
+      sessionStorage.setItem(sessionKey, "true");
+    }, HOLD_MODEL_LOADING_SESSION_KEY);
+    await page.reload();
+
+    await page.getByTestId("ai-chatbot-button").click();
+    await expect(page.getByTestId("chat-input")).toBeVisible({
+      timeout: 10_000,
+    });
+
+    const visualizerButton = page.getByTestId("profile-visualizer-button");
+    await expect(visualizerButton).toBeDisabled();
+    await expect(visualizerButton).toHaveAttribute(
+      "aria-label",
+      "Open LLM Visualizer"
+    );
+  });
+
+  test("closes the chat overlay when opened", async ({ page }) => {
+    await openVisualizer(page);
+    await expect(page.getByTestId("chat-input")).toHaveCount(0);
+  });
+
+  test("renders nonblank canvas pixels", async ({ page }) => {
+    await openVisualizer(page);
+    const canvas = page.getByTestId("profile-visualizer-canvas");
+    await expect(canvas).toBeVisible();
+    await page.waitForTimeout(500);
+
+    const nonBlackPixels = await canvas.evaluate((element) => {
+      const canvasElement = element as HTMLCanvasElement;
+      const gl =
+        canvasElement.getContext("webgl2") ??
+        canvasElement.getContext("webgl");
+      if (gl) {
+        const width = gl.drawingBufferWidth;
+        const height = gl.drawingBufferHeight;
+        const pixels = new Uint8Array(width * height * 4);
+        gl.readPixels(0, 0, width, height, gl.RGBA, gl.UNSIGNED_BYTE, pixels);
+        let count = 0;
+        for (let index = 0; index < pixels.length; index += 4) {
+          if (pixels[index] + pixels[index + 1] + pixels[index + 2] > 24) {
+            count += 1;
+          }
+        }
+        return count;
+      }
+
+      const context = canvasElement.getContext("2d");
+      if (!context) {
+        return 0;
+      }
+      const imageData = context.getImageData(
+        0,
+        0,
+        canvasElement.width,
+        canvasElement.height
+      );
+      let count = 0;
+      for (let index = 0; index < imageData.data.length; index += 4) {
+        if (
+          imageData.data[index] +
+            imageData.data[index + 1] +
+            imageData.data[index + 2] >
+          24
+        ) {
+          count += 1;
+        }
+      }
+      return count;
+    });
+
+    expect(nonBlackPixels).toBeGreaterThan(100);
+  });
+
+  test("offers zoom controls for the scene", async ({ page }) => {
+    await openVisualizer(page);
+
+    const zoomValue = page.getByTestId("profile-visualizer-zoom-value");
+    await expect(zoomValue).toHaveText("100%");
+
+    await page.getByTestId("profile-visualizer-zoom-in").click();
+    await expect(zoomValue).toHaveText("114%");
+    await expect(page.getByTestId("profile-visualizer-zoom-reset")).toBeEnabled();
+
+    await page.getByTestId("profile-visualizer-zoom-reset").click();
+    await expect(zoomValue).toHaveText("100%");
+
+    await page.getByTestId("profile-visualizer-zoom-out").click();
+    await expect(zoomValue).toHaveText("86%");
+
+    await page.getByTestId("profile-visualizer-zoom-reset").click();
+    for (let index = 0; index < 6; index += 1) {
+      await page.getByTestId("profile-visualizer-zoom-in").click();
+    }
+    await expect(zoomValue).toHaveText("184%");
+    await expect(page.getByTestId("profile-visualizer-zoom-in")).toBeDisabled();
+  });
+
+  test("runs the real service path with mocked worker streaming", async ({
+    page,
+  }) => {
+    await openVisualizer(page);
+    await page.getByTestId("profile-visualizer-question").fill(VISUALIZER_QUESTION);
+    await expect(
+      page.getByTestId("profile-visualizer-transform-question")
+    ).toContainText(VISUALIZER_QUESTION);
+    await expect(
+      page.getByTestId("profile-visualizer-transform-worker")
+    ).toContainText("Context:");
+    await expect(
+      page.getByTestId("profile-visualizer-transform-worker")
+    ).toContainText("Question:");
+    await expect(
+      page.getByTestId("profile-visualizer-transform-worker")
+    ).toContainText(VISUALIZER_QUESTION);
+    await expect(
+      page.getByTestId("profile-visualizer-transform-worker")
+    ).toContainText("Answer:");
+    await expect(
+      page.getByTestId("profile-visualizer-transform-retrieval")
+    ).toContainText("teapotai/teapotembedding");
+
+    await page.getByTestId("profile-visualizer-stage-decoder").click();
+    await expect
+      .poll(() => getTraceCardCenterDelta(page, "decoder"))
+      .toBeLessThan(90);
+
+    await page.getByTestId("profile-visualizer-play").click();
+
+    await expect(page.getByTestId("profile-visualizer-stream")).toContainText(
+      MOCK_ANSWER
+    );
+    await expect(page.getByTestId("profile-visualizer-stage-decoder")).toHaveAttribute(
+      "data-stage-state",
+      "complete"
+    );
+    await expect
+      .poll(() => getTraceCardCenterDelta(page, "decoder"))
+      .toBeLessThan(90);
+
+    const workerMessages = await page.evaluate(() => {
+      const mockWindow = window as unknown as {
+        __mockWorkerMessages: MockWorkerMessage[];
+      };
+      return mockWindow.__mockWorkerMessages;
+    });
+    const generateMessage = workerMessages.find(
+      (message) => message.action === "generate"
+    );
+
+    expect(
+      workerMessages.filter((message) => message.action === "load")
+    ).toHaveLength(1);
+    expect(generateMessage?.input).toBe(VISUALIZER_QUESTION);
+    expect(generateMessage?.conversationTurns).toEqual([]);
+  });
+});


### PR DESCRIPTION
## What changed
- Added the LLM Visualizer modal, trace plumbing, centered Three.js scene, and updated tests for the chat/visualizer flow.
- Hardened the Teapot profile QA pipeline so training, evaluation, merge, and export stay on the TeapotLLM lineage and emit the expected ONNX artifacts.

## Validation
- `npm run lint`
- `npx tsc --noEmit`
- `npx playwright test tests/visualizer.spec.ts --project=chromium`
- `npm run flight-check`

## Notes
- The branch is split into two commits so the app-facing work and the Teapot pipeline hardening stay easy to review independently.