### PR TITLE
Scope Pages workflow permissions by job

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,10 +13,7 @@ on:
       - "*.mjs"
   workflow_dispatch:
 
-permissions:
-  contents: read
-  pages: write
-  id-token: write
+permissions: {}
 
 concurrency:
   group: deploy-${{ github.ref }}
@@ -24,6 +21,9 @@ concurrency:
 
 jobs:
   build:
+    permissions:
+      contents: read
+      pages: read
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -86,6 +86,9 @@ jobs:
           path: out
 
   deploy:
+    permissions:
+      pages: write
+      id-token: write
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}


### PR DESCRIPTION
## What

- Default the workflow token to no permissions.
- Give the build job only `contents: read` and `pages: read`.
- Give the deploy job only `pages: write` and `id-token: write`.

## Why

The current workflow grants Pages write and OIDC token minting to every step in the build job, including dependency installation, build scripts, and browser tests. GitHub supports job-level token permissions, so deployment authority can be isolated to the one job that needs it.

## Validation

- PyYAML parsed the workflow.
- Structural assertions verified the exact workflow/build/deploy permission maps.
- `git diff --check` passed.