### PR TITLE
fix: mobile llm visualizer overlaps

### DIFF
--- a/src/components/profile/ProfileVisualizerModal.tsx
+++ b/src/components/profile/ProfileVisualizerModal.tsx
@@ -412,7 +412,7 @@ export default function ProfileVisualizerModal({
 
         <div className="grid min-h-0 flex-1 content-start gap-3 overflow-y-auto p-3 lg:grid-cols-[minmax(0,1.45fr)_minmax(340px,0.9fr)] lg:content-stretch lg:overflow-hidden lg:p-4">
           <section
-            className="flex min-h-0 flex-col overflow-visible rounded-lg border border-gray-800 bg-black lg:overflow-hidden"
+            className="flex min-h-0 flex-col overflow-hidden rounded-lg border border-gray-800 bg-black"
             data-testid="profile-visualizer-scene-panel"
           >
             <div className="border-b border-gray-800 px-4 py-3">
@@ -468,7 +468,7 @@ export default function ProfileVisualizerModal({
                 </div>
               </div>
             </div>
-            <div className="min-h-[280px] flex-1 lg:min-h-0">
+            <div className="h-[260px] min-h-[260px] shrink-0 lg:h-auto lg:min-h-0 lg:flex-1">
               <ProfileVisualizerScene
                 activeStageId={activeStageId}
                 completedStageIds={completedStageIds}

--- a/src/components/profile/ProfileVisualizerModal.tsx
+++ b/src/components/profile/ProfileVisualizerModal.tsx
@@ -468,7 +468,7 @@ export default function ProfileVisualizerModal({
                 </div>
               </div>
             </div>
-            <div className="h-[260px] min-h-[260px] shrink-0 lg:h-auto lg:min-h-0 lg:flex-1">
+            <div className="h-[260px] min-h-[260px] shrink-0 overflow-hidden lg:h-auto lg:min-h-0 lg:flex-1">
               <ProfileVisualizerScene
                 activeStageId={activeStageId}
                 completedStageIds={completedStageIds}

--- a/src/components/profile/ProfileVisualizerScene.tsx
+++ b/src/components/profile/ProfileVisualizerScene.tsx
@@ -786,10 +786,10 @@ export function ProfileVisualizerScene({
   }, []);
 
   return (
-    <div className="relative h-full min-h-[260px] w-full bg-black">
+    <div className="relative h-full min-h-[260px] w-full overflow-hidden bg-black">
       <canvas
         ref={canvasRef}
-        className="h-full min-h-[260px] w-full cursor-pointer bg-black"
+        className="block h-full min-h-[260px] w-full cursor-pointer bg-black"
         data-testid="profile-visualizer-canvas"
         aria-label="Three-dimensional LLM architecture visualizer"
       />

--- a/src/components/profile/ProfileVisualizerScene.tsx
+++ b/src/components/profile/ProfileVisualizerScene.tsx
@@ -786,10 +786,10 @@ export function ProfileVisualizerScene({
   }, []);
 
   return (
-    <div className="relative h-full min-h-[260px] w-full overflow-hidden bg-black">
+    <div className="relative h-full min-h-0 w-full overflow-hidden bg-black">
       <canvas
         ref={canvasRef}
-        className="block h-full min-h-[260px] w-full cursor-pointer bg-black"
+        className="block h-full min-h-0 w-full cursor-pointer bg-black"
         data-testid="profile-visualizer-canvas"
         aria-label="Three-dimensional LLM architecture visualizer"
       />

--- a/tests/visualizer.spec.ts
+++ b/tests/visualizer.spec.ts
@@ -305,6 +305,7 @@ test.describe("LLM Visualizer", () => {
           sendButtonRect.bottom <= viewportHeight,
         inputAboveScene: inputRect.bottom <= sceneRect.top,
         sendButtonAboveScene: sendButtonRect.bottom <= sceneRect.top,
+        sceneContainedByPanel: sceneRect.bottom <= scenePanelRect.bottom,
         scenePanelAboveTracePanel: scenePanelRect.bottom <= tracePanelRect.top,
       };
     });
@@ -315,6 +316,7 @@ test.describe("LLM Visualizer", () => {
     expect(layout?.sendButtonFullyInViewport).toBe(true);
     expect(layout?.inputAboveScene).toBe(true);
     expect(layout?.sendButtonAboveScene).toBe(true);
+    expect(layout?.sceneContainedByPanel).toBe(true);
     expect(layout?.scenePanelAboveTracePanel).toBe(true);
   });
 


### PR DESCRIPTION
### Motivation
- Prevent the visualizer canvas and controls from being obscured by the trace panel on narrow/mobile viewports so the question input and Send button remain fully accessible.

### Description
- Changed the scene panel container in `src/components/profile/ProfileVisualizerModal.tsx` to clip overflowing content by replacing `overflow-visible` with `overflow-hidden` so the visualizer cannot bleed into the trace panel. 
- Constrained the canvas area on small viewports by giving the scene container a fixed mobile height (`h-[260px] min-h-[260px] shrink-0 lg:h-auto lg:min-h-0 lg:flex-1`) while preserving flexible desktop layout. 
- Extended the Playwright regression test in `tests/visualizer.spec.ts` to assert the scene canvas is contained within its panel (`sceneContainedByPanel`) before the trace panel begins.

### Testing
- Ran `git diff --check` which reported no whitespace or diff-check errors. 
- Ran `npm run lint` which failed because ESLint could not resolve the local `@eslint/js` dependency. 
- Ran `npm run flight-check` which failed at the lint step for the same missing `@eslint/js` dependency. 
- Attempted `npm install` to restore deps which failed due to a network error while fetching `onnxruntime-node` assets (`ENETUNREACH`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a387709b33c83218ccdf4218c65e703)