### PR TITLE
Patch high-severity transitive dependency vulnerabilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2300,9 +2300,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3895,9 +3895,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.17",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
+      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,8 @@
   },
   "overrides": {
     "adm-zip": "0.6.0",
+    "brace-expansion": "5.0.9",
+    "nanoid": "3.3.17",
     "postcss": "$postcss",
     "protobufjs": "7.6.5",
     "sharp": "0.35.3"


### PR DESCRIPTION
## What

- Override `brace-expansion` to 5.0.9, fixing GHSA-rgw5-rvv9-x895.
- Override `nanoid` to 3.3.17, fixing GHSA-2v37-7h3g-55p8.
- Regenerate the lockfile with the repository's declared Node 24.18.1 and npm 12.0.2 toolchain.

## Why

`npm audit` reports two high-severity denial-of-service advisories in the locked dependency graph: `brace-expansion` 5.0.8 through ESLint/minimatch and `nanoid` 3.3.16 through PostCSS.

## Validation

- Clean `npm ci --ignore-scripts` succeeded with Node 24.18.1/npm 12.0.2.
- `npm ls` resolves `brace-expansion@5.0.9` and `nanoid@3.3.17`.
- `npm audit --package-lock-only`: 0 vulnerabilities.
- Full application lint passed.
- `git diff --check` passed.