### PR TITLE
Respect reduced-motion preferences

### DIFF
--- a/src/components/chat/components/ChatContainer.tsx
+++ b/src/components/chat/components/ChatContainer.tsx
@@ -4,6 +4,7 @@
  */
 
 import React, { useCallback, useEffect, useId, useRef } from "react";
+import { useReducedMotion } from "framer-motion";
 import { ChatMessages } from "./ChatMessages";
 import { ChatInput } from "./ChatInput";
 import { useChatHistory, useAIGeneration, useModelManagement } from "../hooks";
@@ -36,6 +37,7 @@ function getFocusableElements(container: HTMLElement): HTMLElement[] {
 
 export function ChatContainer({ onClose }: ChatContainerProps): React.ReactElement {
   const titleId = useId();
+  const shouldReduceMotion = useReducedMotion();
   const { messages, clearHistory, canClear } = useChatHistory();
   const { isGenerating, currentResponse, generate } = useAIGeneration();
   const {
@@ -112,8 +114,10 @@ export function ChatContainer({ onClose }: ChatContainerProps): React.ReactEleme
   }, [handleDialogKeyDown]);
 
   useEffect(() => {
-    messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
-  }, [messages, currentResponse, isGenerating, isLoading]);
+    messagesEndRef.current?.scrollIntoView({
+      behavior: shouldReduceMotion ? "auto" : "smooth",
+    });
+  }, [messages, currentResponse, isGenerating, isLoading, shouldReduceMotion]);
 
   function handleSend(message: string): void {
     if (error) {

--- a/src/components/chat/components/Typewriter.tsx
+++ b/src/components/chat/components/Typewriter.tsx
@@ -4,6 +4,7 @@
  */
 
 import React, { useState, useEffect } from 'react';
+import { useReducedMotion } from "framer-motion";
 
 export interface TypewriterProps {
   text: string;
@@ -13,8 +14,13 @@ export interface TypewriterProps {
 export function Typewriter({ text, delay }: TypewriterProps): React.ReactElement {
   const [currentText, setCurrentText] = useState('');
   const [currentIndex, setCurrentIndex] = useState(0);
+  const shouldReduceMotion = useReducedMotion();
 
   useEffect(() => {
+    if (shouldReduceMotion) {
+      return undefined;
+    }
+
     const words = text.split(' ');
     if (currentIndex < words.length) {
       const timeout = setTimeout(() => {
@@ -24,7 +30,11 @@ export function Typewriter({ text, delay }: TypewriterProps): React.ReactElement
 
       return () => clearTimeout(timeout);
     }
-  }, [currentIndex, delay, text]);
+  }, [currentIndex, delay, shouldReduceMotion, text]);
 
-  return <span>{currentText}</span>;
+  return (
+    <span data-testid="typewriter-text">
+      {shouldReduceMotion ? text : currentText}
+    </span>
+  );
 }

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -96,3 +96,14 @@ iframe {
   border: none;
   overflow-y: auto; /* Enables scrolling inside iframe */
 }
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    scroll-behavior: auto !important;
+    transition-duration: 0.01ms !important;
+  }
+}

--- a/tests/chatbot.spec.ts
+++ b/tests/chatbot.spec.ts
@@ -3,6 +3,7 @@ import {
   getPersonalContextBudget,
   getPromptBudget,
 } from "../src/services/ai/contextProvider";
+import { CHATBOT_CONFIG } from "../src/config";
 
 const HELD_LOADING_MESSAGE = "Downloading model... 83%";
 const HOLD_MODEL_LOADING_SESSION_KEY = "__holdModelLoading";
@@ -149,6 +150,17 @@ test.describe("Chatbot UI Tests", () => {
       "AI can make mistakes. Always verify the information.",
     );
     await expect(disclaimer).toBeVisible();
+  });
+
+  test("should skip the welcome animation when reduced motion is requested", async ({
+    page,
+  }) => {
+    await page.emulateMedia({ reducedMotion: "reduce" });
+    await page.reload();
+    await openChat(page);
+
+    const welcomeText = await page.getByTestId("typewriter-text").innerText();
+    expect(CHATBOT_CONFIG.welcomeMessages).toContain(welcomeText);
   });
 
   test("should display model loading message without model size", async ({


### PR DESCRIPTION
## What

- Render typewriter text immediately when the user requests reduced motion.
- Replace smooth chat scrolling with immediate scrolling under that preference.
- Collapse CSS animation and transition durations in `prefers-reduced-motion: reduce`.
- Cover the complete welcome message behavior in a reduced-motion browser test.

## Why

The current typewriter, smooth-scroll, spinner, and transition behavior ignores the operating-system accessibility preference and can create unnecessary motion for sensitive users.

## Validation

- Targeted ESLint passed.
- TypeScript no-emit check passed.
- `git diff --check` passed.

Browser execution is left to CI because Chromium could not be installed in this sandbox.