### PR TITLE
Fix case-sensitive architecture documentation links

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -162,11 +162,11 @@ Update these as needed when making changes:
 | `/README.md` | Repository orientation changes |
 | `/AGENTS.md` | Agent instructions change |
 | `/docs/CUSTOMIZATION.md` | User-facing configuration changes |
-| `/docs/diagrams.md` | Architecture, runtime flow, deployment behavior, or profile-QA pipeline changes |
+| `/docs/DIAGRAMS.md` | Architecture, runtime flow, deployment behavior, or profile-QA pipeline changes |
 | `/ml/profile-qa/README.md` | Local training, evaluation, export, or publishing commands change |
 
 Keep docs concise and layered: README for orientation, `docs/CUSTOMIZATION.md`
-for configuration, `docs/diagrams.md` for system flow, and
+for configuration, `docs/DIAGRAMS.md` for system flow, and
 `ml/profile-qa/README.md` for command-level fine-tuning details. Use exact file
 paths so both humans and agents can act on the instructions.
 

--- a/docs/CUSTOMIZATION.md
+++ b/docs/CUSTOMIZATION.md
@@ -4,7 +4,7 @@ Make this static portfolio your own. The browser chatbot answers from reusable
 public profile sections, so configuration should stay factual, public, and easy
 to sync with the optional training pipeline.
 
-For a system map, see [diagrams.md](diagrams.md).
+For a system map, see [DIAGRAMS.md](DIAGRAMS.md).
 
 ## Quick Setup
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -66,7 +66,7 @@ at pre-push.
 
 | Document | Purpose |
 | --- | --- |
-| [Architecture and pipeline diagrams](diagrams.md) | System map and fine-tuning handoff |
+| [Architecture and pipeline diagrams](DIAGRAMS.md) | System map and fine-tuning handoff |
 | [Customization](CUSTOMIZATION.md) | Site personalization |
 | [Contributing](CONTRIBUTING.md) | Contribution workflow |
 | [Security](SECURITY.md) | Vulnerability reporting |

--- a/ml/profile-qa/README.md
+++ b/ml/profile-qa/README.md
@@ -5,7 +5,7 @@ browser profile Q&A model targeting a 1024-token prompt budget. Generated data,
 checkpoints, merged weights, ONNX exports, and reports are ignored by git.
 
 For the end-to-end app and promotion handoff, see
-[docs/diagrams.md](../../docs/diagrams.md).
+[docs/DIAGRAMS.md](../../docs/DIAGRAMS.md).
 
 The profile ontology is intentionally generic for fork reuse: section IDs should
 stay in resume categories such as `identity`, `current_role`, `experience`,


### PR DESCRIPTION
## What

- Update references from `docs/diagrams.md` to the repository's actual `docs/DIAGRAMS.md` path.
- Fix links in contributor guidance, development/customization docs, and the ML README.

## Why

The lowercase links work on some case-insensitive local filesystems but return 404s on GitHub and Linux because the checked-in filename is uppercase.

## Validation

- Confirmed `docs/DIAGRAMS.md` exists.
- Confirmed no stale lowercase diagram links remain in the affected documentation.
- `git diff --check` passed.