### PR TITLE
Enforce ML promotion thresholds before packaging

### DIFF
--- a/docs/DIAGRAMS.md
+++ b/docs/DIAGRAMS.md
@@ -126,7 +126,7 @@ does not train models and does not call a server.
 | Training | `ml/profile-qa/profile_qa/config.py` or CLI flags | Fixed `teapotai/teapotllm` base; local 8GB NVIDIA LoRA/QLoRA runs |
 | Evaluation | `python -m profile_qa.evaluate` | Seq2seq-only; records model and dataset fingerprints plus the evaluated split |
 | ONNX export | `python -m profile_qa.export_onnx` | Requires merged Teapot lineage; rejects external data; hashes the source model and `int8`/`uint8` browser payload into a candidate manifest |
-| Artifact prep | `python -m profile_qa.prepare_hf_artifacts` | Validates report provenance, browser integrity, relative test-macro improvement, and internally consistent validation/test refusal and multi-turn thresholds before replacing payloads |
+| Artifact prep | `python -m profile_qa.prepare_hf_artifacts` | Rescores report predictions, validates provenance/browser integrity and thresholds, and preserves fingerprinted full-dataset bytes before replacing payloads |
 | App promotion | `src/config/models.ts` | Update `MODEL_ID` and keep `MODEL_CONTEXT_LIMIT` honest |
 
 Promotion should satisfy the automated report gates and manual release gates in

--- a/docs/DIAGRAMS.md
+++ b/docs/DIAGRAMS.md
@@ -103,10 +103,11 @@ flowchart TD
   pyProfile --> data["synthetic_data.py"]
   data --> train["train_lora.py"]
   train --> eval["evaluate.py"]
-  eval --> gate["Promotion gate"]
-  gate --> merge["merge_adapter.py"]
+  eval --> manualGate["Manual release gates"]
+  manualGate --> merge["merge_adapter.py"]
   merge --> export["export_onnx.py"]
-  export --> artifacts["prepare_hf_artifacts.py"]
+  export --> artifacts["Validate metrics + prepare payloads"]
+  eval --> artifacts
   artifacts --> publish["publish.py"]
   publish --> hfRepo["Hugging Face model repo"]
   hfRepo --> modelConfig["src/config/models.ts"]
@@ -125,10 +126,11 @@ does not train models and does not call a server.
 | Training | `ml/profile-qa/profile_qa/config.py` or CLI flags | Fixed `teapotai/teapotllm` base; local 8GB NVIDIA LoRA/QLoRA runs |
 | Evaluation | `python -m profile_qa.evaluate` | Seq2seq only; adapters must record `teapotai/teapotllm` as their base |
 | ONNX export | `python -m profile_qa.export_onnx` | Requires the merged Teapot lineage marker; rejects `.onnx.data`; publishes `int8` and `uint8` encoder/decoder artifacts |
+| Artifact prep | `python -m profile_qa.prepare_hf_artifacts` | Validates report schema, relative test-macro improvement, and validation/test refusal and multi-turn thresholds before replacing payloads |
 | App promotion | `src/config/models.ts` | Update `MODEL_ID` and keep `MODEL_CONTEXT_LIMIT` honest |
 
-Promotion should satisfy the gate in `ml/profile-qa/README.md` before changing
-the app default model.
+Promotion should satisfy the automated report gates and manual release gates in
+`ml/profile-qa/README.md` before changing the app default model.
 
 ## Agent Notes
 

--- a/docs/DIAGRAMS.md
+++ b/docs/DIAGRAMS.md
@@ -102,10 +102,10 @@ flowchart TD
   facts["Public profile facts"] --> pyProfile["public_profile.py"]
   pyProfile --> data["synthetic_data.py"]
   data --> train["train_lora.py"]
-  train --> eval["evaluate.py"]
+  train --> merge["merge_adapter.py"]
+  merge --> eval["evaluate.py"]
   eval --> manualGate["Manual release gates"]
-  manualGate --> merge["merge_adapter.py"]
-  merge --> export["export_onnx.py"]
+  manualGate --> export["export_onnx.py"]
   export --> artifacts["Validate metrics + prepare payloads"]
   eval --> artifacts
   artifacts --> publish["publish.py"]
@@ -124,9 +124,9 @@ does not train models and does not call a server.
 | Facts | `src/config/site.ts` and `ml/profile-qa/profile_qa/public_profile.py` | Keep public facts aligned before generating data |
 | Dataset | `python -m profile_qa.synthetic_data` | Generated data stays under ignored `ml/profile-qa/data/` |
 | Training | `ml/profile-qa/profile_qa/config.py` or CLI flags | Fixed `teapotai/teapotllm` base; local 8GB NVIDIA LoRA/QLoRA runs |
-| Evaluation | `python -m profile_qa.evaluate` | Seq2seq only; adapters must record `teapotai/teapotllm` as their base |
-| ONNX export | `python -m profile_qa.export_onnx` | Requires the merged Teapot lineage marker; rejects `.onnx.data`; publishes `int8` and `uint8` encoder/decoder artifacts |
-| Artifact prep | `python -m profile_qa.prepare_hf_artifacts` | Validates report schema, relative test-macro improvement, and validation/test refusal and multi-turn thresholds before replacing payloads |
+| Evaluation | `python -m profile_qa.evaluate` | Seq2seq-only; records model and dataset fingerprints plus the evaluated split |
+| ONNX export | `python -m profile_qa.export_onnx` | Requires merged Teapot lineage; rejects external data; hashes the source model and `int8`/`uint8` browser payload into a candidate manifest |
+| Artifact prep | `python -m profile_qa.prepare_hf_artifacts` | Validates report provenance, browser integrity, relative test-macro improvement, and internally consistent validation/test refusal and multi-turn thresholds before replacing payloads |
 | App promotion | `src/config/models.ts` | Update `MODEL_ID` and keep `MODEL_CONTEXT_LIMIT` honest |
 
 Promotion should satisfy the automated report gates and manual release gates in

--- a/docs/DIAGRAMS.md
+++ b/docs/DIAGRAMS.md
@@ -104,9 +104,9 @@ flowchart TD
   data --> train["train_lora.py"]
   train --> merge["merge_adapter.py"]
   merge --> eval["evaluate.py"]
-  eval --> manualGate["Manual release gates"]
-  manualGate --> export["export_onnx.py"]
-  export --> artifacts["Validate metrics + prepare payloads"]
+  eval --> export["export_onnx.py"]
+  export --> manualGate["Manual release gates"]
+  manualGate --> artifacts["Validate metrics + prepare payloads"]
   eval --> artifacts
   artifacts --> publish["publish.py"]
   publish --> hfRepo["Hugging Face model repo"]

--- a/ml/profile-qa/README.md
+++ b/ml/profile-qa/README.md
@@ -120,6 +120,15 @@ browser candidate requires a complete export and quantization run; either export
 skip flag intentionally omits the provenance manifest, so artifact preparation
 will reject that development-only output.
 
+The candidate `browser_sha256` has one payload boundary: every regular file
+under the directory containing `profile_qa_candidate_provenance.json`, at any
+depth, except the manifest itself. Export records the initial browser directory;
+artifact preparation refreshes the same digest after generating the model card,
+and model publishing verifies it again immediately before upload. Adding,
+removing, or changing any payload file after preparation therefore blocks
+publication. Source-model fingerprints similarly cover every regular file under
+the local merged-model directory.
+
 Metric reports also fail closed when required scores are missing, non-numeric,
 non-finite, outside `[0, 1]`, or when promoted validation/test reports omit the
 `refusal` or `multi_turn` task. Each required task score must agree with its

--- a/ml/profile-qa/README.md
+++ b/ml/profile-qa/README.md
@@ -123,7 +123,11 @@ will reject that development-only output.
 Metric reports also fail closed when required scores are missing, non-numeric,
 non-finite, outside `[0, 1]`, or when promoted validation/test reports omit the
 `refusal` or `multi_turn` task. Each required task score must agree with its
-corresponding top-level accuracy.
+corresponding top-level accuracy. Artifact preparation additionally rescores
+every reported prediction against the fingerprinted dataset and requires the
+stored per-record, per-task, and aggregate scores to match. The full published
+`profile_qa.jsonl` preserves the evaluated source bytes; derived split files use
+the canonical JSONL writer.
 
 | Gate | Automated requirement |
 | --- | --- |

--- a/ml/profile-qa/README.md
+++ b/ml/profile-qa/README.md
@@ -102,23 +102,39 @@ or repair export/browser packaging issues. Do not switch base models.
 Do not update the app's browser `MODEL_ID` or default `MODEL_CONTEXT_LIMIT`
 until all of these are true:
 
-| Gate | Requirement |
+### Automated report gates
+
+`profile_qa.prepare_hf_artifacts` validates all three evaluation reports before
+it replaces any model or dataset payload. Reports fail closed when required
+metrics are missing, non-numeric, non-finite, outside `[0, 1]`, or when the
+promoted test report lacks per-task scores.
+
+| Gate | Automated requirement |
+| --- | --- |
+| Baseline | Promoted test macro is at least `baseline test macro * 1.15`; the baseline macro must be greater than zero |
+| Refusal | Promoted validation and promoted test refusal accuracy are each at least 95% |
+| Multi-turn | Promoted validation and promoted test multi-turn accuracy are each at least 80% |
+
+### Manual release gates
+
+These checks are not encoded in the packaged evaluation reports. Confirm them
+before running artifact preparation and retain the supporting logs or reports
+with the release notes.
+
+| Gate | Manual requirement |
 | --- | --- |
 | GPU health | `python -m profile_qa.gpu_health` passes on the training host |
 | Training | Completed locally on the NVIDIA GPU with the 8GB-safe defaults |
 | Loss | Eval loss <= 0.12 and recent training-loss windows <= 0.05 on a split-isolated validation set |
 | Context | Promoted model accepts 1024-token prompts without truncating below 1024 |
-| Baseline | Eval beats the current Teapot baseline by at least 15% macro score |
-| Refusal | Refusal accuracy is at least 95% |
-| Multi-turn | Multi-turn follow-up accuracy is at least 80% |
 | Browser smoke | Loads and answers a 900-1024 token prompt in Chromium desktop and Mobile Chrome without worker crashes |
-| ONNX artifacts | Include `int8` and `uint8` variants and no `.onnx.data` files |
+| ONNX artifacts | Include `int8` and `uint8` variants; artifact preparation separately rejects `.onnx.data` files |
 
 ## Tests
 
 The Python tests cover deterministic generation, schema validation, split
 isolation, evidence references, no private-data leakage in non-refusal examples,
-and GPU health-check behavior:
+promotion-report validation, pre-mutation gating, and GPU health-check behavior:
 
 ```bash
 PYTHONPATH=ml/profile-qa python -m pytest ml/profile-qa/tests

--- a/ml/profile-qa/README.md
+++ b/ml/profile-qa/README.md
@@ -66,10 +66,12 @@ exporter supports Transformers 5.
 PYTHONPATH=ml/profile-qa python -m profile_qa.gpu_health
 PYTHONPATH=ml/profile-qa python -m profile_qa.synthetic_data --output ml/profile-qa/data/profile_qa.jsonl
 PYTHONPATH=ml/profile-qa python -m profile_qa.train_lora --dataset ml/profile-qa/data/profile_qa.jsonl
-PYTHONPATH=ml/profile-qa python -m profile_qa.evaluate --dataset ml/profile-qa/data/profile_qa.jsonl --model-id teapotai/teapotllm
 PYTHONPATH=ml/profile-qa python -m profile_qa.merge_adapter --adapter-model-id ml/profile-qa/checkpoints/teapot-profile-qa-lora/checkpoint-400 --output-dir ml/profile-qa/merged/teapot-profile-qa
-PYTHONPATH=ml/profile-qa ml/profile-qa/.venv-export/bin/python -m profile_qa.export_onnx --output-dir ml/profile-qa/onnx/candidate
-PYTHONPATH=ml/profile-qa python -m profile_qa.prepare_hf_artifacts --model-browser-dir ml/profile-qa/onnx/candidate/browser
+PYTHONPATH=ml/profile-qa python -m profile_qa.evaluate --dataset ml/profile-qa/data/profile_qa.jsonl --model-id teapotai/teapotllm --split test --output ml/profile-qa/reports/profile_qa_eval_baseline_test.json
+PYTHONPATH=ml/profile-qa python -m profile_qa.evaluate --dataset ml/profile-qa/data/profile_qa.jsonl --model-id ml/profile-qa/merged/teapot-profile-qa --split validation --output ml/profile-qa/reports/profile_qa_eval_candidate_validation.json
+PYTHONPATH=ml/profile-qa python -m profile_qa.evaluate --dataset ml/profile-qa/data/profile_qa.jsonl --model-id ml/profile-qa/merged/teapot-profile-qa --split test --output ml/profile-qa/reports/profile_qa_eval_candidate_test.json
+PYTHONPATH=ml/profile-qa ml/profile-qa/.venv-export/bin/python -m profile_qa.export_onnx --model ml/profile-qa/merged/teapot-profile-qa --output-dir ml/profile-qa/onnx/candidate
+PYTHONPATH=ml/profile-qa python -m profile_qa.prepare_hf_artifacts --model-browser-dir ml/profile-qa/onnx/candidate/browser --baseline-report ml/profile-qa/reports/profile_qa_eval_baseline_test.json --validation-report ml/profile-qa/reports/profile_qa_eval_candidate_validation.json --test-report ml/profile-qa/reports/profile_qa_eval_candidate_test.json
 PYTHONPATH=ml/profile-qa python -m profile_qa.publish --repo-id justinthelaw/teapot-profile-qa-browser-1024 --artifact-dir ml/profile-qa/hf/model
 PYTHONPATH=ml/profile-qa python -m profile_qa.publish --repo-type dataset --repo-id justinthelaw/profile-qa-synthetic-public-v1 --artifact-dir ml/profile-qa/hf/dataset
 ```
@@ -104,16 +106,30 @@ until all of these are true:
 
 ### Automated report gates
 
-`profile_qa.prepare_hf_artifacts` validates all three evaluation reports before
-it replaces any model or dataset payload. Reports fail closed when required
-metrics are missing, non-numeric, non-finite, outside `[0, 1]`, or when the
-promoted test report lacks per-task scores.
+`profile_qa.evaluate` fingerprints the evaluated model and full dataset and
+records the evaluated split. `profile_qa.export_onnx` adds a manifest binding the
+browser files to their source-model fingerprint. Pass all three report paths
+explicitly to `profile_qa.prepare_hf_artifacts`; it verifies this provenance and
+the browser-file digest before replacing any model or dataset payload. This
+prevents a passing report from an older candidate, another dataset, or the wrong
+split from authorizing a new payload. A `--predictions-json` file must be an
+object with `predictions` and `provenance` fields; its provenance must exactly
+match the model, dataset, and split requested on the evaluation command. Inputs
+that change while evaluation or export is running are rejected. A packageable
+browser candidate requires a complete export and quantization run; either export
+skip flag intentionally omits the provenance manifest, so artifact preparation
+will reject that development-only output.
+
+Metric reports also fail closed when required scores are missing, non-numeric,
+non-finite, outside `[0, 1]`, or when promoted validation/test reports omit the
+`refusal` or `multi_turn` task. Each required task score must agree with its
+corresponding top-level accuracy.
 
 | Gate | Automated requirement |
 | --- | --- |
 | Baseline | Promoted test macro is at least `baseline test macro * 1.15`; the baseline macro must be greater than zero |
-| Refusal | Promoted validation and promoted test refusal accuracy are each at least 95% |
-| Multi-turn | Promoted validation and promoted test multi-turn accuracy are each at least 80% |
+| Refusal | Promoted validation and promoted test `by_task.refusal` and matching top-level refusal accuracy are each at least 95% |
+| Multi-turn | Promoted validation and promoted test `by_task.multi_turn` and matching top-level multi-turn accuracy are each at least 80% |
 
 ### Manual release gates
 

--- a/ml/profile-qa/profile_qa/evaluate.py
+++ b/ml/profile-qa/profile_qa/evaluate.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import argparse
 import json
 from collections import defaultdict
+from collections.abc import Mapping
 from pathlib import Path
 from typing import Any
 
@@ -14,6 +15,7 @@ from .config import (
     MODEL_CONTEXT_LIMIT,
     PRIMARY_BASE_MODEL_ID,
 )
+from .provenance import evaluation_provenance
 from .train_lora import (
     ensure_primary_base_model_id,
     ensure_teapot_seq2seq_config,
@@ -32,7 +34,9 @@ def score_answer(record: dict[str, Any], prediction: str) -> dict[str, float]:
     term_hits = sum(1 for term in expected_terms if term in normalized)
     term_score = 1.0 if not expected_terms else term_hits / len(expected_terms)
     requires_refusal = bool(record.get("requires_refusal"))
-    refusal_hit = "does not say" in normalized or "not in the public profile" in normalized
+    refusal_hit = (
+        "does not say" in normalized or "not in the public profile" in normalized
+    )
     refusal_score = 1.0 if refusal_hit == requires_refusal else 0.0
     if requires_refusal:
         return {"macro": refusal_score, "term": 1.0, "refusal": refusal_score}
@@ -40,7 +44,9 @@ def score_answer(record: dict[str, Any], prediction: str) -> dict[str, float]:
     return {"macro": macro, "term": term_score, "refusal": refusal_score}
 
 
-def score_predictions(records: list[dict[str, Any]], predictions: dict[str, str]) -> dict[str, Any]:
+def score_predictions(
+    records: list[dict[str, Any]], predictions: dict[str, str]
+) -> dict[str, Any]:
     """Aggregate macro, per-task, refusal, and multi-turn metrics."""
 
     per_record: list[dict[str, Any]] = []
@@ -57,7 +63,9 @@ def score_predictions(records: list[dict[str, Any]], predictions: dict[str, str]
             refusal_scores.append(scores["refusal"])
         if task == "multi_turn":
             multi_turn_scores.append(scores["macro"])
-        per_record.append({"id": record["id"], "task": task, "prediction": prediction, **scores})
+        per_record.append(
+            {"id": record["id"], "task": task, "prediction": prediction, **scores}
+        )
 
     macro_scores = [item["macro"] for item in per_record]
     return {
@@ -73,6 +81,40 @@ def _mean(values: list[float]) -> float:
     return sum(values) / len(values) if values else 0.0
 
 
+def _load_prediction_bundle(
+    path: Path,
+    *,
+    expected_provenance: dict[str, Any],
+) -> dict[str, str]:
+    """Load precomputed predictions only when their provenance matches this run."""
+
+    try:
+        bundle = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ValueError(f"could not load prediction bundle {path}: {exc}") from exc
+    if not isinstance(bundle, Mapping):
+        raise ValueError(f"prediction bundle {path} must contain a JSON object")
+    if bundle.get("provenance") != expected_provenance:
+        raise ValueError(
+            f"prediction bundle {path} provenance does not match the requested "
+            "model, dataset, and split"
+        )
+
+    predictions = bundle.get("predictions")
+    if not isinstance(predictions, Mapping):
+        raise ValueError(
+            f"prediction bundle {path} field 'predictions' must be an object"
+        )
+    if not all(
+        isinstance(key, str) and isinstance(value, str)
+        for key, value in predictions.items()
+    ):
+        raise ValueError(
+            f"prediction bundle {path} predictions must map string IDs to strings"
+        )
+    return dict(predictions)
+
+
 def _load_generation_stack() -> dict[str, Any]:
     try:
         import torch
@@ -83,7 +125,9 @@ def _load_generation_stack() -> dict[str, Any]:
             AutoTokenizer,
         )
     except ImportError as exc:
-        raise RuntimeError("Install eval dependencies with pip install -r ml/profile-qa/requirements.txt") from exc
+        raise RuntimeError(
+            "Install eval dependencies with pip install -r ml/profile-qa/requirements.txt"
+        ) from exc
     return {
         "torch": torch,
         "AutoConfig": AutoConfig,
@@ -102,9 +146,13 @@ def _adapter_base_model_id(model_id: str) -> str | None:
     return str(base_model_id) if isinstance(base_model_id, str) else None
 
 
-def _ensure_generation_lineage(model_id: str, adapter_base_model_id: str | None, config: Any) -> None:
+def _ensure_generation_lineage(
+    model_id: str, adapter_base_model_id: str | None, config: Any
+) -> None:
     if adapter_base_model_id:
-        ensure_primary_base_model_id(adapter_base_model_id, source=f"{model_id} adapter base")
+        ensure_primary_base_model_id(
+            adapter_base_model_id, source=f"{model_id} adapter base"
+        )
         return
 
     if model_id.rstrip("/") == PRIMARY_BASE_MODEL_ID:
@@ -118,7 +166,9 @@ def _ensure_generation_lineage(model_id: str, adapter_base_model_id: str | None,
     )
 
 
-def generate_predictions(model_id: str, records: list[dict[str, Any]]) -> dict[str, str]:
+def generate_predictions(
+    model_id: str, records: list[dict[str, Any]]
+) -> dict[str, str]:
     """Generate answers locally for a model or adapter directory."""
 
     stack = _load_generation_stack()
@@ -171,27 +221,63 @@ def generate_predictions(model_id: str, records: list[dict[str, Any]]) -> dict[s
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--dataset", default=str(DEFAULT_DATASET_PATH))
-    parser.add_argument("--model-id")
+    parser.add_argument(
+        "--model-id",
+        required=True,
+        help="Pinned baseline ID or local candidate directory represented by this run",
+    )
     parser.add_argument("--predictions-json")
-    parser.add_argument("--split", default="test")
+    parser.add_argument(
+        "--split",
+        choices=("train", "validation", "test"),
+        default="test",
+    )
     parser.add_argument("--output", default=str(DEFAULT_EVAL_REPORT_PATH))
     args = parser.parse_args()
 
+    dataset_path = Path(args.dataset)
+    provenance = evaluation_provenance(
+        dataset_path=dataset_path,
+        split=args.split,
+        model_id=args.model_id,
+    )
     records = [
-        record for record in read_jsonl(Path(args.dataset)) if record.get("split") == args.split
+        record
+        for record in read_jsonl(dataset_path)
+        if record.get("split") == args.split
     ]
     if args.predictions_json:
-        predictions = json.loads(Path(args.predictions_json).read_text(encoding="utf-8"))
-    elif args.model_id:
-        predictions = generate_predictions(args.model_id, records)
+        predictions = _load_prediction_bundle(
+            Path(args.predictions_json),
+            expected_provenance=provenance,
+        )
     else:
-        raise RuntimeError("provide --model-id or --predictions-json")
+        predictions = generate_predictions(args.model_id, records)
+
+    if (
+        evaluation_provenance(
+            dataset_path=dataset_path,
+            split=args.split,
+            model_id=args.model_id,
+        )
+        != provenance
+    ):
+        raise RuntimeError(
+            "evaluation model or dataset changed while the run was in progress"
+        )
 
     report = score_predictions(records, predictions)
+    report["provenance"] = provenance
     output_path = Path(args.output)
     output_path.parent.mkdir(parents=True, exist_ok=True)
-    output_path.write_text(json.dumps(report, indent=2, sort_keys=True), encoding="utf-8")
-    print(json.dumps({key: value for key, value in report.items() if key != "records"}, indent=2))
+    output_path.write_text(
+        json.dumps(report, indent=2, sort_keys=True), encoding="utf-8"
+    )
+    print(
+        json.dumps(
+            {key: value for key, value in report.items() if key != "records"}, indent=2
+        )
+    )
     return 0
 
 

--- a/ml/profile-qa/profile_qa/export_onnx.py
+++ b/ml/profile-qa/profile_qa/export_onnx.py
@@ -11,6 +11,7 @@ from pathlib import Path
 
 from .config import MERGED_DIR, ONNX_DIR
 from .merge_adapter import LINEAGE_FILENAME
+from .provenance import model_provenance, write_candidate_provenance
 from .train_lora import ensure_primary_base_model_id
 
 TEAPOT_EXPORT_TASK = "text2text-generation-with-past"
@@ -22,13 +23,17 @@ def reject_external_data_files(output_dir: Path) -> None:
     external_files = sorted(output_dir.rglob("*.onnx.data"))
     if external_files:
         joined = "\n".join(str(path) for path in external_files)
-        raise RuntimeError(f"ONNX export uses external data files, which are not browser-safe:\n{joined}")
+        raise RuntimeError(
+            f"ONNX export uses external data files, which are not browser-safe:\n{joined}"
+        )
 
 
 def run_command(command: list[str]) -> None:
     result = subprocess.run(command, check=False)
     if result.returncode != 0:
-        raise RuntimeError(f"command failed with exit code {result.returncode}: {' '.join(command)}")
+        raise RuntimeError(
+            f"command failed with exit code {result.returncode}: {' '.join(command)}"
+        )
 
 
 def venv_tool(name: str) -> str:
@@ -116,7 +121,9 @@ def get_browser_model_paths(quantized_dir: Path) -> list[Path]:
     )
 
 
-def assemble_browser_artifact(fp_dir: Path, quantized_dirs: dict[str, Path], output_dir: Path) -> None:
+def assemble_browser_artifact(
+    fp_dir: Path, quantized_dirs: dict[str, Path], output_dir: Path
+) -> None:
     """Create a Transformers.js-compatible upload directory."""
 
     if output_dir.exists():
@@ -146,6 +153,8 @@ def main() -> int:
     parser.add_argument("--skip-quantize", action="store_true")
     args = parser.parse_args()
 
+    ensure_teapot_export_model(args.model)
+    source_provenance = model_provenance(args.model)
     output_dir = Path(args.output_dir)
     fp_dir = output_dir / "onnx"
     if args.skip_export:
@@ -160,9 +169,22 @@ def main() -> int:
     if not args.skip_quantize:
         for dtype, quantized_dir in quantized_dirs.items():
             quantize_onnx(fp_dir, quantized_dir, dtype)
-    assemble_browser_artifact(fp_dir, quantized_dirs, output_dir / "browser")
+    browser_dir = output_dir / "browser"
+    assemble_browser_artifact(fp_dir, quantized_dirs, browser_dir)
 
-    print(f"validated browser-safe ONNX artifacts under {output_dir / 'browser'}")
+    print(f"validated browser-safe ONNX artifacts under {browser_dir}")
+    if args.skip_export or args.skip_quantize:
+        print(
+            "skipped export stages; no candidate provenance was written, so this "
+            "browser directory cannot pass artifact preparation"
+        )
+    else:
+        provenance_path = write_candidate_provenance(
+            source_model=args.model,
+            browser_dir=browser_dir,
+            expected_source=source_provenance,
+        )
+        print(f"wrote candidate provenance: {provenance_path}")
     return 0
 
 

--- a/ml/profile-qa/profile_qa/prepare_hf_artifacts.py
+++ b/ml/profile-qa/profile_qa/prepare_hf_artifacts.py
@@ -4,8 +4,10 @@ from __future__ import annotations
 
 import argparse
 import json
+import math
 import shutil
 from collections import Counter
+from collections.abc import Mapping
 from pathlib import Path
 from typing import Any
 
@@ -16,10 +18,163 @@ from .validation import read_jsonl, write_jsonl
 
 DEFAULT_MODEL_REPO_ID = "justinthelaw/teapot-profile-qa-browser-1024"
 DEFAULT_DATASET_REPO_ID = "justinthelaw/profile-qa-synthetic-public-v1"
+MIN_BASELINE_RELATIVE_MACRO_IMPROVEMENT = 0.15
+MIN_REFUSAL_ACCURACY = 0.95
+MIN_MULTI_TURN_ACCURACY = 0.80
+_REQUIRED_REPORT_METRICS = (
+    "macro",
+    "refusal_accuracy",
+    "multi_turn_accuracy",
+)
+_COMPARISON_TOLERANCE = 1e-12
 
 
 def _load_report(path: Path) -> dict[str, Any]:
-    return json.loads(path.read_text(encoding="utf-8"))
+    try:
+        report = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ValueError(f"could not load evaluation report {path}: {exc}") from exc
+    if not isinstance(report, dict):
+        raise ValueError(f"evaluation report {path} must contain a JSON object")
+    return report
+
+
+def _read_score(
+    report: Mapping[str, Any],
+    *,
+    report_name: str,
+    metric_name: str,
+    errors: list[str],
+) -> float | None:
+    if metric_name not in report:
+        errors.append(f"{report_name} report is missing metric {metric_name!r}")
+        return None
+
+    value = report[metric_name]
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        errors.append(
+            f"{report_name} metric {metric_name!r} must be a number, got {value!r}"
+        )
+        return None
+
+    score = float(value)
+    if not math.isfinite(score):
+        errors.append(
+            f"{report_name} metric {metric_name!r} must be finite, got {value!r}"
+        )
+        return None
+    if not 0.0 <= score <= 1.0:
+        errors.append(
+            f"{report_name} metric {metric_name!r} must be between 0 and 1, "
+            f"got {score:.4f}"
+        )
+        return None
+    return score
+
+
+def validate_promotion_metrics(
+    *,
+    baseline_test: object,
+    promoted_validation: object,
+    promoted_test: object,
+) -> None:
+    """Reject malformed or below-threshold evaluation reports before packaging."""
+
+    reports = {
+        "baseline test": baseline_test,
+        "promoted validation": promoted_validation,
+        "promoted test": promoted_test,
+    }
+    errors: list[str] = []
+    scores: dict[tuple[str, str], float] = {}
+
+    for report_name, report in reports.items():
+        if not isinstance(report, Mapping):
+            errors.append(f"{report_name} report must be a JSON object")
+            continue
+        for metric_name in _REQUIRED_REPORT_METRICS:
+            score = _read_score(
+                report,
+                report_name=report_name,
+                metric_name=metric_name,
+                errors=errors,
+            )
+            if score is not None:
+                scores[(report_name, metric_name)] = score
+
+    if isinstance(promoted_test, Mapping):
+        by_task = promoted_test.get("by_task")
+        if not isinstance(by_task, Mapping) or not by_task:
+            errors.append(
+                "promoted test report field 'by_task' must be a non-empty object"
+            )
+        else:
+            for task, value in by_task.items():
+                if not isinstance(task, str) or not task.strip():
+                    errors.append(
+                        "promoted test report contains an invalid by_task name"
+                    )
+                    continue
+                _read_score(
+                    {f"by_task.{task}": value},
+                    report_name="promoted test",
+                    metric_name=f"by_task.{task}",
+                    errors=errors,
+                )
+
+    baseline_macro = scores.get(("baseline test", "macro"))
+    promoted_test_macro = scores.get(("promoted test", "macro"))
+    if baseline_macro is not None and promoted_test_macro is not None:
+        if baseline_macro <= 0.0:
+            errors.append(
+                "baseline test macro must be greater than 0 for a relative "
+                f"improvement comparison, got {baseline_macro:.4f}"
+            )
+        else:
+            required_macro = baseline_macro * (
+                1.0 + MIN_BASELINE_RELATIVE_MACRO_IMPROVEMENT
+            )
+            if promoted_test_macro + _COMPARISON_TOLERANCE < required_macro:
+                relative_improvement = promoted_test_macro / baseline_macro - 1.0
+                errors.append(
+                    "promoted test macro must improve on baseline test by at least "
+                    f"{MIN_BASELINE_RELATIVE_MACRO_IMPROVEMENT:.0%}: "
+                    f"baseline={baseline_macro:.4f}, "
+                    f"promoted={promoted_test_macro:.4f}, "
+                    f"relative improvement={relative_improvement:.2%}, "
+                    f"required promoted macro>={required_macro:.4f}"
+                )
+
+    accuracy_gates = (
+        ("refusal_accuracy", MIN_REFUSAL_ACCURACY),
+        ("multi_turn_accuracy", MIN_MULTI_TURN_ACCURACY),
+    )
+    for report_name in ("promoted validation", "promoted test"):
+        for metric_name, minimum in accuracy_gates:
+            score = scores.get((report_name, metric_name))
+            if score is not None and score + _COMPARISON_TOLERANCE < minimum:
+                errors.append(
+                    f"{report_name} metric {metric_name!r} must be at least "
+                    f"{minimum:.4f}, got {score:.4f}"
+                )
+
+    if errors:
+        details = "\n".join(f"- {error}" for error in errors)
+        raise ValueError(f"promotion metric validation failed:\n{details}")
+
+
+def _load_and_validate_promotion_reports(
+    args: argparse.Namespace,
+) -> tuple[dict[str, Any], dict[str, Any], dict[str, Any]]:
+    baseline_test = _load_report(Path(args.baseline_report))
+    promoted_validation = _load_report(Path(args.validation_report))
+    promoted_test = _load_report(Path(args.test_report))
+    validate_promotion_metrics(
+        baseline_test=baseline_test,
+        promoted_validation=promoted_validation,
+        promoted_test=promoted_test,
+    )
+    return baseline_test, promoted_validation, promoted_test
 
 
 def _metric(value: float) -> str:
@@ -353,6 +508,9 @@ MIT.
 
 
 def prepare_model_payload(args: argparse.Namespace) -> Path:
+    baseline_test, promoted_validation, promoted_test = (
+        _load_and_validate_promotion_reports(args)
+    )
     browser_dir = Path(args.model_browser_dir)
     if not browser_dir.exists():
         raise RuntimeError(f"model browser directory does not exist: {browser_dir}")
@@ -361,9 +519,6 @@ def prepare_model_payload(args: argparse.Namespace) -> Path:
     model_output_dir = Path(args.output_dir) / "model"
     _copy_tree_contents(browser_dir, model_output_dir)
 
-    baseline_test = _load_report(Path(args.baseline_report))
-    promoted_validation = _load_report(Path(args.validation_report))
-    promoted_test = _load_report(Path(args.test_report))
     _write_model_card(
         model_output_dir / "README.md",
         model_repo_id=args.model_repo_id,
@@ -377,6 +532,9 @@ def prepare_model_payload(args: argparse.Namespace) -> Path:
 
 
 def prepare_dataset_payload(args: argparse.Namespace) -> Path:
+    baseline_test, promoted_validation, promoted_test = (
+        _load_and_validate_promotion_reports(args)
+    )
     records = read_jsonl(Path(args.dataset))
     dataset_output_dir = Path(args.output_dir) / "dataset"
     if dataset_output_dir.exists():
@@ -385,7 +543,10 @@ def prepare_dataset_payload(args: argparse.Namespace) -> Path:
 
     write_jsonl(dataset_output_dir / "profile_qa.jsonl", records)
     for split in ["train", "validation", "test"]:
-        write_jsonl(dataset_output_dir / f"profile_qa_{split}.jsonl", _split_records(records, split))
+        write_jsonl(
+            dataset_output_dir / f"profile_qa_{split}.jsonl",
+            _split_records(records, split),
+        )
     _write_json(dataset_output_dir / "profile_sections.json", PROFILE_SECTIONS)
 
     reports_dir = dataset_output_dir / "eval_reports"
@@ -397,9 +558,6 @@ def prepare_dataset_payload(args: argparse.Namespace) -> Path:
     ]:
         shutil.copy2(report_path, reports_dir / report_path.name)
 
-    baseline_test = _load_report(Path(args.baseline_report))
-    promoted_validation = _load_report(Path(args.validation_report))
-    promoted_test = _load_report(Path(args.test_report))
     _write_dataset_card(
         dataset_output_dir / "README.md",
         records=records,

--- a/ml/profile-qa/profile_qa/prepare_hf_artifacts.py
+++ b/ml/profile-qa/profile_qa/prepare_hf_artifacts.py
@@ -5,14 +5,27 @@ from __future__ import annotations
 import argparse
 import json
 import math
+import re
 import shutil
 from collections import Counter
 from collections.abc import Mapping
 from pathlib import Path
 from typing import Any
 
-from .config import DEFAULT_DATASET_PATH, ONNX_DIR, PACKAGE_ROOT, REPORT_DIR
+from .config import (
+    DEFAULT_DATASET_PATH,
+    ONNX_DIR,
+    PACKAGE_ROOT,
+    PRIMARY_BASE_MODEL_ID,
+    PRIMARY_BASE_MODEL_REVISION,
+)
 from .export_onnx import reject_external_data_files
+from .provenance import (
+    CANDIDATE_PROVENANCE_FILENAME,
+    PROVENANCE_SCHEMA_VERSION,
+    sha256_directory,
+    sha256_file,
+)
 from .public_profile import PROFILE_SECTIONS
 from .validation import read_jsonl, write_jsonl
 
@@ -27,6 +40,7 @@ _REQUIRED_REPORT_METRICS = (
     "multi_turn_accuracy",
 )
 _COMPARISON_TOLERANCE = 1e-12
+_SHA256_PATTERN = re.compile(r"[0-9a-f]{64}")
 
 
 def _load_report(path: Path) -> dict[str, Any]:
@@ -102,24 +116,55 @@ def validate_promotion_metrics(
             if score is not None:
                 scores[(report_name, metric_name)] = score
 
-    if isinstance(promoted_test, Mapping):
-        by_task = promoted_test.get("by_task")
+    task_metric_pairs = (
+        ("refusal", "refusal_accuracy"),
+        ("multi_turn", "multi_turn_accuracy"),
+    )
+    for report_name, report in (
+        ("promoted validation", promoted_validation),
+        ("promoted test", promoted_test),
+    ):
+        if not isinstance(report, Mapping):
+            continue
+        by_task = report.get("by_task")
         if not isinstance(by_task, Mapping) or not by_task:
             errors.append(
-                "promoted test report field 'by_task' must be a non-empty object"
+                f"{report_name} report field 'by_task' must be a non-empty object"
             )
-        else:
-            for task, value in by_task.items():
-                if not isinstance(task, str) or not task.strip():
-                    errors.append(
-                        "promoted test report contains an invalid by_task name"
-                    )
-                    continue
-                _read_score(
-                    {f"by_task.{task}": value},
-                    report_name="promoted test",
-                    metric_name=f"by_task.{task}",
-                    errors=errors,
+            continue
+
+        task_scores: dict[str, float] = {}
+        for task, value in by_task.items():
+            if not isinstance(task, str) or not task.strip():
+                errors.append(f"{report_name} report contains an invalid by_task name")
+                continue
+            score = _read_score(
+                {f"by_task.{task}": value},
+                report_name=report_name,
+                metric_name=f"by_task.{task}",
+                errors=errors,
+            )
+            if score is not None:
+                task_scores[task] = score
+
+        for task_name, metric_name in task_metric_pairs:
+            if task_name not in by_task:
+                errors.append(
+                    f"{report_name} report is missing required by_task entry "
+                    f"{task_name!r}"
+                )
+                continue
+            task_score = task_scores.get(task_name)
+            top_level_score = scores.get((report_name, metric_name))
+            if (
+                task_score is not None
+                and top_level_score is not None
+                and abs(task_score - top_level_score) > _COMPARISON_TOLERANCE
+            ):
+                errors.append(
+                    f"{report_name} by_task {task_name!r} must agree with "
+                    f"{metric_name!r}: by_task={task_score:.4f}, "
+                    f"top-level={top_level_score:.4f}"
                 )
 
     baseline_macro = scores.get(("baseline test", "macro"))
@@ -163,6 +208,150 @@ def validate_promotion_metrics(
         raise ValueError(f"promotion metric validation failed:\n{details}")
 
 
+def _valid_sha256(value: object) -> bool:
+    return isinstance(value, str) and _SHA256_PATTERN.fullmatch(value) is not None
+
+
+def _valid_schema_version(value: object) -> bool:
+    return type(value) is int and value == PROVENANCE_SCHEMA_VERSION
+
+
+def _load_candidate_provenance(model_browser_dir: Path) -> dict[str, Any]:
+    manifest_path = model_browser_dir / CANDIDATE_PROVENANCE_FILENAME
+    if manifest_path.is_symlink():
+        raise ValueError(f"candidate provenance cannot be a symlink: {manifest_path}")
+    try:
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ValueError(
+            f"could not load candidate provenance {manifest_path}: {exc}"
+        ) from exc
+    if not isinstance(manifest, dict):
+        raise ValueError(
+            f"candidate provenance {manifest_path} must contain a JSON object"
+        )
+    return manifest
+
+
+def validate_promotion_provenance(
+    *,
+    baseline_test: object,
+    promoted_validation: object,
+    promoted_test: object,
+    dataset_path: Path,
+    model_browser_dir: Path,
+) -> None:
+    """Bind reports to the exact dataset, split, source model, and browser export."""
+
+    errors: list[str] = []
+    try:
+        dataset_sha256 = sha256_file(dataset_path)
+    except ValueError as exc:
+        errors.append(str(exc))
+        dataset_sha256 = None
+
+    try:
+        manifest = _load_candidate_provenance(model_browser_dir)
+    except ValueError as exc:
+        errors.append(str(exc))
+        manifest = {}
+
+    if not _valid_schema_version(manifest.get("schema_version")):
+        errors.append(
+            f"candidate provenance schema_version must be {PROVENANCE_SCHEMA_VERSION}"
+        )
+
+    source_model = manifest.get("source_model")
+    candidate_model_sha256: str | None = None
+    if not isinstance(source_model, Mapping):
+        errors.append("candidate provenance field 'source_model' must be an object")
+    else:
+        candidate_sha = source_model.get("sha256")
+        if not _valid_sha256(candidate_sha):
+            errors.append(
+                "candidate provenance source_model.sha256 must be a lowercase "
+                "SHA-256 digest"
+            )
+        else:
+            candidate_model_sha256 = candidate_sha
+
+    recorded_browser_sha = manifest.get("browser_sha256")
+    if not _valid_sha256(recorded_browser_sha):
+        errors.append(
+            "candidate provenance browser_sha256 must be a lowercase SHA-256 digest"
+        )
+    else:
+        try:
+            actual_browser_sha = sha256_directory(
+                model_browser_dir,
+                excluded_relative_paths={CANDIDATE_PROVENANCE_FILENAME},
+            )
+        except ValueError as exc:
+            errors.append(str(exc))
+        else:
+            if actual_browser_sha != recorded_browser_sha:
+                errors.append(
+                    "candidate browser artifact does not match its provenance: "
+                    f"recorded={recorded_browser_sha}, actual={actual_browser_sha}"
+                )
+
+    report_expectations = (
+        ("baseline test", baseline_test, "test", False),
+        ("promoted validation", promoted_validation, "validation", True),
+        ("promoted test", promoted_test, "test", True),
+    )
+    for report_name, report, expected_split, is_promoted in report_expectations:
+        if not isinstance(report, Mapping):
+            continue
+        provenance = report.get("provenance")
+        if not isinstance(provenance, Mapping):
+            errors.append(f"{report_name} report field 'provenance' must be an object")
+            continue
+        if not _valid_schema_version(provenance.get("schema_version")):
+            errors.append(
+                f"{report_name} provenance schema_version must be "
+                f"{PROVENANCE_SCHEMA_VERSION}"
+            )
+        if provenance.get("dataset_sha256") != dataset_sha256:
+            errors.append(
+                f"{report_name} provenance does not match dataset {dataset_path}"
+            )
+        if provenance.get("split") != expected_split:
+            errors.append(
+                f"{report_name} provenance split must be {expected_split!r}, "
+                f"got {provenance.get('split')!r}"
+            )
+
+        report_model = provenance.get("model")
+        if not isinstance(report_model, Mapping):
+            errors.append(f"{report_name} provenance field 'model' must be an object")
+            continue
+        if is_promoted:
+            report_model_sha = report_model.get("sha256")
+            if not _valid_sha256(report_model_sha):
+                errors.append(
+                    f"{report_name} provenance model.sha256 must be a lowercase "
+                    "SHA-256 digest"
+                )
+            elif report_model_sha != candidate_model_sha256:
+                errors.append(
+                    f"{report_name} provenance model does not match the browser "
+                    "candidate source model"
+                )
+        elif (
+            report_model.get("id") != PRIMARY_BASE_MODEL_ID
+            or report_model.get("revision") != PRIMARY_BASE_MODEL_REVISION
+        ):
+            errors.append(
+                "baseline test provenance must identify the pinned Teapot baseline "
+                f"{PRIMARY_BASE_MODEL_ID}@{PRIMARY_BASE_MODEL_REVISION}"
+            )
+
+    if errors:
+        details = "\n".join(f"- {error}" for error in errors)
+        raise ValueError(f"promotion provenance validation failed:\n{details}")
+
+
 def _load_and_validate_promotion_reports(
     args: argparse.Namespace,
 ) -> tuple[dict[str, Any], dict[str, Any], dict[str, Any]]:
@@ -173,6 +362,13 @@ def _load_and_validate_promotion_reports(
         baseline_test=baseline_test,
         promoted_validation=promoted_validation,
         promoted_test=promoted_test,
+    )
+    validate_promotion_provenance(
+        baseline_test=baseline_test,
+        promoted_validation=promoted_validation,
+        promoted_test=promoted_test,
+        dataset_path=Path(args.dataset),
+        model_browser_dir=Path(args.model_browser_dir),
     )
     return baseline_test, promoted_validation, promoted_test
 
@@ -581,15 +777,15 @@ def main() -> int:
     parser.add_argument("--dataset-repo-id", default=DEFAULT_DATASET_REPO_ID)
     parser.add_argument(
         "--baseline-report",
-        default=str(REPORT_DIR / "profile_qa_eval_baseline_test.json"),
+        required=True,
     )
     parser.add_argument(
         "--validation-report",
-        default=str(REPORT_DIR / "profile_qa_eval_v5_validation.json"),
+        required=True,
     )
     parser.add_argument(
         "--test-report",
-        default=str(REPORT_DIR / "profile_qa_eval_v5_test.json"),
+        required=True,
     )
     args = parser.parse_args()
 

--- a/ml/profile-qa/profile_qa/prepare_hf_artifacts.py
+++ b/ml/profile-qa/profile_qa/prepare_hf_artifacts.py
@@ -22,9 +22,10 @@ from .config import (
 from .evaluate import score_predictions
 from .export_onnx import reject_external_data_files
 from .provenance import (
-    CANDIDATE_PROVENANCE_FILENAME,
     PROVENANCE_SCHEMA_VERSION,
-    sha256_directory,
+    candidate_payload_sha256,
+    load_candidate_provenance,
+    refresh_candidate_provenance,
     sha256_file,
 )
 from .public_profile import PROFILE_SECTIONS
@@ -387,23 +388,6 @@ def _valid_schema_version(value: object) -> bool:
     return type(value) is int and value == PROVENANCE_SCHEMA_VERSION
 
 
-def _load_candidate_provenance(model_browser_dir: Path) -> dict[str, Any]:
-    manifest_path = model_browser_dir / CANDIDATE_PROVENANCE_FILENAME
-    if manifest_path.is_symlink():
-        raise ValueError(f"candidate provenance cannot be a symlink: {manifest_path}")
-    try:
-        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError) as exc:
-        raise ValueError(
-            f"could not load candidate provenance {manifest_path}: {exc}"
-        ) from exc
-    if not isinstance(manifest, dict):
-        raise ValueError(
-            f"candidate provenance {manifest_path} must contain a JSON object"
-        )
-    return manifest
-
-
 def validate_promotion_provenance(
     *,
     baseline_test: object,
@@ -422,7 +406,7 @@ def validate_promotion_provenance(
         dataset_sha256 = None
 
     try:
-        manifest = _load_candidate_provenance(model_browser_dir)
+        manifest = load_candidate_provenance(model_browser_dir)
     except ValueError as exc:
         errors.append(str(exc))
         manifest = {}
@@ -453,10 +437,7 @@ def validate_promotion_provenance(
         )
     else:
         try:
-            actual_browser_sha = sha256_directory(
-                model_browser_dir,
-                excluded_relative_paths={CANDIDATE_PROVENANCE_FILENAME},
-            )
+            actual_browser_sha = candidate_payload_sha256(model_browser_dir)
         except ValueError as exc:
             errors.append(str(exc))
         else:
@@ -900,6 +881,7 @@ def prepare_model_payload(args: argparse.Namespace) -> Path:
         promoted_validation=promoted_validation,
         promoted_test=promoted_test,
     )
+    refresh_candidate_provenance(model_output_dir)
     reject_external_data_files(model_output_dir)
     return model_output_dir
 

--- a/ml/profile-qa/profile_qa/prepare_hf_artifacts.py
+++ b/ml/profile-qa/profile_qa/prepare_hf_artifacts.py
@@ -19,6 +19,7 @@ from .config import (
     PRIMARY_BASE_MODEL_ID,
     PRIMARY_BASE_MODEL_REVISION,
 )
+from .evaluate import score_predictions
 from .export_onnx import reject_external_data_files
 from .provenance import (
     CANDIDATE_PROVENANCE_FILENAME,
@@ -208,6 +209,176 @@ def validate_promotion_metrics(
         raise ValueError(f"promotion metric validation failed:\n{details}")
 
 
+def validate_report_aggregates(
+    *,
+    baseline_test: object,
+    promoted_validation: object,
+    promoted_test: object,
+    dataset_records: list[dict[str, Any]],
+) -> None:
+    """Recompute report scores from predictions and the fingerprinted dataset."""
+
+    errors: list[str] = []
+    report_expectations = (
+        ("baseline test", baseline_test, "test"),
+        ("promoted validation", promoted_validation, "validation"),
+        ("promoted test", promoted_test, "test"),
+    )
+    for report_name, report, split in report_expectations:
+        if not isinstance(report, Mapping):
+            continue
+
+        split_records = [
+            record for record in dataset_records if record.get("split") == split
+        ]
+        expected_ids: list[str] = []
+        for index, record in enumerate(split_records):
+            record_id = record.get("id")
+            if not isinstance(record_id, str) or not record_id:
+                errors.append(
+                    f"dataset {split} record at index {index} must have a non-empty "
+                    "string id"
+                )
+                continue
+            expected_ids.append(record_id)
+        if len(expected_ids) != len(set(expected_ids)):
+            errors.append(f"dataset {split} records contain duplicate ids")
+
+        raw_report_records = report.get("records")
+        if not isinstance(raw_report_records, list) or not raw_report_records:
+            errors.append(
+                f"{report_name} report field 'records' must be a non-empty array"
+            )
+            continue
+
+        report_records: dict[str, Mapping[str, Any]] = {}
+        predictions: dict[str, str] = {}
+        for index, raw_record in enumerate(raw_report_records):
+            if not isinstance(raw_record, Mapping):
+                errors.append(
+                    f"{report_name} report record at index {index} must be an object"
+                )
+                continue
+            record_id = raw_record.get("id")
+            prediction = raw_record.get("prediction")
+            if not isinstance(record_id, str) or not record_id:
+                errors.append(
+                    f"{report_name} report record at index {index} must have a "
+                    "non-empty string id"
+                )
+                continue
+            if record_id in report_records:
+                errors.append(
+                    f"{report_name} report contains duplicate id {record_id!r}"
+                )
+                continue
+            if not isinstance(prediction, str):
+                errors.append(
+                    f"{report_name} report record {record_id!r} prediction must be "
+                    "a string"
+                )
+                continue
+            report_records[record_id] = raw_record
+            predictions[record_id] = prediction
+
+        expected_id_set = set(expected_ids)
+        report_id_set = set(report_records)
+        missing_ids = sorted(expected_id_set - report_id_set)
+        extra_ids = sorted(report_id_set - expected_id_set)
+        if missing_ids:
+            errors.append(f"{report_name} report is missing record ids: {missing_ids}")
+        if extra_ids:
+            errors.append(
+                f"{report_name} report has unexpected record ids: {extra_ids}"
+            )
+        if missing_ids or extra_ids or len(expected_ids) != len(expected_id_set):
+            continue
+
+        recomputed = score_predictions(split_records, predictions)
+        for metric_name in _REQUIRED_REPORT_METRICS:
+            reported_score = _read_score(
+                report,
+                report_name=report_name,
+                metric_name=metric_name,
+                errors=errors,
+            )
+            expected_score = float(recomputed[metric_name])
+            if (
+                reported_score is not None
+                and abs(reported_score - expected_score) > _COMPARISON_TOLERANCE
+            ):
+                errors.append(
+                    f"{report_name} metric {metric_name!r} does not match its "
+                    f"records: reported={reported_score:.4f}, "
+                    f"recomputed={expected_score:.4f}"
+                )
+
+        reported_by_task = report.get("by_task")
+        expected_by_task = recomputed["by_task"]
+        if not isinstance(reported_by_task, Mapping):
+            errors.append(f"{report_name} report field 'by_task' must be an object")
+        else:
+            reported_tasks = {
+                task for task in reported_by_task if isinstance(task, str)
+            }
+            expected_tasks = set(expected_by_task)
+            if reported_tasks != expected_tasks:
+                errors.append(
+                    f"{report_name} by_task keys do not match its records: "
+                    f"reported={sorted(reported_tasks)}, "
+                    f"recomputed={sorted(expected_tasks)}"
+                )
+            for task_name, expected_score in expected_by_task.items():
+                reported_score = _read_score(
+                    reported_by_task,
+                    report_name=report_name,
+                    metric_name=task_name,
+                    errors=errors,
+                )
+                if (
+                    reported_score is not None
+                    and abs(reported_score - expected_score) > _COMPARISON_TOLERANCE
+                ):
+                    errors.append(
+                        f"{report_name} by_task {task_name!r} does not match its "
+                        f"records: reported={reported_score:.4f}, "
+                        f"recomputed={expected_score:.4f}"
+                    )
+
+        recomputed_records = {
+            str(record["id"]): record for record in recomputed["records"]
+        }
+        for record_id, raw_record in report_records.items():
+            expected_record = recomputed_records[record_id]
+            if raw_record.get("task") != expected_record["task"]:
+                errors.append(
+                    f"{report_name} record {record_id!r} task does not match the "
+                    "dataset"
+                )
+            for metric_name in ("macro", "term", "refusal"):
+                reported_score = _read_score(
+                    raw_record,
+                    report_name=f"{report_name} record {record_id!r}",
+                    metric_name=metric_name,
+                    errors=errors,
+                )
+                expected_score = float(expected_record[metric_name])
+                if (
+                    reported_score is not None
+                    and abs(reported_score - expected_score) > _COMPARISON_TOLERANCE
+                ):
+                    errors.append(
+                        f"{report_name} record {record_id!r} metric "
+                        f"{metric_name!r} does not match its prediction: "
+                        f"reported={reported_score:.4f}, "
+                        f"recomputed={expected_score:.4f}"
+                    )
+
+    if errors:
+        details = "\n".join(f"- {error}" for error in errors)
+        raise ValueError(f"evaluation report aggregate validation failed:\n{details}")
+
+
 def _valid_sha256(value: object) -> bool:
     return isinstance(value, str) and _SHA256_PATTERN.fullmatch(value) is not None
 
@@ -369,6 +540,12 @@ def _load_and_validate_promotion_reports(
         promoted_test=promoted_test,
         dataset_path=Path(args.dataset),
         model_browser_dir=Path(args.model_browser_dir),
+    )
+    validate_report_aggregates(
+        baseline_test=baseline_test,
+        promoted_validation=promoted_validation,
+        promoted_test=promoted_test,
+        dataset_records=read_jsonl(Path(args.dataset)),
     )
     return baseline_test, promoted_validation, promoted_test
 
@@ -737,7 +914,7 @@ def prepare_dataset_payload(args: argparse.Namespace) -> Path:
         shutil.rmtree(dataset_output_dir)
     dataset_output_dir.mkdir(parents=True, exist_ok=True)
 
-    write_jsonl(dataset_output_dir / "profile_qa.jsonl", records)
+    shutil.copy2(Path(args.dataset), dataset_output_dir / "profile_qa.jsonl")
     for split in ["train", "validation", "test"]:
         write_jsonl(
             dataset_output_dir / f"profile_qa_{split}.jsonl",

--- a/ml/profile-qa/profile_qa/provenance.py
+++ b/ml/profile-qa/profile_qa/provenance.py
@@ -1,0 +1,129 @@
+"""Deterministic provenance helpers for profile-QA evaluation and export."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Collection, Mapping
+from pathlib import Path
+from typing import Any
+
+from .config import PRIMARY_BASE_MODEL_ID, PRIMARY_BASE_MODEL_REVISION
+
+CANDIDATE_PROVENANCE_FILENAME = "profile_qa_candidate_provenance.json"
+PROVENANCE_SCHEMA_VERSION = 1
+_HASH_CHUNK_SIZE = 1024 * 1024
+
+
+def sha256_file(path: Path) -> str:
+    """Return a SHA-256 digest for one regular file."""
+
+    if path.is_symlink() or not path.is_file():
+        raise ValueError(f"provenance input must be a regular file: {path}")
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(_HASH_CHUNK_SIZE), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def sha256_directory(
+    path: Path,
+    *,
+    excluded_relative_paths: Collection[str] = (),
+) -> str:
+    """Hash regular-file paths and contents in a directory deterministically."""
+
+    if path.is_symlink() or not path.is_dir():
+        raise ValueError(f"provenance input must be a directory: {path}")
+
+    excluded = set(excluded_relative_paths)
+    digest = hashlib.sha256()
+    for candidate in sorted(path.rglob("*")):
+        relative_path = candidate.relative_to(path).as_posix()
+        if candidate.is_symlink():
+            raise ValueError(
+                f"provenance directories cannot contain symlinks: {candidate}"
+            )
+        if relative_path in excluded:
+            continue
+        if not candidate.is_file():
+            continue
+        digest.update(relative_path.encode("utf-8"))
+        digest.update(b"\0")
+        with candidate.open("rb") as handle:
+            for chunk in iter(lambda: handle.read(_HASH_CHUNK_SIZE), b""):
+                digest.update(chunk)
+        digest.update(b"\0")
+    return digest.hexdigest()
+
+
+def model_provenance(model_id: str) -> dict[str, Any]:
+    """Describe the pinned baseline or fingerprint a trusted local candidate."""
+
+    if model_id.rstrip("/") == PRIMARY_BASE_MODEL_ID:
+        return {
+            "id": PRIMARY_BASE_MODEL_ID,
+            "revision": PRIMARY_BASE_MODEL_REVISION,
+        }
+
+    model_path = Path(model_id)
+    if not model_path.is_dir():
+        raise ValueError(
+            "candidate evaluation provenance requires --model-id to be a local "
+            f"model directory, got {model_id}"
+        )
+    return {
+        "kind": "local-directory",
+        "sha256": sha256_directory(model_path),
+    }
+
+
+def evaluation_provenance(
+    *,
+    dataset_path: Path,
+    split: str,
+    model_id: str,
+) -> dict[str, Any]:
+    """Build provenance attached to an evaluation report."""
+
+    return {
+        "schema_version": PROVENANCE_SCHEMA_VERSION,
+        "model": model_provenance(model_id),
+        "dataset_sha256": sha256_file(dataset_path),
+        "split": split,
+    }
+
+
+def write_candidate_provenance(
+    *,
+    source_model: str,
+    browser_dir: Path,
+    expected_source: Mapping[str, Any] | None = None,
+) -> Path:
+    """Bind a browser export to the local model directory that produced it."""
+
+    source = model_provenance(source_model)
+    if "sha256" not in source:
+        raise ValueError(
+            "browser candidates must be exported from a local model directory"
+        )
+    if expected_source is not None and source != expected_source:
+        raise RuntimeError(
+            "source model changed while the browser export was in progress"
+        )
+
+    manifest_path = browser_dir / CANDIDATE_PROVENANCE_FILENAME
+    manifest = {
+        "schema_version": PROVENANCE_SCHEMA_VERSION,
+        "source_model": source,
+        "browser_sha256": sha256_directory(
+            browser_dir,
+            excluded_relative_paths={CANDIDATE_PROVENANCE_FILENAME},
+        ),
+    }
+    manifest_path.write_text(
+        json.dumps(manifest, indent=2, sort_keys=True),
+        encoding="utf-8",
+    )
+    return manifest_path

--- a/ml/profile-qa/profile_qa/provenance.py
+++ b/ml/profile-qa/profile_qa/provenance.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import re
 from collections.abc import Collection, Mapping
 from pathlib import Path
 from typing import Any
@@ -13,6 +14,8 @@ from .config import PRIMARY_BASE_MODEL_ID, PRIMARY_BASE_MODEL_REVISION
 CANDIDATE_PROVENANCE_FILENAME = "profile_qa_candidate_provenance.json"
 PROVENANCE_SCHEMA_VERSION = 1
 _HASH_CHUNK_SIZE = 1024 * 1024
+_DIRECTORY_HASH_DOMAIN = b"profile-qa-directory-sha256-v2\0"
+_SHA256_PATTERN = re.compile(r"[0-9a-f]{64}")
 
 
 def sha256_file(path: Path) -> str:
@@ -39,6 +42,7 @@ def sha256_directory(
 
     excluded = set(excluded_relative_paths)
     digest = hashlib.sha256()
+    digest.update(_DIRECTORY_HASH_DOMAIN)
     for candidate in sorted(path.rglob("*")):
         relative_path = candidate.relative_to(path).as_posix()
         if candidate.is_symlink():
@@ -49,13 +53,69 @@ def sha256_directory(
             continue
         if not candidate.is_file():
             continue
-        digest.update(relative_path.encode("utf-8"))
-        digest.update(b"\0")
+        relative_path_bytes = relative_path.encode("utf-8")
+        file_digest = hashlib.sha256()
         with candidate.open("rb") as handle:
             for chunk in iter(lambda: handle.read(_HASH_CHUNK_SIZE), b""):
-                digest.update(chunk)
-        digest.update(b"\0")
+                file_digest.update(chunk)
+        digest.update(len(relative_path_bytes).to_bytes(8, byteorder="big"))
+        digest.update(relative_path_bytes)
+        digest.update(file_digest.digest())
     return digest.hexdigest()
+
+
+def candidate_payload_sha256(payload_dir: Path) -> str:
+    """Hash every regular payload file except the manifest containing the digest."""
+
+    return sha256_directory(
+        payload_dir,
+        excluded_relative_paths={CANDIDATE_PROVENANCE_FILENAME},
+    )
+
+
+def load_candidate_provenance(payload_dir: Path) -> dict[str, Any]:
+    """Load a candidate manifest without following a manifest symlink."""
+
+    manifest_path = payload_dir / CANDIDATE_PROVENANCE_FILENAME
+    if manifest_path.is_symlink():
+        raise ValueError(f"candidate provenance cannot be a symlink: {manifest_path}")
+    try:
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ValueError(
+            f"could not load candidate provenance {manifest_path}: {exc}"
+        ) from exc
+    if not isinstance(manifest, dict):
+        raise ValueError(
+            f"candidate provenance {manifest_path} must contain a JSON object"
+        )
+    return manifest
+
+
+def verify_candidate_payload(payload_dir: Path) -> dict[str, Any]:
+    """Reject a candidate whose containing payload no longer matches its manifest."""
+
+    manifest = load_candidate_provenance(payload_dir)
+    schema_version = manifest.get("schema_version")
+    if type(schema_version) is not int or schema_version != PROVENANCE_SCHEMA_VERSION:
+        raise ValueError(
+            f"candidate provenance schema_version must be {PROVENANCE_SCHEMA_VERSION}"
+        )
+    recorded_sha256 = manifest.get("browser_sha256")
+    if (
+        not isinstance(recorded_sha256, str)
+        or _SHA256_PATTERN.fullmatch(recorded_sha256) is None
+    ):
+        raise ValueError(
+            "candidate provenance browser_sha256 must be a lowercase SHA-256 digest"
+        )
+    actual_sha256 = candidate_payload_sha256(payload_dir)
+    if actual_sha256 != recorded_sha256:
+        raise ValueError(
+            "candidate payload does not match its provenance: "
+            f"recorded={recorded_sha256}, actual={actual_sha256}"
+        )
+    return manifest
 
 
 def model_provenance(model_id: str) -> dict[str, Any]:
@@ -117,11 +177,22 @@ def write_candidate_provenance(
     manifest = {
         "schema_version": PROVENANCE_SCHEMA_VERSION,
         "source_model": source,
-        "browser_sha256": sha256_directory(
-            browser_dir,
-            excluded_relative_paths={CANDIDATE_PROVENANCE_FILENAME},
-        ),
+        "browser_sha256": candidate_payload_sha256(browser_dir),
     }
+    manifest_path.write_text(
+        json.dumps(manifest, indent=2, sort_keys=True),
+        encoding="utf-8",
+    )
+    return manifest_path
+
+
+def refresh_candidate_provenance(browser_dir: Path) -> Path:
+    """Refresh a copied candidate manifest after deterministic payload changes."""
+
+    manifest_path = browser_dir / CANDIDATE_PROVENANCE_FILENAME
+    manifest = load_candidate_provenance(browser_dir)
+
+    manifest["browser_sha256"] = candidate_payload_sha256(browser_dir)
     manifest_path.write_text(
         json.dumps(manifest, indent=2, sort_keys=True),
         encoding="utf-8",

--- a/ml/profile-qa/profile_qa/publish.py
+++ b/ml/profile-qa/profile_qa/publish.py
@@ -6,6 +6,7 @@ import argparse
 from pathlib import Path
 
 from .export_onnx import reject_external_data_files
+from .provenance import verify_candidate_payload
 
 
 def main() -> int:
@@ -19,11 +20,15 @@ def main() -> int:
 
     artifact_dir = Path(args.artifact_dir)
     reject_external_data_files(artifact_dir)
+    if args.repo_type == "model":
+        verify_candidate_payload(artifact_dir)
 
     try:
         from huggingface_hub import HfApi
     except ImportError as exc:
-        raise RuntimeError("Install publish dependencies with pip install -r ml/profile-qa/requirements.txt") from exc
+        raise RuntimeError(
+            "Install publish dependencies with pip install -r ml/profile-qa/requirements.txt"
+        ) from exc
 
     api = HfApi()
     repo_type = None if args.repo_type == "model" else args.repo_type

--- a/ml/profile-qa/tests/test_promotion_metrics.py
+++ b/ml/profile-qa/tests/test_promotion_metrics.py
@@ -1,0 +1,201 @@
+from __future__ import annotations
+
+import argparse
+import json
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+import pytest
+from profile_qa.prepare_hf_artifacts import (
+    prepare_dataset_payload,
+    prepare_model_payload,
+    validate_promotion_metrics,
+)
+
+
+def _report(
+    *,
+    macro: float = 0.92,
+    refusal_accuracy: float = 0.95,
+    multi_turn_accuracy: float = 0.80,
+) -> dict[str, Any]:
+    return {
+        "macro": macro,
+        "refusal_accuracy": refusal_accuracy,
+        "multi_turn_accuracy": multi_turn_accuracy,
+        "by_task": {
+            "multi_turn": multi_turn_accuracy,
+            "refusal": refusal_accuracy,
+            "single_turn": macro,
+        },
+    }
+
+
+def _passing_reports() -> dict[str, dict[str, Any]]:
+    return {
+        "baseline_test": _report(macro=0.80),
+        "promoted_validation": _report(macro=0.90),
+        "promoted_test": _report(macro=0.92),
+    }
+
+
+def test_promotion_metrics_accept_exact_thresholds() -> None:
+    reports = _passing_reports()
+
+    validate_promotion_metrics(**reports)
+
+
+@pytest.mark.parametrize(
+    ("report_name", "metric_name", "value", "message"),
+    [
+        (
+            "promoted_test",
+            "macro",
+            0.919,
+            "must improve on baseline test by at least 15%",
+        ),
+        (
+            "promoted_validation",
+            "refusal_accuracy",
+            0.949,
+            "promoted validation metric 'refusal_accuracy'",
+        ),
+        (
+            "promoted_test",
+            "refusal_accuracy",
+            0.949,
+            "promoted test metric 'refusal_accuracy'",
+        ),
+        (
+            "promoted_validation",
+            "multi_turn_accuracy",
+            0.799,
+            "promoted validation metric 'multi_turn_accuracy'",
+        ),
+        (
+            "promoted_test",
+            "multi_turn_accuracy",
+            0.799,
+            "promoted test metric 'multi_turn_accuracy'",
+        ),
+    ],
+)
+def test_promotion_metrics_reject_threshold_failures(
+    report_name: str,
+    metric_name: str,
+    value: float,
+    message: str,
+) -> None:
+    reports = _passing_reports()
+    reports[report_name][metric_name] = value
+
+    with pytest.raises(ValueError, match=message):
+        validate_promotion_metrics(**reports)
+
+
+def test_promotion_metrics_reject_missing_metrics() -> None:
+    reports = _passing_reports()
+    del reports["baseline_test"]["macro"]
+
+    with pytest.raises(
+        ValueError, match="baseline test report is missing metric 'macro'"
+    ):
+        validate_promotion_metrics(**reports)
+
+
+def test_promotion_metrics_reject_zero_baseline_for_relative_comparison() -> None:
+    reports = _passing_reports()
+    reports["baseline_test"]["macro"] = 0.0
+
+    with pytest.raises(ValueError, match="baseline test macro must be greater than 0"):
+        validate_promotion_metrics(**reports)
+
+
+@pytest.mark.parametrize(
+    ("value", "message"),
+    [
+        ("0.95", "must be a number"),
+        (float("nan"), "must be finite"),
+        (1.01, "must be between 0 and 1"),
+    ],
+)
+def test_promotion_metrics_reject_invalid_score_values(
+    value: object,
+    message: str,
+) -> None:
+    reports = _passing_reports()
+    reports["promoted_validation"]["refusal_accuracy"] = value
+
+    with pytest.raises(ValueError, match=message):
+        validate_promotion_metrics(**reports)
+
+
+def test_promotion_metrics_reject_malformed_task_metrics() -> None:
+    reports = _passing_reports()
+    reports["promoted_test"]["by_task"] = []
+
+    with pytest.raises(ValueError, match="field 'by_task' must be a non-empty object"):
+        validate_promotion_metrics(**reports)
+
+
+def test_promotion_metrics_reject_non_object_reports() -> None:
+    reports = _passing_reports()
+
+    with pytest.raises(ValueError, match="promoted test report must be a JSON object"):
+        validate_promotion_metrics(
+            baseline_test=reports["baseline_test"],
+            promoted_validation=reports["promoted_validation"],
+            promoted_test=[],
+        )
+
+
+def _write_report(path: Path, report: dict[str, Any]) -> None:
+    path.write_text(json.dumps(report), encoding="utf-8")
+
+
+@pytest.mark.parametrize(
+    ("prepare_payload", "payload_name"),
+    [
+        (prepare_model_payload, "model"),
+        (prepare_dataset_payload, "dataset"),
+    ],
+)
+def test_payload_preflight_preserves_existing_output_on_metric_failure(
+    tmp_path: Path,
+    prepare_payload: Callable[[argparse.Namespace], Path],
+    payload_name: str,
+) -> None:
+    browser_dir = tmp_path / "browser"
+    browser_dir.mkdir()
+    dataset_path = tmp_path / "profile_qa.jsonl"
+    dataset_path.write_text("{}\n", encoding="utf-8")
+
+    reports = _passing_reports()
+    reports["promoted_validation"]["refusal_accuracy"] = 0.94
+    report_paths = {
+        report_name: tmp_path / f"{report_name}.json" for report_name in reports
+    }
+    for report_name, report in reports.items():
+        _write_report(report_paths[report_name], report)
+
+    output_dir = tmp_path / "hf"
+    existing_payload = output_dir / payload_name
+    existing_payload.mkdir(parents=True)
+    sentinel = existing_payload / "keep.txt"
+    sentinel.write_text("unchanged", encoding="utf-8")
+    args = argparse.Namespace(
+        baseline_report=str(report_paths["baseline_test"]),
+        validation_report=str(report_paths["promoted_validation"]),
+        test_report=str(report_paths["promoted_test"]),
+        model_browser_dir=str(browser_dir),
+        dataset=str(dataset_path),
+        output_dir=str(output_dir),
+        model_repo_id="example/model",
+        dataset_repo_id="example/dataset",
+    )
+
+    with pytest.raises(ValueError, match="promotion metric validation failed"):
+        prepare_payload(args)
+
+    assert sentinel.read_text(encoding="utf-8") == "unchanged"

--- a/ml/profile-qa/tests/test_promotion_metrics.py
+++ b/ml/profile-qa/tests/test_promotion_metrics.py
@@ -6,14 +6,16 @@ from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 
+import profile_qa.prepare_hf_artifacts as prepare_hf_artifacts_module
 import pytest
 from profile_qa.config import PRIMARY_BASE_MODEL_ID
-from profile_qa.evaluate import _load_prediction_bundle
+from profile_qa.evaluate import _load_prediction_bundle, score_predictions
 from profile_qa.prepare_hf_artifacts import (
     prepare_dataset_payload,
     prepare_model_payload,
     validate_promotion_metrics,
     validate_promotion_provenance,
+    validate_report_aggregates,
 )
 from profile_qa.provenance import (
     evaluation_provenance,
@@ -207,6 +209,102 @@ def _write_report(path: Path, report: dict[str, Any]) -> None:
     path.write_text(json.dumps(report), encoding="utf-8")
 
 
+def _aggregate_inputs() -> tuple[dict[str, dict[str, Any]], list[dict[str, Any]]]:
+    records: list[dict[str, Any]] = []
+    for split in ("validation", "test"):
+        records.extend(
+            [
+                {
+                    "id": f"{split}-refusal",
+                    "split": split,
+                    "task": "refusal",
+                    "expected_terms": [],
+                    "requires_refusal": True,
+                },
+                {
+                    "id": f"{split}-multi-turn",
+                    "split": split,
+                    "task": "multi_turn",
+                    "expected_terms": ["alpha"],
+                    "requires_refusal": False,
+                },
+                {
+                    "id": f"{split}-single-turn",
+                    "split": split,
+                    "task": "single_turn",
+                    "expected_terms": ["beta"],
+                    "requires_refusal": False,
+                },
+            ]
+        )
+
+    validation_records = [
+        record for record in records if record["split"] == "validation"
+    ]
+    test_records = [record for record in records if record["split"] == "test"]
+    validation_predictions = {
+        "validation-refusal": "The public profile does not say.",
+        "validation-multi-turn": "alpha",
+        "validation-single-turn": "beta",
+    }
+    promoted_test_predictions = {
+        "test-refusal": "The public profile does not say.",
+        "test-multi-turn": "alpha",
+        "test-single-turn": "beta",
+    }
+    baseline_test_predictions = {
+        "test-refusal": "The public profile does not say.",
+        "test-multi-turn": "",
+        "test-single-turn": "",
+    }
+    return (
+        {
+            "baseline_test": score_predictions(
+                test_records,
+                baseline_test_predictions,
+            ),
+            "promoted_validation": score_predictions(
+                validation_records,
+                validation_predictions,
+            ),
+            "promoted_test": score_predictions(
+                test_records,
+                promoted_test_predictions,
+            ),
+        },
+        records,
+    )
+
+
+def test_report_aggregates_match_rescored_predictions() -> None:
+    reports, records = _aggregate_inputs()
+
+    validate_report_aggregates(**reports, dataset_records=records)
+
+
+def test_report_aggregates_reject_forged_scores() -> None:
+    reports, records = _aggregate_inputs()
+    for report_record in reports["promoted_test"]["records"]:
+        report_record["prediction"] = ""
+
+    with pytest.raises(
+        ValueError,
+        match="promoted test metric 'macro' does not match its records",
+    ):
+        validate_report_aggregates(**reports, dataset_records=records)
+
+
+def test_report_aggregates_reject_corrupt_record_scores() -> None:
+    reports, records = _aggregate_inputs()
+    reports["promoted_test"]["records"][0]["macro"] = 0.0
+
+    with pytest.raises(
+        ValueError,
+        match="promoted test record 'test-refusal' metric 'macro'",
+    ):
+        validate_report_aggregates(**reports, dataset_records=records)
+
+
 def _provenance_inputs(
     tmp_path: Path,
 ) -> tuple[dict[str, dict[str, Any]], Path, Path, Path]:
@@ -353,6 +451,46 @@ def test_promotion_provenance_rejects_boolean_schema_version(tmp_path: Path) -> 
             dataset_path=dataset_path,
             model_browser_dir=browser_dir,
         )
+
+
+def test_dataset_payload_preserves_fingerprinted_source_bytes(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    dataset_path = tmp_path / "profile_qa.jsonl"
+    source_bytes = b'{ "task": "single_turn", "split": "train", "id": "example" }\r\n'
+    dataset_path.write_bytes(source_bytes)
+
+    reports = _passing_reports()
+    monkeypatch.setattr(
+        prepare_hf_artifacts_module,
+        "_load_and_validate_promotion_reports",
+        lambda args: (
+            reports["baseline_test"],
+            reports["promoted_validation"],
+            reports["promoted_test"],
+        ),
+    )
+    report_paths = {
+        report_name: tmp_path / f"{report_name}.json" for report_name in reports
+    }
+    for report_path in report_paths.values():
+        report_path.write_text("{}", encoding="utf-8")
+
+    args = argparse.Namespace(
+        baseline_report=str(report_paths["baseline_test"]),
+        validation_report=str(report_paths["promoted_validation"]),
+        test_report=str(report_paths["promoted_test"]),
+        model_browser_dir=str(tmp_path / "browser"),
+        dataset=str(dataset_path),
+        output_dir=str(tmp_path / "hf"),
+        model_repo_id="example/model",
+        dataset_repo_id="example/dataset",
+    )
+
+    payload_dir = prepare_dataset_payload(args)
+
+    assert (payload_dir / "profile_qa.jsonl").read_bytes() == source_bytes
 
 
 @pytest.mark.parametrize(

--- a/ml/profile-qa/tests/test_promotion_metrics.py
+++ b/ml/profile-qa/tests/test_promotion_metrics.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import sys
 from collections.abc import Callable
 from pathlib import Path
 from typing import Any
@@ -18,9 +19,14 @@ from profile_qa.prepare_hf_artifacts import (
     validate_report_aggregates,
 )
 from profile_qa.provenance import (
+    CANDIDATE_PROVENANCE_FILENAME,
+    candidate_payload_sha256,
     evaluation_provenance,
+    sha256_directory,
+    verify_candidate_payload,
     write_candidate_provenance,
 )
+from profile_qa.publish import main as publish_main
 
 
 def _report(
@@ -451,6 +457,99 @@ def test_promotion_provenance_rejects_boolean_schema_version(tmp_path: Path) -> 
             dataset_path=dataset_path,
             model_browser_dir=browser_dir,
         )
+
+
+def test_directory_hash_frames_binary_file_records(tmp_path: Path) -> None:
+    single_file_dir = tmp_path / "single"
+    single_file_dir.mkdir()
+    (single_file_dir / "a").write_bytes(b"x\0b\0y")
+
+    two_file_dir = tmp_path / "two"
+    two_file_dir.mkdir()
+    (two_file_dir / "a").write_bytes(b"x")
+    (two_file_dir / "b").write_bytes(b"y")
+
+    assert sha256_directory(single_file_dir) != sha256_directory(two_file_dir)
+
+
+def test_model_payload_refreshes_manifest_after_writing_card(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source_model_dir = tmp_path / "merged-model"
+    source_model_dir.mkdir()
+    (source_model_dir / "model.safetensors").write_bytes(b"candidate weights")
+    browser_dir = tmp_path / "browser"
+    browser_dir.mkdir()
+    (browser_dir / "config.json").write_text("{}", encoding="utf-8")
+    write_candidate_provenance(
+        source_model=str(source_model_dir),
+        browser_dir=browser_dir,
+    )
+
+    reports = _passing_reports()
+    monkeypatch.setattr(
+        prepare_hf_artifacts_module,
+        "_load_and_validate_promotion_reports",
+        lambda args: (
+            reports["baseline_test"],
+            reports["promoted_validation"],
+            reports["promoted_test"],
+        ),
+    )
+    args = argparse.Namespace(
+        model_browser_dir=str(browser_dir),
+        output_dir=str(tmp_path / "hf"),
+        model_repo_id="example/model",
+        dataset_repo_id="example/dataset",
+    )
+
+    payload_dir = prepare_model_payload(args)
+    manifest = json.loads(
+        (payload_dir / CANDIDATE_PROVENANCE_FILENAME).read_text(encoding="utf-8")
+    )
+
+    assert (payload_dir / "README.md").is_file()
+    assert manifest["browser_sha256"] == candidate_payload_sha256(payload_dir)
+    assert verify_candidate_payload(payload_dir) == manifest
+
+    (payload_dir / "generated-after-preparation.txt").write_text(
+        "unexpected",
+        encoding="utf-8",
+    )
+    with pytest.raises(ValueError, match="candidate payload does not match"):
+        verify_candidate_payload(payload_dir)
+
+
+def test_model_publish_rechecks_candidate_payload_boundary(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source_model_dir = tmp_path / "merged-model"
+    source_model_dir.mkdir()
+    (source_model_dir / "model.safetensors").write_bytes(b"candidate weights")
+    payload_dir = tmp_path / "model-payload"
+    payload_dir.mkdir()
+    (payload_dir / "config.json").write_text("{}", encoding="utf-8")
+    write_candidate_provenance(
+        source_model=str(source_model_dir),
+        browser_dir=payload_dir,
+    )
+    (payload_dir / "late-generated-file.txt").write_text("tamper", encoding="utf-8")
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "profile_qa.publish",
+            "--repo-id",
+            "example/model",
+            "--artifact-dir",
+            str(payload_dir),
+        ],
+    )
+
+    with pytest.raises(ValueError, match="candidate payload does not match"):
+        publish_main()
 
 
 def test_dataset_payload_preserves_fingerprinted_source_bytes(

--- a/ml/profile-qa/tests/test_promotion_metrics.py
+++ b/ml/profile-qa/tests/test_promotion_metrics.py
@@ -7,10 +7,17 @@ from pathlib import Path
 from typing import Any
 
 import pytest
+from profile_qa.config import PRIMARY_BASE_MODEL_ID
+from profile_qa.evaluate import _load_prediction_bundle
 from profile_qa.prepare_hf_artifacts import (
     prepare_dataset_payload,
     prepare_model_payload,
     validate_promotion_metrics,
+    validate_promotion_provenance,
+)
+from profile_qa.provenance import (
+    evaluation_provenance,
+    write_candidate_provenance,
 )
 
 
@@ -89,6 +96,12 @@ def test_promotion_metrics_reject_threshold_failures(
 ) -> None:
     reports = _passing_reports()
     reports[report_name][metric_name] = value
+    task_name_by_metric = {
+        "refusal_accuracy": "refusal",
+        "multi_turn_accuracy": "multi_turn",
+    }
+    if metric_name in task_name_by_metric:
+        reports[report_name]["by_task"][task_name_by_metric[metric_name]] = value
 
     with pytest.raises(ValueError, match=message):
         validate_promotion_metrics(**reports)
@@ -139,6 +152,46 @@ def test_promotion_metrics_reject_malformed_task_metrics() -> None:
         validate_promotion_metrics(**reports)
 
 
+@pytest.mark.parametrize("report_name", ["promoted_validation", "promoted_test"])
+@pytest.mark.parametrize("task_name", ["refusal", "multi_turn"])
+def test_promotion_metrics_require_gated_task_metrics(
+    report_name: str,
+    task_name: str,
+) -> None:
+    reports = _passing_reports()
+    del reports[report_name]["by_task"][task_name]
+
+    with pytest.raises(
+        ValueError,
+        match=rf"{report_name.replace('_', ' ')} report is missing required by_task entry '{task_name}'",
+    ):
+        validate_promotion_metrics(**reports)
+
+
+@pytest.mark.parametrize(
+    ("report_name", "task_name", "metric_name"),
+    [
+        ("promoted_validation", "refusal", "refusal_accuracy"),
+        ("promoted_validation", "multi_turn", "multi_turn_accuracy"),
+        ("promoted_test", "refusal", "refusal_accuracy"),
+        ("promoted_test", "multi_turn", "multi_turn_accuracy"),
+    ],
+)
+def test_promotion_metrics_reject_inconsistent_task_and_top_level_scores(
+    report_name: str,
+    task_name: str,
+    metric_name: str,
+) -> None:
+    reports = _passing_reports()
+    reports[report_name]["by_task"][task_name] = 0.99
+
+    with pytest.raises(
+        ValueError,
+        match=rf"{report_name.replace('_', ' ')} by_task '{task_name}' must agree with '{metric_name}'",
+    ):
+        validate_promotion_metrics(**reports)
+
+
 def test_promotion_metrics_reject_non_object_reports() -> None:
     reports = _passing_reports()
 
@@ -154,6 +207,154 @@ def _write_report(path: Path, report: dict[str, Any]) -> None:
     path.write_text(json.dumps(report), encoding="utf-8")
 
 
+def _provenance_inputs(
+    tmp_path: Path,
+) -> tuple[dict[str, dict[str, Any]], Path, Path, Path]:
+    dataset_path = tmp_path / "profile_qa.jsonl"
+    dataset_path.write_text('{"id":"example"}\n', encoding="utf-8")
+
+    source_model_dir = tmp_path / "merged-model"
+    source_model_dir.mkdir()
+    (source_model_dir / "model.safetensors").write_bytes(b"candidate weights")
+
+    browser_dir = tmp_path / "browser"
+    browser_dir.mkdir()
+    (browser_dir / "config.json").write_text("{}", encoding="utf-8")
+    write_candidate_provenance(
+        source_model=str(source_model_dir),
+        browser_dir=browser_dir,
+    )
+
+    reports = _passing_reports()
+    reports["baseline_test"]["provenance"] = evaluation_provenance(
+        dataset_path=dataset_path,
+        split="test",
+        model_id=PRIMARY_BASE_MODEL_ID,
+    )
+    for report_name, split in (
+        ("promoted_validation", "validation"),
+        ("promoted_test", "test"),
+    ):
+        reports[report_name]["provenance"] = evaluation_provenance(
+            dataset_path=dataset_path,
+            split=split,
+            model_id=str(source_model_dir),
+        )
+    return reports, dataset_path, source_model_dir, browser_dir
+
+
+def test_promotion_provenance_accepts_matching_candidate_dataset_and_splits(
+    tmp_path: Path,
+) -> None:
+    reports, dataset_path, _, browser_dir = _provenance_inputs(tmp_path)
+
+    validate_promotion_provenance(
+        **reports,
+        dataset_path=dataset_path,
+        model_browser_dir=browser_dir,
+    )
+
+
+def test_promotion_provenance_rejects_stale_candidate_report(tmp_path: Path) -> None:
+    reports, dataset_path, _, browser_dir = _provenance_inputs(tmp_path)
+    reports["promoted_test"]["provenance"]["model"]["sha256"] = "0" * 64
+
+    with pytest.raises(
+        ValueError,
+        match="promoted test provenance model does not match the browser candidate",
+    ):
+        validate_promotion_provenance(
+            **reports,
+            dataset_path=dataset_path,
+            model_browser_dir=browser_dir,
+        )
+
+
+def test_promotion_provenance_rejects_stale_dataset_report(tmp_path: Path) -> None:
+    reports, dataset_path, _, browser_dir = _provenance_inputs(tmp_path)
+    dataset_path.write_text('{"id":"changed"}\n', encoding="utf-8")
+
+    with pytest.raises(ValueError, match="does not match dataset"):
+        validate_promotion_provenance(
+            **reports,
+            dataset_path=dataset_path,
+            model_browser_dir=browser_dir,
+        )
+
+
+def test_promotion_provenance_rejects_wrong_report_split(tmp_path: Path) -> None:
+    reports, dataset_path, _, browser_dir = _provenance_inputs(tmp_path)
+    reports["promoted_validation"]["provenance"]["split"] = "test"
+
+    with pytest.raises(
+        ValueError,
+        match="promoted validation provenance split must be 'validation'",
+    ):
+        validate_promotion_provenance(
+            **reports,
+            dataset_path=dataset_path,
+            model_browser_dir=browser_dir,
+        )
+
+
+def test_promotion_provenance_rejects_modified_browser_artifact(tmp_path: Path) -> None:
+    reports, dataset_path, _, browser_dir = _provenance_inputs(tmp_path)
+    (browser_dir / "config.json").write_text('{"changed":true}', encoding="utf-8")
+
+    with pytest.raises(
+        ValueError,
+        match="candidate browser artifact does not match its provenance",
+    ):
+        validate_promotion_provenance(
+            **reports,
+            dataset_path=dataset_path,
+            model_browser_dir=browser_dir,
+        )
+
+
+def test_prediction_bundle_requires_matching_provenance(tmp_path: Path) -> None:
+    reports, _, _, _ = _provenance_inputs(tmp_path)
+    expected_provenance = reports["promoted_test"]["provenance"]
+    bundle_path = tmp_path / "predictions.json"
+    bundle_path.write_text(
+        json.dumps(
+            {
+                "predictions": {"example": "answer"},
+                "provenance": expected_provenance,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    assert _load_prediction_bundle(
+        bundle_path,
+        expected_provenance=expected_provenance,
+    ) == {"example": "answer"}
+
+    stale_provenance = dict(expected_provenance)
+    stale_provenance["split"] = "validation"
+    with pytest.raises(ValueError, match="provenance does not match"):
+        _load_prediction_bundle(
+            bundle_path,
+            expected_provenance=stale_provenance,
+        )
+
+
+def test_promotion_provenance_rejects_boolean_schema_version(tmp_path: Path) -> None:
+    reports, dataset_path, _, browser_dir = _provenance_inputs(tmp_path)
+    reports["promoted_test"]["provenance"]["schema_version"] = True
+
+    with pytest.raises(
+        ValueError,
+        match="promoted test provenance schema_version must be 1",
+    ):
+        validate_promotion_provenance(
+            **reports,
+            dataset_path=dataset_path,
+            model_browser_dir=browser_dir,
+        )
+
+
 @pytest.mark.parametrize(
     ("prepare_payload", "payload_name"),
     [
@@ -166,13 +367,9 @@ def test_payload_preflight_preserves_existing_output_on_metric_failure(
     prepare_payload: Callable[[argparse.Namespace], Path],
     payload_name: str,
 ) -> None:
-    browser_dir = tmp_path / "browser"
-    browser_dir.mkdir()
-    dataset_path = tmp_path / "profile_qa.jsonl"
-    dataset_path.write_text("{}\n", encoding="utf-8")
-
-    reports = _passing_reports()
+    reports, dataset_path, _, browser_dir = _provenance_inputs(tmp_path)
     reports["promoted_validation"]["refusal_accuracy"] = 0.94
+    reports["promoted_validation"]["by_task"]["refusal"] = 0.94
     report_paths = {
         report_name: tmp_path / f"{report_name}.json" for report_name in reports
     }
@@ -196,6 +393,48 @@ def test_payload_preflight_preserves_existing_output_on_metric_failure(
     )
 
     with pytest.raises(ValueError, match="promotion metric validation failed"):
+        prepare_payload(args)
+
+    assert sentinel.read_text(encoding="utf-8") == "unchanged"
+
+
+@pytest.mark.parametrize(
+    ("prepare_payload", "payload_name"),
+    [
+        (prepare_model_payload, "model"),
+        (prepare_dataset_payload, "dataset"),
+    ],
+)
+def test_payload_preflight_preserves_existing_output_on_provenance_failure(
+    tmp_path: Path,
+    prepare_payload: Callable[[argparse.Namespace], Path],
+    payload_name: str,
+) -> None:
+    reports, dataset_path, _, browser_dir = _provenance_inputs(tmp_path)
+    reports["promoted_test"]["provenance"]["model"]["sha256"] = "0" * 64
+    report_paths = {
+        report_name: tmp_path / f"{report_name}.json" for report_name in reports
+    }
+    for report_name, report in reports.items():
+        _write_report(report_paths[report_name], report)
+
+    output_dir = tmp_path / "hf"
+    existing_payload = output_dir / payload_name
+    existing_payload.mkdir(parents=True)
+    sentinel = existing_payload / "keep.txt"
+    sentinel.write_text("unchanged", encoding="utf-8")
+    args = argparse.Namespace(
+        baseline_report=str(report_paths["baseline_test"]),
+        validation_report=str(report_paths["promoted_validation"]),
+        test_report=str(report_paths["promoted_test"]),
+        model_browser_dir=str(browser_dir),
+        dataset=str(dataset_path),
+        output_dir=str(output_dir),
+        model_repo_id="example/model",
+        dataset_repo_id="example/dataset",
+    )
+
+    with pytest.raises(ValueError, match="promotion provenance validation failed"):
         prepare_payload(args)
 
     assert sentinel.read_text(encoding="utf-8") == "unchanged"


### PR DESCRIPTION
## What

- Require promoted test macro accuracy to improve on baseline by at least 15%.
- Require both promoted validation and test reports to reach 0.95 refusal accuracy and 0.80 multi-turn accuracy.
- Fail closed on missing, malformed, nonnumeric, nonfinite, or out-of-range reports and task metrics.
- Validate before replacing either model or dataset payloads.
- Separate automated report gates from the remaining manual release checks in the docs.

## Why

The repository documents promotion criteria but the packaging command currently accepts any supplied reports. A weak or malformed checkpoint can therefore be packaged and published despite failing the stated release policy.

## Validation

- Full Python suite: 33 passed.
- Ruff formatting, `E`, `F`, and import checks passed.
- `git diff --check` passed.

Tests ran with Python 3.12 because the repository-pinned Python 3.14 runtime was unavailable. GPU training/evaluation, ONNX export, browser smoke, and artifact inspection remain manual release gates.