### PR TITLE
Make the profile content crawlable and shareable

### DIFF
--- a/docs/CUSTOMIZATION.md
+++ b/docs/CUSTOMIZATION.md
@@ -15,6 +15,7 @@ For a system map, see [diagrams.md](diagrams.md).
 - [ ] Set `githubUsername` to your username
 - [ ] Set `githubBioFallback` to a short, durable profile summary
 - [ ] Set `repository.owner` and `repository.name`
+- [ ] Set `seo.imageUrl` to a public, absolute HTTPS image URL
 - [ ] Set `resumeFileId` (from Google Drive share link)
 - [ ] Update `socialLinks` (empty string hides a link)
 - [ ] Summarize public resume/profile knowledge in `PROFILE_SECTIONS`
@@ -38,6 +39,10 @@ Pages Actions. `npm run deploy` is the manual path and publishes `out/` to a
 `SITE_CONFIG.githubBioFallback` is included in the static export so crawlers and
 visitors always receive a profile summary. After hydration, the browser still
 refreshes it from GitHub and keeps the configured text if that request fails.
+
+`SITE_CONFIG.seo.imageUrl` is reused for the browser favicon, the Open Graph
+`og:image`, and the Twitter card `twitter:image`. Use a publicly reachable image
+that works both as a small icon and as the preview image when the site is shared.
 
 ## Configuration Map
 

--- a/docs/CUSTOMIZATION.md
+++ b/docs/CUSTOMIZATION.md
@@ -13,6 +13,7 @@ For a system map, see [diagrams.md](diagrams.md).
 - [ ] Set GitHub Pages source to GitHub Actions for CI deploys
 - [ ] Set `name` to your name
 - [ ] Set `githubUsername` to your username
+- [ ] Set `githubBioFallback` to a short, durable profile summary
 - [ ] Set `repository.owner` and `repository.name`
 - [ ] Set `resumeFileId` (from Google Drive share link)
 - [ ] Update `socialLinks` (empty string hides a link)
@@ -33,6 +34,10 @@ For this repository, that means `/justinthelaw`; forks should not hardcode it.
 The `main` branch deploys through `.github/workflows/deploy.yml` using GitHub
 Pages Actions. `npm run deploy` is the manual path and publishes `out/` to a
 `gh-pages` branch.
+
+`SITE_CONFIG.githubBioFallback` is included in the static export so crawlers and
+visitors always receive a profile summary. After hydration, the browser still
+refreshes it from GitHub and keeps the configured text if that request fails.
 
 ## Configuration Map
 

--- a/docs/DIAGRAMS.md
+++ b/docs/DIAGRAMS.md
@@ -22,10 +22,13 @@ fit together.
 
 ```mermaid
 flowchart TD
+  siteConfig["SITE_CONFIG.githubBioFallback"] --> staticSite
   visitor["Visitor browser"] --> staticSite["Static export in out/"]
   staticSite --> page["src/pages/index.tsx"]
-  page --> profile["GitHubProfile"]
-  profile --> github["GitHub REST API"]
+  page --> profile["GitHubProfile renders configured fallback"]
+  profile -->|"After hydration: refresh"| github["GitHub REST API"]
+  github -->|"Success: replace bio"| profile
+  github -.->|"Failure: keep fallback"| profile
   page --> resume["ResumeViewer"]
   resume --> drive["Google Drive PDF preview"]
   page --> chat["ChatContainer, client only"]

--- a/src/components/profile/GitHubProfile.tsx
+++ b/src/components/profile/GitHubProfile.tsx
@@ -8,15 +8,23 @@ import { fetchGitHubBio } from '@/services/github';
 import { SITE_CONFIG } from '@/config/site';
 
 export function GitHubProfile(): React.ReactElement {
-  const [bio, setBio] = useState('');
+  const [bio, setBio] = useState<string>(SITE_CONFIG.githubBioFallback);
 
   useEffect(() => {
-    const loadBio = async () => {
+    let isCurrent = true;
+
+    const loadBio = async (): Promise<void> => {
       const fetchedBio = await fetchGitHubBio(SITE_CONFIG.githubUsername);
-      setBio(fetchedBio);
+      if (isCurrent) {
+        setBio(fetchedBio);
+      }
     };
 
-    loadBio();
+    void loadBio();
+
+    return () => {
+      isCurrent = false;
+    };
   }, []);
 
   return (

--- a/src/config/site.ts
+++ b/src/config/site.ts
@@ -15,6 +15,8 @@ export const SITE_CONFIG = {
   name: "Justin",
   fullName: "Justin Law",
   githubUsername: "justinthelaw",
+  githubBioFallback:
+    "AI Deployment Engineer focused on secure software engineering and AI-powered developer tools.",
 
   // Repository Configuration (for GitHub Pages deployment)
   // Update these if you rename your repository or change ownership
@@ -51,6 +53,7 @@ export const SITE_CONFIG = {
     title: "Justin Law",
     description:
       "Justin Law's personal website showcasing AI deployment, secure software engineering, and AI-powered chat",
+    imageUrl: "https://avatars.githubusercontent.com/u/81255462?v=4",
   },
 } as const;
 

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -2,12 +2,13 @@ import "@/styles/globals.css";
 import type { AppProps } from "next/app";
 import Head from "next/head";
 import { Fragment, type ReactElement } from "react";
+import { SITE_CONFIG } from "@/config/site";
 
 export default function MyApp({ Component, pageProps }: AppProps): ReactElement {
   return (
     <Fragment>
       <Head>
-        <link rel="icon" href="https://avatars.githubusercontent.com/u/81255462?v=4" />
+        <link rel="icon" href={SITE_CONFIG.seo.imageUrl} />
       </Head>
       <Component {...pageProps} />
     </Fragment>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -2,7 +2,7 @@ import { Fragment, useRef, useState } from "react";
 import dynamic from "next/dynamic";
 import Head from "next/head";
 import { Bot } from "@deemlol/next-icons";
-import { SITE_CONFIG } from "@/config/site";
+import { DERIVED_CONFIG, SITE_CONFIG } from "@/config/site";
 import { LinkIconButton } from "@/components/links";
 import { GitHubProfile } from "@/components/profile";
 import { ResumeViewer } from "@/components/resume";
@@ -62,18 +62,37 @@ export default function Home(): React.ReactElement {
         <title>{SITE_CONFIG.seo.title}</title>
         <meta name="description" content={SITE_CONFIG.seo.description} />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <link rel="canonical" href={DERIVED_CONFIG.siteUrl} />
+        <meta property="og:type" content="profile" />
+        <meta property="og:url" content={DERIVED_CONFIG.siteUrl} />
+        <meta property="og:title" content={SITE_CONFIG.seo.title} />
+        <meta property="og:description" content={SITE_CONFIG.seo.description} />
+        <meta property="og:image" content={SITE_CONFIG.seo.imageUrl} />
+        <meta
+          property="og:image:alt"
+          content={`${SITE_CONFIG.fullName}'s profile photo`}
+        />
+        <meta property="profile:username" content={SITE_CONFIG.githubUsername} />
+        <meta name="twitter:card" content="summary" />
+        <meta name="twitter:title" content={SITE_CONFIG.seo.title} />
+        <meta name="twitter:description" content={SITE_CONFIG.seo.description} />
+        <meta name="twitter:image" content={SITE_CONFIG.seo.imageUrl} />
+        <meta
+          name="twitter:image:alt"
+          content={`${SITE_CONFIG.fullName}'s profile photo`}
+        />
       </Head>
 
       <div className="grid grid-rows-[auto_1fr_auto] h-screen gap-2 pb-4 pt-8">
-        <div className="flex flex-col items-center gap-4">
-          <header
+        <header className="flex flex-col items-center gap-4">
+          <h1
             className="text-center text-3xl sm:text-5xl font-bold"
             data-testid="main-header"
           >
             {SITE_CONFIG.fullName}
-          </header>
+          </h1>
           <GitHubProfile />
-        </div>
+        </header>
 
         <main className="flex items-center justify-center overflow-hidden">
           <ResumeViewer />

--- a/src/services/github/githubService.ts
+++ b/src/services/github/githubService.ts
@@ -7,8 +7,6 @@ import { SITE_CONFIG } from "@/config/site";
 import { createLogger, LOG_AREAS } from "@/utils";
 
 const GITHUB_API_BASE = "https://api.github.com";
-const PERSON_NAME = SITE_CONFIG.fullName || "this person";
-const DEFAULT_BIO_FALLBACK = `Oops! It seems like GitHub's API might be down so the website can't grab ${PERSON_NAME}'s GitHub bio. Anyway, let's just assume that ${PERSON_NAME} is really cool!`;
 const logger = createLogger(LOG_AREAS.GITHUB_SERVICE);
 
 export interface GitHubUser {
@@ -41,7 +39,7 @@ export async function fetchGitHubUser(username: string): Promise<GitHubUser> {
  */
 export async function fetchGitHubBio(
   username: string,
-  fallbackMessage: string = DEFAULT_BIO_FALLBACK
+  fallbackMessage: string = SITE_CONFIG.githubBioFallback
 ): Promise<string> {
   try {
     const user = await fetchGitHubUser(username);

--- a/tests/export.spec.ts
+++ b/tests/export.spec.ts
@@ -71,27 +71,6 @@ async function readExportedJavaScript(): Promise<string> {
   return contents.join("\n");
 }
 
-function hasHtmlTagWithAttributes(
-  html: string,
-  tagName: string,
-  attributes: Readonly<Record<string, string>>,
-): boolean {
-  const tags = html.match(new RegExp(`<${tagName}\\b[^>]*>`, "g")) ?? [];
-
-  return tags.some((tag) =>
-    Object.entries(attributes).every(([attributeName, attributeValue]) => {
-      const escapedValue = attributeValue
-        .replaceAll("&", "&amp;")
-        .replaceAll('"', "&quot;")
-        .replaceAll("'", "&#x27;")
-        .replaceAll("<", "&lt;")
-        .replaceAll(">", "&gt;");
-
-      return tag.includes(`${attributeName}="${escapedValue}"`);
-    }),
-  );
-}
-
 interface StaticPreviewServer {
   origin: string;
   close: () => Promise<void>;
@@ -222,7 +201,7 @@ test("should export bundled social icon assets with valid local paths", async ()
   expect(hasBlockedRawGitHubSource).toBe(false);
 });
 
-test("should export crawlable profile content and share metadata", async () => {
+test("should export crawlable profile content and share metadata", async ({ page }) => {
   const exportIndexPath = path.resolve(process.cwd(), "out", "index.html");
   const exportHtml = await readFile(exportIndexPath, "utf8").catch(() => {
     throw new Error(
@@ -230,40 +209,32 @@ test("should export crawlable profile content and share metadata", async () => {
     );
   });
 
-  expect(exportHtml).toContain(SITE_CONFIG.githubBioFallback);
-  expect(exportHtml).toMatch(
-    new RegExp(`<h1\\b[^>]*>${SITE_CONFIG.fullName}</h1>`),
+  await page.setContent(exportHtml);
+
+  await expect(page.getByTestId("github-bio")).toHaveText(
+    SITE_CONFIG.githubBioFallback,
   );
-  expect(
-    hasHtmlTagWithAttributes(exportHtml, "link", {
-      rel: "canonical",
-      href: DERIVED_CONFIG.siteUrl,
-    }),
-  ).toBe(true);
-  expect(
-    hasHtmlTagWithAttributes(exportHtml, "meta", {
-      property: "og:url",
-      content: DERIVED_CONFIG.siteUrl,
-    }),
-  ).toBe(true);
-  expect(
-    hasHtmlTagWithAttributes(exportHtml, "meta", {
-      property: "og:description",
-      content: SITE_CONFIG.seo.description,
-    }),
-  ).toBe(true);
-  expect(
-    hasHtmlTagWithAttributes(exportHtml, "meta", {
-      name: "twitter:card",
-      content: "summary",
-    }),
-  ).toBe(true);
-  expect(
-    hasHtmlTagWithAttributes(exportHtml, "meta", {
-      name: "twitter:description",
-      content: SITE_CONFIG.seo.description,
-    }),
-  ).toBe(true);
+  await expect(page.locator("h1")).toHaveText(SITE_CONFIG.fullName);
+  await expect(page.locator('link[rel="canonical"]')).toHaveAttribute(
+    "href",
+    DERIVED_CONFIG.siteUrl,
+  );
+  await expect(page.locator('meta[property="og:url"]')).toHaveAttribute(
+    "content",
+    DERIVED_CONFIG.siteUrl,
+  );
+  await expect(page.locator('meta[property="og:description"]')).toHaveAttribute(
+    "content",
+    SITE_CONFIG.seo.description,
+  );
+  await expect(page.locator('meta[name="twitter:card"]')).toHaveAttribute(
+    "content",
+    "summary",
+  );
+  await expect(page.locator('meta[name="twitter:description"]')).toHaveAttribute(
+    "content",
+    SITE_CONFIG.seo.description,
+  );
 });
 
 test("should export the current browser AI worker bundle", async () => {

--- a/tests/export.spec.ts
+++ b/tests/export.spec.ts
@@ -71,6 +71,27 @@ async function readExportedJavaScript(): Promise<string> {
   return contents.join("\n");
 }
 
+function hasHtmlTagWithAttributes(
+  html: string,
+  tagName: string,
+  attributes: Readonly<Record<string, string>>,
+): boolean {
+  const tags = html.match(new RegExp(`<${tagName}\\b[^>]*>`, "g")) ?? [];
+
+  return tags.some((tag) =>
+    Object.entries(attributes).every(([attributeName, attributeValue]) => {
+      const escapedValue = attributeValue
+        .replaceAll("&", "&amp;")
+        .replaceAll('"', "&quot;")
+        .replaceAll("'", "&#x27;")
+        .replaceAll("<", "&lt;")
+        .replaceAll(">", "&gt;");
+
+      return tag.includes(`${attributeName}="${escapedValue}"`);
+    }),
+  );
+}
+
 interface StaticPreviewServer {
   origin: string;
   close: () => Promise<void>;
@@ -199,6 +220,50 @@ test("should export bundled social icon assets with valid local paths", async ()
   );
 
   expect(hasBlockedRawGitHubSource).toBe(false);
+});
+
+test("should export crawlable profile content and share metadata", async () => {
+  const exportIndexPath = path.resolve(process.cwd(), "out", "index.html");
+  const exportHtml = await readFile(exportIndexPath, "utf8").catch(() => {
+    throw new Error(
+      "Missing exported index HTML at out/index.html. Run `npm run build` before Playwright tests.",
+    );
+  });
+
+  expect(exportHtml).toContain(SITE_CONFIG.githubBioFallback);
+  expect(exportHtml).toMatch(
+    new RegExp(`<h1\\b[^>]*>${SITE_CONFIG.fullName}</h1>`),
+  );
+  expect(
+    hasHtmlTagWithAttributes(exportHtml, "link", {
+      rel: "canonical",
+      href: DERIVED_CONFIG.siteUrl,
+    }),
+  ).toBe(true);
+  expect(
+    hasHtmlTagWithAttributes(exportHtml, "meta", {
+      property: "og:url",
+      content: DERIVED_CONFIG.siteUrl,
+    }),
+  ).toBe(true);
+  expect(
+    hasHtmlTagWithAttributes(exportHtml, "meta", {
+      property: "og:description",
+      content: SITE_CONFIG.seo.description,
+    }),
+  ).toBe(true);
+  expect(
+    hasHtmlTagWithAttributes(exportHtml, "meta", {
+      name: "twitter:card",
+      content: "summary",
+    }),
+  ).toBe(true);
+  expect(
+    hasHtmlTagWithAttributes(exportHtml, "meta", {
+      name: "twitter:description",
+      content: SITE_CONFIG.seo.description,
+    }),
+  ).toBe(true);
 });
 
 test("should export the current browser AI worker bundle", async () => {

--- a/tests/home.spec.ts
+++ b/tests/home.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from "@playwright/test";
-import { SITE_CONFIG } from "../src/config/site";
+import { DERIVED_CONFIG, SITE_CONFIG } from "../src/config/site";
 
 function getSocialIconFiles(): string[] {
   const socialIconFiles: string[] = [];
@@ -33,6 +33,9 @@ test.describe('Homepage E2E Tests', () => {
     await expect(page.getByTestId("main-header")).toHaveText(
       SITE_CONFIG.fullName,
     );
+    await expect(
+      page.getByRole("heading", { level: 1, name: SITE_CONFIG.fullName }),
+    ).toBeVisible();
 
     // Assert that the AI Chatbot button is visible
     await expect(page.getByTestId("ai-chatbot-button")).toBeVisible();
@@ -77,15 +80,84 @@ test.describe('Homepage E2E Tests', () => {
     await expect(chatbotButton).not.toBeVisible();
   });
 
-  test("should display GitHub profile description", async ({ page }) => {
+  test("should retain the configured profile description when GitHub fails", async ({
+    page,
+  }) => {
+    await page.route(
+      `https://api.github.com/users/${SITE_CONFIG.githubUsername}`,
+      async (route) => {
+        await route.fulfill({ status: 503, body: "Service Unavailable" });
+      },
+    );
     await page.goto("/");
 
-    // Wait for the GitHub profile description to load and be visible
     const bioElement = page.getByTestId("github-bio");
-    await expect(bioElement).toBeVisible({ timeout: 10000 });
+    await expect(bioElement).toBeVisible();
+    await expect(bioElement).toHaveText(SITE_CONFIG.githubBioFallback);
+  });
 
-    // Should contain some text (either actual bio or fallback)
-    await expect(bioElement).not.toBeEmpty();
+  test("should refresh the configured profile description from GitHub", async ({
+    page,
+  }) => {
+    const liveBio = "Live GitHub profile description";
+    await page.route(
+      `https://api.github.com/users/${SITE_CONFIG.githubUsername}`,
+      async (route) => {
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({ bio: liveBio }),
+        });
+      },
+    );
+    await page.goto("/");
+
+    await expect(page.getByTestId("github-bio")).toHaveText(liveBio);
+  });
+
+  test("should expose canonical and social share metadata", async ({ page }) => {
+    await page.goto("/");
+
+    await expect(page.locator('link[rel="canonical"]')).toHaveAttribute(
+      "href",
+      DERIVED_CONFIG.siteUrl,
+    );
+    await expect(page.locator('meta[property="og:type"]')).toHaveAttribute(
+      "content",
+      "profile",
+    );
+    await expect(page.locator('meta[property="og:url"]')).toHaveAttribute(
+      "content",
+      DERIVED_CONFIG.siteUrl,
+    );
+    await expect(page.locator('meta[property="og:title"]')).toHaveAttribute(
+      "content",
+      SITE_CONFIG.seo.title,
+    );
+    await expect(page.locator('meta[property="og:description"]')).toHaveAttribute(
+      "content",
+      SITE_CONFIG.seo.description,
+    );
+    await expect(page.locator('meta[property="og:image"]')).toHaveAttribute(
+      "content",
+      SITE_CONFIG.seo.imageUrl,
+    );
+    await expect(page.locator('meta[name="twitter:card"]')).toHaveAttribute(
+      "content",
+      "summary",
+    );
+    await expect(page.locator('meta[name="twitter:title"]')).toHaveAttribute(
+      "content",
+      SITE_CONFIG.seo.title,
+    );
+    await expect(page.locator('meta[name="twitter:description"]')).toHaveAttribute(
+      "content",
+      SITE_CONFIG.seo.description,
+    );
+    await expect(page.locator('meta[name="twitter:image"]')).toHaveAttribute(
+      "content",
+      SITE_CONFIG.seo.imageUrl,
+    );
   });
 
   test('should render social icons with deterministic src paths', async ({ page }) => {


### PR DESCRIPTION
## What

- Server-render a configured factual bio, then refresh it from GitHub after hydration.
- Keep the configured bio as the API-failure fallback.
- Add a real page heading plus canonical, Open Graph, and Twitter metadata.
- Centralize favicon/share image configuration and document the new profile fields.
- Add static-export and browser coverage for crawlability and metadata.

## Why

The exported page currently ships an empty bio and relies on client-side GitHub API access. Text-only crawlers, link unfurlers, rate-limited visitors, and JavaScript-disabled clients therefore miss the site's main description; the page also lacks canonical/social metadata.

## Validation

- Full ESLint passed.
- Production build, typecheck, and static export passed with a sandbox workaround for native config loading.
- Seven targeted export tests passed.

The remaining browser test is left to CI because Chromium could not be installed in this sandbox.