### PR TITLE
Fix browser model task selection

### DIFF
--- a/src/services/ai/modelLoader.ts
+++ b/src/services/ai/modelLoader.ts
@@ -1,13 +1,12 @@
 /**
  * Model loader.
- * Handles loading the browser text generation model with dtype fallback.
+ * Handles loading the browser text-to-text generation model with dtype fallback.
  */
 
 import {
   pipeline,
   env,
   type Text2TextGenerationPipeline,
-  type TextGenerationPipeline,
 } from "@huggingface/transformers";
 import {
   MODEL_ID,
@@ -20,32 +19,18 @@ env.allowLocalModels = false;
 env.remoteHost = "https://huggingface.co";
 
 const logger = createLogger(LOG_AREAS.AI_MODEL_LOADER);
-
-export type GenerationTask = "text-generation" | "text2text-generation";
-
-export type GenerationPipeline =
-  | TextGenerationPipeline
-  | Text2TextGenerationPipeline;
+const GENERATION_TASK = "text2text-generation" as const;
 
 export type GenerationPipelineFactory = (
-  task: GenerationTask,
+  task: typeof GENERATION_TASK,
   modelId: string,
   options: Record<string, unknown>
-) => Promise<GenerationPipeline>;
+) => Promise<Text2TextGenerationPipeline>;
 
-export interface LoadedTextGenerationPipeline {
-  task: "text-generation";
-  generator: TextGenerationPipeline;
-}
-
-export interface LoadedText2TextGenerationPipeline {
-  task: "text2text-generation";
+export interface LoadedGenerationPipeline {
+  task: typeof GENERATION_TASK;
   generator: Text2TextGenerationPipeline;
 }
-
-export type LoadedGenerationPipeline =
-  | LoadedTextGenerationPipeline
-  | LoadedText2TextGenerationPipeline;
 
 export interface LoaderCallbacks {
   viewportWidth?: number;
@@ -61,7 +46,6 @@ interface NormalizedLoadError {
   message: string;
   isLikelyMemoryError: boolean;
   isNumericRuntimeCode: boolean;
-  isLikelyTaskMismatch: boolean;
 }
 
 const DOWNLOAD_COMPLETE_PROGRESS = 100;
@@ -81,7 +65,6 @@ function normalizeLoadError(error: unknown): NormalizedLoadError {
       message: `Runtime error code: ${error}`,
       isLikelyMemoryError: true,
       isNumericRuntimeCode: true,
-      isLikelyTaskMismatch: false,
     };
   }
 
@@ -94,7 +77,6 @@ function normalizeLoadError(error: unknown): NormalizedLoadError {
         lower.includes("allocation") ||
         lower.includes("out of bounds"),
       isNumericRuntimeCode: /^\d+$/.test(error.trim()),
-      isLikelyTaskMismatch: isLikelyTaskMismatchMessage(lower),
     };
   }
 
@@ -108,7 +90,6 @@ function normalizeLoadError(error: unknown): NormalizedLoadError {
         lower.includes("allocation") ||
         lower.includes("out of bounds"),
       isNumericRuntimeCode: false,
-      isLikelyTaskMismatch: isLikelyTaskMismatchMessage(lower),
     };
   }
 
@@ -137,7 +118,6 @@ function normalizeLoadError(error: unknown): NormalizedLoadError {
         lower.includes("out of bounds") ||
         (maybeCode !== null && /^\d+$/.test(maybeCode)),
       isNumericRuntimeCode: maybeCode !== null && /^\d+$/.test(maybeCode),
-      isLikelyTaskMismatch: isLikelyTaskMismatchMessage(lower),
     };
   }
 
@@ -145,19 +125,7 @@ function normalizeLoadError(error: unknown): NormalizedLoadError {
     message: String(error),
     isLikelyMemoryError: false,
     isNumericRuntimeCode: false,
-    isLikelyTaskMismatch: false,
   };
-}
-
-export function isLikelyTaskMismatchMessage(message: string): boolean {
-  const lower = message.toLowerCase();
-
-  return (
-    lower.includes("unsupported model type") ||
-    lower.includes('for task "text-generation"') ||
-    lower.includes("modelwithlmhead") ||
-    lower.includes("modelforcausallm")
-  );
 }
 
 function normalizeProgress(progress: number): number {
@@ -165,21 +133,16 @@ function normalizeProgress(progress: number): number {
 }
 
 async function createGenerationPipeline(
-  task: GenerationTask,
+  task: typeof GENERATION_TASK,
   modelId: string,
   options: Record<string, unknown>
-): Promise<GenerationPipeline> {
-  if (task === "text-generation") {
-    const pipelineResult = await pipeline("text-generation", modelId, options);
-    return pipelineResult as TextGenerationPipeline;
-  }
-
-  const pipelineResult = await pipeline("text2text-generation", modelId, options);
+): Promise<Text2TextGenerationPipeline> {
+  const pipelineResult = await pipeline(task, modelId, options);
   return pipelineResult as Text2TextGenerationPipeline;
 }
 
 /**
- * Loads the configured text generation model.
+ * Loads the configured text-to-text generation model.
  * Dtype is selected from viewport-aware preferences with fallback ordering.
  */
 export async function loadModel(
@@ -295,14 +258,14 @@ export async function loadModel(
       logger.log(`loading model (${dtype}): ${MODEL_ID}`);
 
       const pipelineResult = await createPipeline(
-        "text-generation",
+        GENERATION_TASK,
         MODEL_ID,
         pipelineOptions
       );
 
       return {
-        task: "text-generation",
-        generator: pipelineResult as TextGenerationPipeline,
+        task: GENERATION_TASK,
+        generator: pipelineResult,
       };
     } catch (error) {
       const normalizedError = normalizeLoadError(error);
@@ -311,48 +274,8 @@ export async function loadModel(
         : "Trying next dtype fallback option.";
 
       logger.error(
-        `attempt ${attempts} failed for ${dtype} (text-generation): ${normalizedError.message}`
+        `attempt ${attempts} failed for ${dtype} (${GENERATION_TASK}): ${normalizedError.message}`
       );
-
-      if (normalizedError.isLikelyTaskMismatch) {
-        logger.warn(
-          `model ${MODEL_ID} appears incompatible with text-generation; retrying text2text-generation for the same dtype.`
-        );
-
-        try {
-          const pipelineResult = await createPipeline(
-            "text2text-generation",
-            MODEL_ID,
-            pipelineOptions
-          );
-
-          return {
-            task: "text2text-generation",
-            generator: pipelineResult as Text2TextGenerationPipeline,
-          };
-        } catch (fallbackError) {
-          const normalizedFallbackError = normalizeLoadError(fallbackError);
-          const fallbackTaskHint = normalizedFallbackError.isLikelyMemoryError
-            ? "Likely memory/runtime pressure while retrying text2text-generation."
-            : "Trying next dtype fallback option.";
-
-          logger.error(
-            `attempt ${attempts} failed for ${dtype} (text2text-generation): ${normalizedFallbackError.message}`
-          );
-
-          if (
-            normalizedFallbackError.isLikelyMemoryError ||
-            normalizedFallbackError.isNumericRuntimeCode
-          ) {
-            logger.warn(fallbackTaskHint);
-            if (normalizedFallbackError.isNumericRuntimeCode) {
-              logger.warn(
-                "numeric runtime codes from ONNX/WebAssembly are often opaque; fallback will continue."
-              );
-            }
-          }
-        }
-      }
 
       if (
         normalizedError.isLikelyMemoryError ||

--- a/src/services/ai/worker.ts
+++ b/src/services/ai/worker.ts
@@ -7,7 +7,6 @@ import {
   TextStreamer,
   env,
   type Text2TextGenerationOutput,
-  type TextGenerationOutput,
 } from "@huggingface/transformers";
 import { WorkerAction, WorkerStatus, type WorkerRequest } from "@/types/worker";
 import { GENERATION_PARAMS } from "@/config/prompts";
@@ -21,51 +20,6 @@ env.remoteHost = "https://huggingface.co";
 let viewportWidth: number | undefined;
 let loadedPipeline: LoadedGenerationPipeline | null = null;
 const logger = createLogger(LOG_AREAS.AI_WORKER);
-
-function extractGeneratedText(output: TextGenerationOutput): string {
-  const generated = output[0]?.generated_text;
-
-  if (typeof generated === "string") {
-    return generated.trim();
-  }
-
-  if (Array.isArray(generated)) {
-    for (let index = generated.length - 1; index >= 0; index -= 1) {
-      const message = generated[index];
-      if (message.role !== "assistant") {
-        continue;
-      }
-
-      if (typeof message.content === "string") {
-        return message.content.trim();
-      }
-
-      if (Array.isArray(message.content)) {
-        return message.content
-          .map((part) => {
-            if (typeof part === "string") {
-              return part;
-            }
-
-            if (
-              typeof part === "object" &&
-              part !== null &&
-              "text" in part &&
-              typeof part.text === "string"
-            ) {
-              return part.text;
-            }
-
-            return "";
-          })
-          .join("")
-          .trim();
-      }
-    }
-  }
-
-  return "";
-}
 
 self.addEventListener("message", async (event: MessageEvent<WorkerRequest>) => {
   const {
@@ -163,51 +117,26 @@ self.addEventListener("message", async (event: MessageEvent<WorkerRequest>) => {
         },
       });
 
-      if (loadedPipeline.task === "text-generation") {
-        const output = await loadedPipeline.generator(prompt, {
-          temperature: generationParams.temperature,
-          max_new_tokens: generationParams.maxTokens,
-          do_sample: false,
-          repetition_penalty: generationParams.repetitionPenalty,
-          top_k: generationParams.topK,
-          early_stopping: true,
-          return_full_text: false,
-          streamer,
+      const output = await loadedPipeline.generator(prompt, {
+        temperature: generationParams.temperature,
+        max_new_tokens: generationParams.maxTokens,
+        do_sample: false,
+        repetition_penalty: generationParams.repetitionPenalty,
+        top_k: generationParams.topK,
+        early_stopping: true,
+        streamer,
+      });
+
+      const generatedText =
+        (output as Text2TextGenerationOutput)[0]?.generated_text.trim() ?? "";
+
+      if (!generatedText) {
+        logger.warn("text2text-generation output completed without text");
+      } else if (!streamedText.trim()) {
+        self.postMessage({
+          status: WorkerStatus.STREAM,
+          response: generatedText,
         });
-
-        const generatedText = extractGeneratedText(
-          output as TextGenerationOutput
-        );
-        if (!generatedText) {
-          logger.warn("text-generation output completed without assistant text");
-        } else if (!streamedText.trim()) {
-          self.postMessage({
-            status: WorkerStatus.STREAM,
-            response: generatedText,
-          });
-        }
-      } else {
-        const output = await loadedPipeline.generator(prompt, {
-          temperature: generationParams.temperature,
-          max_new_tokens: generationParams.maxTokens,
-          do_sample: false,
-          repetition_penalty: generationParams.repetitionPenalty,
-          top_k: generationParams.topK,
-          early_stopping: true,
-          streamer,
-        });
-
-        const generatedText =
-          (output as Text2TextGenerationOutput)[0]?.generated_text.trim() ?? "";
-
-        if (!generatedText) {
-          logger.warn("text2text-generation output completed without text");
-        } else if (!streamedText.trim()) {
-          self.postMessage({
-            status: WorkerStatus.STREAM,
-            response: generatedText,
-          });
-        }
       }
     } catch (e) {
       self.postMessage({

--- a/tests/models.spec.ts
+++ b/tests/models.spec.ts
@@ -15,18 +15,13 @@ import {
 } from "../src/services/ai/contextProvider";
 import type { ConversationTurn } from "../src/types";
 import {
-  isLikelyTaskMismatchMessage,
   loadModel,
   type GenerationPipelineFactory,
-  type GenerationTask,
 } from "../src/services/ai/modelLoader";
-import type {
-  Text2TextGenerationPipeline,
-  TextGenerationPipeline,
-} from "@huggingface/transformers";
+import type { Text2TextGenerationPipeline } from "@huggingface/transformers";
 
 interface PipelineCall {
-  task: GenerationTask;
+  task: Parameters<GenerationPipelineFactory>[0];
   modelId: string;
   dtype: string;
 }
@@ -47,21 +42,7 @@ test.describe("Model dtype policy", () => {
     expect(getDtypeFallbackOrder("q4")).toEqual(["int8", "uint8"]);
   });
 
-  test("detects incompatible live model architectures for task fallback", () => {
-    expect(
-      isLikelyTaskMismatchMessage("Unsupported model type: t5")
-    ).toBeTruthy();
-    expect(
-      isLikelyTaskMismatchMessage(
-        'Unsupported model type "t5" for task "text-generation".'
-      )
-    ).toBeTruthy();
-    expect(
-      isLikelyTaskMismatchMessage("Failed to allocate memory buffer")
-    ).toBeFalsy();
-  });
-
-  test("retries text2text generation after a task mismatch", async () => {
+  test("loads the configured text2text generation task directly", async () => {
     const calls: PipelineCall[] = [];
     const fakeText2TextGenerator = {} as unknown as Text2TextGenerationPipeline;
     const fakePipeline: GenerationPipelineFactory = async (
@@ -75,10 +56,6 @@ test.describe("Model dtype policy", () => {
         dtype: typeof options.dtype === "string" ? options.dtype : "unknown",
       });
 
-      if (task === "text-generation") {
-        throw new Error("Unsupported model type: t5");
-      }
-
       return fakeText2TextGenerator;
     };
 
@@ -87,11 +64,6 @@ test.describe("Model dtype policy", () => {
     expect(loadedPipeline?.task).toBe("text2text-generation");
     expect(calls).toEqual([
       {
-        task: "text-generation",
-        modelId: MODEL_ID,
-        dtype: "int8",
-      },
-      {
         task: "text2text-generation",
         modelId: MODEL_ID,
         dtype: "int8",
@@ -99,9 +71,45 @@ test.describe("Model dtype policy", () => {
     ]);
   });
 
+  test("preserves dtype fallback for text2text generation", async () => {
+    const calls: PipelineCall[] = [];
+    const fakeText2TextGenerator = {} as unknown as Text2TextGenerationPipeline;
+    const fakePipeline: GenerationPipelineFactory = async (
+      task,
+      modelId,
+      options
+    ) => {
+      const dtype =
+        typeof options.dtype === "string" ? options.dtype : "unknown";
+      calls.push({ task, modelId, dtype });
+
+      if (dtype === "int8") {
+        throw new Error("Failed to allocate memory buffer");
+      }
+
+      return fakeText2TextGenerator;
+    };
+
+    const loadedPipeline = await loadModel({}, fakePipeline);
+
+    expect(loadedPipeline?.generator).toBe(fakeText2TextGenerator);
+    expect(calls).toEqual([
+      {
+        task: "text2text-generation",
+        modelId: MODEL_ID,
+        dtype: "int8",
+      },
+      {
+        task: "text2text-generation",
+        modelId: MODEL_ID,
+        dtype: "uint8",
+      },
+    ]);
+  });
+
   test("reports aggregate download progress before the memory loading phase", async () => {
     const progressUpdates: ProgressUpdate[] = [];
-    const fakeTextGenerator = {} as unknown as TextGenerationPipeline;
+    const fakeText2TextGenerator = {} as unknown as Text2TextGenerationPipeline;
     const fakePipeline: GenerationPipelineFactory = async (
       _task,
       _modelId,
@@ -121,7 +129,7 @@ test.describe("Model dtype policy", () => {
       emitProgress({ status: "progress_total", progress: 100 });
       emitProgress({ status: "done" });
 
-      return fakeTextGenerator;
+      return fakeText2TextGenerator;
     };
 
     await loadModel(


### PR DESCRIPTION
## What

- Load the exported T5 model with `text2text-generation` directly.
- Remove error-message parsing that tried to recover from a task mismatch.
- Remove the unreachable causal text-generation worker branch.
- Cover direct task selection and the existing int8-to-uint8 fallback.

## Why

The deployed artifact is an encoder-decoder T5 model, but the browser first requested `text-generation` and depended on upstream exception wording to switch tasks. That makes startup brittle and keeps an incompatible generation path alive.

## Validation

- Full ESLint passed.
- TypeScript no-emit check passed.
- `tests/models.spec.ts`: 14/14 passed.
- `git diff --check` passed.

The full Next build could not start in this sandbox because its native `stacker` dependency panicked while loading `next.config.ts`; CI should exercise the complete flight check.