### PR TITLE
Pin the browser model to an immutable revision

### DIFF
--- a/docs/CUSTOMIZATION.md
+++ b/docs/CUSTOMIZATION.md
@@ -39,14 +39,16 @@ Pages Actions. `npm run deploy` is the manual path and publishes `out/` to a
 | File                    | Purpose                                                    |
 | ----------------------- | ---------------------------------------------------------- |
 | `src/config/site.ts`    | Personal info, resume, and chatbot profile sections        |
-| `src/config/models.ts`  | AI model ID and browser dtype policy                       |
+| `src/config/models.ts`  | AI model ID, pinned revision, and browser dtype policy     |
 | `src/config/prompts.ts` | Chatbot messages and generation settings                   |
 | `next.config.ts`        | Static export, GitHub Pages `basePath`, and asset prefix   |
 | `ml/profile-qa/`        | Local training, eval, ONNX export, and publishing          |
 
 The default browser model is
 `justinthelaw/teapot-profile-qa-browser-1024`, a browser ONNX profile-QA model
-published with `int8` and `uint8` variants.
+published with `int8` and `uint8` variants. Browser downloads are pinned to the
+immutable Hugging Face commit configured by `MODEL_REVISION` rather than the
+repository's mutable `main` revision.
 
 ## Resume
 
@@ -117,20 +119,25 @@ Edit `src/config/models.ts`:
 
 ```typescript
 export const MODEL_ID = "justinthelaw/teapot-profile-qa-browser-1024";
+export const MODEL_REVISION: string =
+  "49f3cd8e9fd6db8310949b41f7b652d00e13d259";
 export const MODEL_CONTEXT_LIMIT = 1024;
 ```
 
 Use a model that is compatible with Transformers.js browser inference. If the
 model uses a different Transformers.js task, update
 `src/services/ai/modelLoader.ts` and `src/services/ai/worker.ts` to match.
+Always use a full Hugging Face commit SHA for `MODEL_REVISION`. When promoting
+new artifacts, update the model ID and revision together so the deployed app
+changes only through a reviewed source commit.
 
 Automatic browser loading uses `int8` first with `uint8` fallback. Do not make
 `q4` the default unless ONNX Runtime Web can reliably load the artifact without
 external `.onnx.data` files.
 
-Before changing the default browser model, satisfy the promotion gate in
-[ml/profile-qa/README.md](../ml/profile-qa/README.md#promotion-gate). At
-minimum, the promoted artifact must include browser-safe `int8` and `uint8`
+Before changing the default browser model or revision, satisfy the promotion
+gate in [ml/profile-qa/README.md](../ml/profile-qa/README.md#promotion-gate).
+At minimum, the promoted artifact must include browser-safe `int8` and `uint8`
 ONNX files, no external `.onnx.data` files, and browser smoke coverage for
 desktop and mobile Chromium.
 
@@ -156,7 +163,7 @@ a custom browser model instead of only prompt/context changes.
 | --- | --- |
 | 1 | Update public facts in both `src/config/site.ts` and `ml/profile-qa/profile_qa/public_profile.py` |
 | 2 | Follow [ml/profile-qa/README.md](../ml/profile-qa/README.md) to generate data, train LoRA/QLoRA, evaluate, merge, export ONNX, prepare Hugging Face artifacts, and publish |
-| 3 | After promotion passes, update `MODEL_ID` and `MODEL_CONTEXT_LIMIT` in `src/config/models.ts` |
+| 3 | After promotion passes, update `MODEL_ID`, `MODEL_REVISION`, and `MODEL_CONTEXT_LIMIT` in `src/config/models.ts` |
 | 4 | Run `npm run flight-check` |
 
 ## Troubleshooting

--- a/docs/DIAGRAMS.md
+++ b/docs/DIAGRAMS.md
@@ -125,7 +125,7 @@ does not train models and does not call a server.
 | Training | `ml/profile-qa/profile_qa/config.py` or CLI flags | Fixed `teapotai/teapotllm` base; local 8GB NVIDIA LoRA/QLoRA runs |
 | Evaluation | `python -m profile_qa.evaluate` | Seq2seq only; adapters must record `teapotai/teapotllm` as their base |
 | ONNX export | `python -m profile_qa.export_onnx` | Requires the merged Teapot lineage marker; rejects `.onnx.data`; publishes `int8` and `uint8` encoder/decoder artifacts |
-| App promotion | `src/config/models.ts` | Update `MODEL_ID` and keep `MODEL_CONTEXT_LIMIT` honest |
+| App promotion | `src/config/models.ts` | Update `MODEL_ID`, pin `MODEL_REVISION` to the promoted commit, and keep `MODEL_CONTEXT_LIMIT` honest |
 
 Promotion should satisfy the gate in `ml/profile-qa/README.md` before changing
 the app default model.

--- a/ml/profile-qa/README.md
+++ b/ml/profile-qa/README.md
@@ -99,8 +99,10 @@ or repair export/browser packaging issues. Do not switch base models.
 
 ## Promotion Gate
 
-Do not update the app's browser `MODEL_ID` or default `MODEL_CONTEXT_LIMIT`
-until all of these are true:
+Do not update the app's browser `MODEL_ID`, `MODEL_REVISION`, or default
+`MODEL_CONTEXT_LIMIT` until all of these are true. After publishing, promote
+the exact Hugging Face commit SHA rather than the repository's mutable `main`
+revision:
 
 | Gate | Requirement |
 | --- | --- |

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -15,6 +15,7 @@ export {
 } from "./site";
 export {
   MODEL_ID,
+  MODEL_REVISION,
   MODEL_DISPLAY_NAME,
   MODEL_CONTEXT_LIMIT,
   getDeviceSpecificDtype,

--- a/src/config/models.ts
+++ b/src/config/models.ts
@@ -8,6 +8,13 @@
 export const MODEL_ID = "justinthelaw/teapot-profile-qa-browser-1024";
 
 /**
+ * Immutable Hugging Face commit loaded by the browser worker.
+ * Update this revision explicitly when promoting new model artifacts.
+ */
+export const MODEL_REVISION: string =
+  "49f3cd8e9fd6db8310949b41f7b652d00e13d259";
+
+/**
  * User-friendly display name for the configured model.
  */
 export const MODEL_DISPLAY_NAME = "Profile-QA Teapot";

--- a/src/services/ai/modelLoader.ts
+++ b/src/services/ai/modelLoader.ts
@@ -11,6 +11,7 @@ import {
 } from "@huggingface/transformers";
 import {
   MODEL_ID,
+  MODEL_REVISION,
   getDeviceSpecificDtype,
   getDtypeFallbackOrder,
 } from "@/config/models";
@@ -249,6 +250,7 @@ export async function loadModel(
     const pipelineOptions: Record<string, unknown> = {
       dtype,
       device: "wasm",
+      revision: MODEL_REVISION,
       progress_callback: (progressData: unknown) => {
         if (typeof progressData !== "object" || progressData === null) {
           return;

--- a/tests/models.spec.ts
+++ b/tests/models.spec.ts
@@ -2,6 +2,7 @@ import { expect, test } from "@playwright/test";
 import {
   MODEL_CONTEXT_LIMIT,
   MODEL_ID,
+  MODEL_REVISION,
   getDeviceSpecificDtype,
   getDtypeFallbackOrder,
 } from "../src/config/models";
@@ -29,6 +30,7 @@ interface PipelineCall {
   task: GenerationTask;
   modelId: string;
   dtype: string;
+  revision: string;
 }
 
 interface ProgressUpdate {
@@ -61,7 +63,7 @@ test.describe("Model dtype policy", () => {
     ).toBeFalsy();
   });
 
-  test("retries text2text generation after a task mismatch", async () => {
+  test("pins primary and task-fallback loads to the promoted revision", async () => {
     const calls: PipelineCall[] = [];
     const fakeText2TextGenerator = {} as unknown as Text2TextGenerationPipeline;
     const fakePipeline: GenerationPipelineFactory = async (
@@ -73,6 +75,8 @@ test.describe("Model dtype policy", () => {
         task,
         modelId,
         dtype: typeof options.dtype === "string" ? options.dtype : "unknown",
+        revision:
+          typeof options.revision === "string" ? options.revision : "unknown",
       });
 
       if (task === "text-generation") {
@@ -90,11 +94,13 @@ test.describe("Model dtype policy", () => {
         task: "text-generation",
         modelId: MODEL_ID,
         dtype: "int8",
+        revision: MODEL_REVISION,
       },
       {
         task: "text2text-generation",
         modelId: MODEL_ID,
         dtype: "int8",
+        revision: MODEL_REVISION,
       },
     ]);
   });
@@ -144,6 +150,9 @@ test.describe("Model dtype policy", () => {
 test.describe("Model prompt policy", () => {
   test("uses the promoted profile-QA model as the single configured browser model", () => {
     expect(MODEL_ID).toBe("justinthelaw/teapot-profile-qa-browser-1024");
+    expect(MODEL_REVISION).toBe(
+      "49f3cd8e9fd6db8310949b41f7b652d00e13d259"
+    );
     expect(MODEL_CONTEXT_LIMIT).toBe(1024);
   });
 


### PR DESCRIPTION
## What

- Pin the browser model to Hugging Face commit `49f3cd8e9fd6db8310949b41f7b652d00e13d259`.
- Pass that revision to every Transformers.js pipeline load, including dtype fallback.
- Export the revision through the model config and document how to update it deliberately.
- Test that every attempted load uses the pinned revision.

## Why

The application currently resolves the model repository's mutable `main` branch at runtime. A later model-repository update can therefore change production behavior without a website commit, review, or reproducible rollback.

## Validation

- `tests/models.spec.ts`: 14/14 passed.
- ESLint passed.
- `git diff --check` passed.

The complete Next build is left to CI because the sandbox's native Next config loader panics before application validation.