### PR TITLE
Gate Pages deployment on application checks

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -77,8 +77,17 @@ jobs:
       - name: Install Dependencies
         run: ${{ steps.detect-package-manager.outputs.manager }} ${{ steps.detect-package-manager.outputs.command }}
 
+      - name: Lint Code
+        run: ${{ steps.detect-package-manager.outputs.manager }} run lint
+
       - name: Build with Next.js
         run: ${{ steps.detect-package-manager.outputs.manager }} run build
+
+      - name: Install Playwright Browsers
+        run: ${{ steps.detect-package-manager.outputs.runner }} playwright install --with-deps
+
+      - name: Run Playwright Tests
+        run: ${{ steps.detect-package-manager.outputs.runner }} playwright test
 
       - name: Upload Artifact
         uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0


### PR DESCRIPTION
## What

- Run application lint after installing the exact deployment candidate's dependencies.
- Build that candidate, install the locked Playwright browsers, and run the browser suite before artifact upload.
- Preserve the existing trigger, permissions, Pages build, and `deploy.needs: build` structure.

## Why

The main-branch Pages workflow currently builds and deploys without running lint or browser tests. A direct or merged change can therefore reach production even when the repository's application checks would fail.

## Validation

- PyYAML parsed the workflow.
- Structural assertions verified install → lint → build → browser install → browser tests → artifact upload and `deploy.needs: build`.
- Locked Playwright 1.62.1 resolved.
- Full application lint passed.
- `git diff --check` passed.