### PR TITLE
Correct the Hugging Face model task metadata

### DIFF
--- a/ml/profile-qa/README.md
+++ b/ml/profile-qa/README.md
@@ -78,7 +78,9 @@ The training, continuation, merge, and export commands are Teapot-only. Training
 always starts from `teapotai/teapotllm`; adapter continuation and merge reject
 checkpoints whose PEFT metadata records a different base model; export expects
 the merged model directory produced by `profile_qa.merge_adapter` and publishes
-the encoder plus merged decoder ONNX files for the T5 browser runtime.
+the encoder plus merged decoder ONNX files for the T5 browser runtime. Artifact
+preparation labels the model card with `pipeline_tag: text2text-generation`,
+matching the Transformers.js task used by the deployed browser worker.
 
 For targeted continuation from an existing LoRA adapter:
 

--- a/ml/profile-qa/profile_qa/prepare_hf_artifacts.py
+++ b/ml/profile-qa/profile_qa/prepare_hf_artifacts.py
@@ -16,6 +16,7 @@ from .validation import read_jsonl, write_jsonl
 
 DEFAULT_MODEL_REPO_ID = "justinthelaw/teapot-profile-qa-browser-1024"
 DEFAULT_DATASET_REPO_ID = "justinthelaw/profile-qa-synthetic-public-v1"
+BROWSER_PIPELINE_TASK = "text2text-generation"
 
 
 def _load_report(path: Path) -> dict[str, Any]:
@@ -106,7 +107,7 @@ def _write_model_card(
 license: mit
 library_name: transformers.js
 base_model: teapotai/teapotllm
-pipeline_tag: text-generation
+pipeline_tag: {BROWSER_PIPELINE_TASK}
 tags:
 - transformers.js
 - onnx
@@ -128,9 +129,8 @@ This model is a browser-oriented ONNX export of a local LoRA continuation from
 `teapotai/teapotllm`. It is tuned for public resume/profile Q&A prompts that fit
 within a 1024-token browser context budget.
 
-Hugging Face model metadata uses the official `text-generation` task category;
-the browser runtime still loads this T5-style export with the Transformers.js
-`text2text-generation` pipeline.
+This T5-style artifact is exported for and loaded by the Transformers.js
+`{BROWSER_PIPELINE_TASK}` pipeline.
 
 The target use case is a static portfolio or resume site that runs inference in
 the browser with Transformers.js, without API routes, hosted inference, server
@@ -157,7 +157,7 @@ as self-contained browser assets.
 import {{ pipeline }} from "@huggingface/transformers";
 
 const generator = await pipeline(
-  "text2text-generation",
+  "{BROWSER_PIPELINE_TASK}",
   "{model_repo_id}",
   {{ dtype: "int8" }},
 );

--- a/ml/profile-qa/tests/test_prepare_hf_artifacts.py
+++ b/ml/profile-qa/tests/test_prepare_hf_artifacts.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from profile_qa.prepare_hf_artifacts import BROWSER_PIPELINE_TASK, _write_model_card
+
+
+class ModelCardMetadataTests(unittest.TestCase):
+    def test_model_card_task_matches_browser_deployment(self) -> None:
+        report = {
+            "macro": 1.0,
+            "refusal_accuracy": 1.0,
+            "multi_turn_accuracy": 1.0,
+            "by_task": {"single_turn": 1.0},
+        }
+
+        with tempfile.TemporaryDirectory() as directory:
+            output_path = Path(directory) / "README.md"
+            _write_model_card(
+                output_path,
+                model_repo_id="owner/model",
+                dataset_repo_id="owner/dataset",
+                baseline_test=report,
+                promoted_validation=report,
+                promoted_test=report,
+            )
+            model_card = output_path.read_text(encoding="utf-8")
+
+        self.assertEqual(BROWSER_PIPELINE_TASK, "text2text-generation")
+        self.assertIn(
+            f"pipeline_tag: {BROWSER_PIPELINE_TASK}\n",
+            model_card,
+        )
+        self.assertIn(f"`{BROWSER_PIPELINE_TASK}` pipeline.", model_card)
+        self.assertIn(f'  "{BROWSER_PIPELINE_TASK}",', model_card)
+        self.assertNotIn("pipeline_tag: text-generation\n", model_card)
+        self.assertNotIn("official `text-generation` task category", model_card)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What

- Emit `pipeline_tag: text2text-generation` for the exported T5 model card.
- Derive the prose and Transformers.js example from the same task constant.
- Document the deployed task contract in the publishing guide.
- Add rendered-card regression coverage.

## Why

The generated model card advertises `text-generation`, even though the exported T5 artifact and browser runtime require `text2text-generation`. Consumers following the published metadata or sample code will choose an incompatible pipeline.

## Validation

- Targeted model-card test passed.
- Available unittest suite: 4/4 passed.
- Markdown lint passed.
- Python AST parsing passed.
- `git diff --check` passed.