### PR TITLE
Use one canonical public profile data source

### DIFF
--- a/.github/workflows/ml.test.yml
+++ b/.github/workflows/ml.test.yml
@@ -10,6 +10,7 @@ on:
     paths:
       - ".github/workflows/ml.test.yml"
       - "ml/profile-qa/**"
+      - "src/config/public-profile.json"
   schedule:
     - cron: "23 7 * * 1"
   workflow_dispatch:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,7 +63,7 @@ src/
 │   └── chat/
 │       ├── components/  # UI components (ChatContainer, ChatMessages, ChatInput, etc.)
 │       └── hooks/       # Business logic (useAIGeneration, useChatHistory, useModelManagement)
-├── config/              # Centralized settings (site.ts, models.ts, prompts.ts)
+├── config/              # Centralized settings and canonical public-profile JSON
 ├── pages/               # Next.js pages router (index.tsx, _app.tsx)
 ├── services/            # External dependencies
 │   ├── ai/              # AI service layer (worker, model loader, context provider)
@@ -85,6 +85,7 @@ tests/                   # Playwright E2E tests
 | Typed worker messages | Use `WorkerAction` and `WorkerStatus` enums for worker communication; avoid magic strings |
 | Browser-safe dtype loading | Automatic model loading uses int8 with uint8 fallback on all viewports; do not re-enable q4 by default unless ORT WASM can mount external `.onnx.data` files in browser workers |
 | Reusable profile sections | Keep section IDs generic and temporally prioritized; put person- or employer-specific terms in fact text and keywords, not section IDs |
+| Canonical public profile | Update facts only in `src/config/public-profile.json`; browser retrieval and Python dataset generation consume the same file |
 
 ## Code Standards
 

--- a/docs/CUSTOMIZATION.md
+++ b/docs/CUSTOMIZATION.md
@@ -2,7 +2,7 @@
 
 Make this static portfolio your own. The browser chatbot answers from reusable
 public profile sections, so configuration should stay factual, public, and easy
-to sync with the optional training pipeline.
+to reuse in the optional training pipeline.
 
 For a system map, see [diagrams.md](diagrams.md).
 
@@ -16,7 +16,7 @@ For a system map, see [diagrams.md](diagrams.md).
 - [ ] Set `repository.owner` and `repository.name`
 - [ ] Set `resumeFileId` (from Google Drive share link)
 - [ ] Update `socialLinks` (empty string hides a link)
-- [ ] Summarize public resume/profile knowledge in `PROFILE_SECTIONS`
+- [ ] Summarize public resume/profile knowledge in `src/config/public-profile.json`
 - [ ] Update `CHATBOT_CONFIG.welcomeMessages`
 - [ ] Install `npm` based on your development environment
 - [ ] `npm install`
@@ -36,13 +36,14 @@ Pages Actions. `npm run deploy` is the manual path and publishes `out/` to a
 
 ## Configuration Map
 
-| File                    | Purpose                                                    |
-| ----------------------- | ---------------------------------------------------------- |
-| `src/config/site.ts`    | Personal info, resume, and chatbot profile sections        |
-| `src/config/models.ts`  | AI model ID and browser dtype policy                       |
-| `src/config/prompts.ts` | Chatbot messages and generation settings                   |
-| `next.config.ts`        | Static export, GitHub Pages `basePath`, and asset prefix   |
-| `ml/profile-qa/`        | Local training, eval, ONNX export, and publishing          |
+| File                             | Purpose                                                          |
+| -------------------------------- | ---------------------------------------------------------------- |
+| `src/config/site.ts`             | Personal info, resume, links, and derived site settings          |
+| `src/config/public-profile.json` | Canonical chatbot facts, retrieval metadata, and scoring terms   |
+| `src/config/models.ts`           | AI model ID and browser dtype policy                             |
+| `src/config/prompts.ts`          | Chatbot messages and generation settings                         |
+| `next.config.ts`                 | Static export, GitHub Pages `basePath`, and asset prefix         |
+| `ml/profile-qa/`                 | Local training, eval, ONNX export, and publishing                |
 
 The default browser model is
 `justinthelaw/teapot-profile-qa-browser-1024`, a browser ONNX profile-QA model
@@ -56,44 +57,45 @@ file ID from `drive.google.com/file/d/[FILE_ID]/view`, and paste it into
 
 ## Chatbot Context
 
-Edit `PROFILE_SECTIONS` in `src/config/site.ts`. Keep the section IDs generic
-so forks can reuse the retrieval behavior:
+Edit `src/config/public-profile.json`. This is the only checked-in source for
+chatbot facts used by both browser retrieval and Python dataset generation.
+Keep section IDs generic so forks can reuse the retrieval behavior:
 
-```typescript
-export const PROFILE_SECTIONS = [
+```json
+[
   {
-    id: "identity",
-    title: "Identity",
-    priority: 100,
-    alwaysInclude: true,
-    keywords: ["name", "location", "identity"],
-    facts: [
+    "id": "identity",
+    "title": "Identity",
+    "priority": 100,
+    "alwaysInclude": true,
+    "keywords": ["name", "location", "identity"],
+    "facts": [
       {
-        id: "identity_location",
-        text: "Your Name is based in Your Location.",
-        keywords: ["your name", "your location"],
-      },
-    ],
-  },
-  // current_role, experience, projects, education, skills, interests,
-  // and recommendations follow the same shape.
-] as const satisfies readonly ProfileSection[];
+        "id": "identity_location",
+        "text": "Your Name is based in Your Location.",
+        "keywords": ["your name", "your location"],
+        "terms": ["Your Name", "Your Location"]
+      }
+    ]
+  }
+]
 ```
 
-`PERSONAL_CONTEXT` is derived from these sections for compatibility. The
-browser prompt builder always includes identity facts, retrieves relevant
-sections from the latest question plus recent turns, and trims user input only
-after selected sections and history fit the active model budget.
+`src/config/site.ts` imports this file as `PROFILE_SECTIONS`, and
+`ml/profile-qa/profile_qa/public_profile.py` loads the same JSON for synthetic
+data generation. `PERSONAL_CONTEXT` is derived from these sections for
+compatibility. The browser prompt builder always includes identity facts,
+retrieves relevant sections from the latest question plus recent turns, and
+trims user input only after selected sections and history fit the active model
+budget.
 
 Put reusable categories in section IDs and person-specific terms in fact text or
-fact keywords. Keep generic sections temporally prioritized: `current_role`,
-`experience`, `projects`, `education`, `recommendations`, `skills`, then
-`interests`. Experience should outrank education; recommendations should sit
-just below education and above hobbies/interests or personality-trait sections.
-
-If you plan to fine-tune a model, mirror public facts in
-`ml/profile-qa/profile_qa/public_profile.py`. The browser reads the TypeScript
-config; the training pipeline reads the Python profile file.
+fact keywords. Browser retrieval uses section `priority`, section `keywords`,
+and fact `keywords`; deterministic Python evaluation uses each fact's `terms`.
+Keep generic sections temporally prioritized: `current_role`, `experience`,
+`projects`, `education`, `recommendations`, `skills`, then `interests`.
+Experience should outrank education; recommendations should sit just below
+education and above hobbies/interests or personality-trait sections.
 
 ## Social Links
 
@@ -154,7 +156,7 @@ a custom browser model instead of only prompt/context changes.
 
 | Step | Action |
 | --- | --- |
-| 1 | Update public facts in both `src/config/site.ts` and `ml/profile-qa/profile_qa/public_profile.py` |
+| 1 | Update facts, retrieval metadata, and scoring terms in `src/config/public-profile.json` |
 | 2 | Follow [ml/profile-qa/README.md](../ml/profile-qa/README.md) to generate data, train LoRA/QLoRA, evaluate, merge, export ONNX, prepare Hugging Face artifacts, and publish |
 | 3 | After promotion passes, update `MODEL_ID` and `MODEL_CONTEXT_LIMIT` in `src/config/models.ts` |
 | 4 | Run `npm run flight-check` |

--- a/docs/CUSTOMIZATION.md
+++ b/docs/CUSTOMIZATION.md
@@ -66,6 +66,13 @@ Keep section IDs generic so forks can reuse the retrieval behavior:
   {
     "id": "identity",
     "title": "Identity",
+    "subject": {
+      "name": "Your Full Name",
+      "shortName": "Your Name",
+      "subjectPronoun": "they",
+      "objectPronoun": "them",
+      "possessivePronoun": "their"
+    },
     "priority": 100,
     "alwaysInclude": true,
     "keywords": ["name", "location", "identity"],
@@ -83,15 +90,21 @@ Keep section IDs generic so forks can reuse the retrieval behavior:
 
 `src/config/site.ts` imports this file as `PROFILE_SECTIONS`, and
 `ml/profile-qa/profile_qa/public_profile.py` loads the same JSON for synthetic
-data generation. `PERSONAL_CONTEXT` is derived from these sections for
-compatibility. The browser prompt builder always includes identity facts,
-retrieves relevant sections from the latest question plus recent turns, and
-trims user input only after selected sections and history fit the active model
-budget.
+data generation. The identity section's `subject` object also supplies the name
+and pronouns rendered into synthetic questions, conversation histories, refusal
+examples, and the training instruction. `PERSONAL_CONTEXT` is derived from
+these sections for compatibility. The browser prompt builder always includes
+identity facts, retrieves relevant sections from the latest question plus
+recent turns, and trims user input only after selected sections and history fit
+the active model budget.
 
 Put reusable categories in section IDs and person-specific terms in fact text or
 fact keywords. Browser retrieval uses section `priority`, section `keywords`,
 and fact `keywords`; deterministic Python evaluation uses each fact's `terms`.
+Facts may also define named `termGroups` when one question needs a narrower
+semantic scoring target than the whole fact. For example, an operator-purpose
+follow-up can select terms about its behavior without accepting a list of tools
+as a complete answer.
 Keep generic sections temporally prioritized: `current_role`, `experience`,
 `projects`, `education`, `recommendations`, `skills`, then `interests`.
 Experience should outrank education; recommendations should sit just below
@@ -154,12 +167,22 @@ export const GENERATION_PARAMS: GenerationParams = {
 The optional local pipeline lives in `ml/profile-qa/`. Use it when a fork needs
 a custom browser model instead of only prompt/context changes.
 
+The canonical JSON owns the training subject identity, answers, evidence, and
+scoring terms. Natural language question and history templates are centralized in
+`ml/profile-qa/profile_qa/synthetic_data.py`. If a changed fact makes one of
+those prompts inaccurate—for example, it names an employer, school, product,
+or role that no longer applies—update the matching `FACT_QA`,
+`TARGETED_COMPLETENESS_QA`, `MULTI_HOP_QA`, or `FOLLOW_UP_QA` entry in that one
+file. Names and pronouns do not need a template edit; they render from
+`identity.subject` automatically.
+
 | Step | Action |
 | --- | --- |
-| 1 | Update facts, retrieval metadata, and scoring terms in `src/config/public-profile.json` |
-| 2 | Follow [ml/profile-qa/README.md](../ml/profile-qa/README.md) to generate data, train LoRA/QLoRA, evaluate, merge, export ONNX, prepare Hugging Face artifacts, and publish |
-| 3 | After promotion passes, update `MODEL_ID` and `MODEL_CONTEXT_LIMIT` in `src/config/models.ts` |
-| 4 | Run `npm run flight-check` |
+| 1 | Update identity, facts, retrieval metadata, scoring terms, and optional named `termGroups` in `src/config/public-profile.json` |
+| 2 | Update the centralized question/history entry in `synthetic_data.py` when changed factual wording makes it inaccurate |
+| 3 | Follow [ml/profile-qa/README.md](../ml/profile-qa/README.md) to generate data, train LoRA/QLoRA, evaluate, merge, export ONNX, prepare Hugging Face artifacts, and publish |
+| 4 | After promotion passes, update `MODEL_ID` and `MODEL_CONTEXT_LIMIT` in `src/config/models.ts` |
+| 5 | Run `npm run flight-check` |
 
 ## Troubleshooting
 

--- a/docs/CUSTOMIZATION.md
+++ b/docs/CUSTOMIZATION.md
@@ -11,13 +11,12 @@ For a system map, see [diagrams.md](diagrams.md).
 - [ ] Fork this repo to your GitHub account
 - [ ] Rename to `[your-username]` (recommended)
 - [ ] Set GitHub Pages source to GitHub Actions for CI deploys
-- [ ] Set `name` to your name
+- [ ] Set `name` and `fullName` for the page UI
 - [ ] Set `githubUsername` to your username
 - [ ] Set `repository.owner` and `repository.name`
 - [ ] Set `resumeFileId` (from Google Drive share link)
 - [ ] Update `socialLinks` (empty string hides a link)
-- [ ] Summarize public resume/profile knowledge in `src/config/public-profile.json`
-- [ ] Update `CHATBOT_CONFIG.welcomeMessages`
+- [ ] Set `identity.subject` and summarize public facts in `src/config/public-profile.json`
 - [ ] Install `npm` based on your development environment
 - [ ] `npm install`
 - [ ] `npm run dev` (test at localhost:3000)
@@ -39,7 +38,7 @@ Pages Actions. `npm run deploy` is the manual path and publishes `out/` to a
 | File                             | Purpose                                                          |
 | -------------------------------- | ---------------------------------------------------------------- |
 | `src/config/site.ts`             | Personal info, resume, links, and derived site settings          |
-| `src/config/public-profile.json` | Canonical chatbot facts, retrieval metadata, and scoring terms   |
+| `src/config/public-profile.json` | Chatbot identity, facts, retrieval metadata, and scoring terms   |
 | `src/config/models.ts`           | AI model ID and browser dtype policy                             |
 | `src/config/prompts.ts`          | Chatbot messages and generation settings                         |
 | `next.config.ts`                 | Static export, GitHub Pages `basePath`, and asset prefix         |
@@ -90,13 +89,14 @@ Keep section IDs generic so forks can reuse the retrieval behavior:
 
 `src/config/site.ts` imports this file as `PROFILE_SECTIONS`, and
 `ml/profile-qa/profile_qa/public_profile.py` loads the same JSON for synthetic
-data generation. The identity section's `subject` object also supplies the name
-and pronouns rendered into synthetic questions, conversation histories, refusal
-examples, and the training instruction. `PERSONAL_CONTEXT` is derived from
-these sections for compatibility. The browser prompt builder always includes
-identity facts, retrieves relevant sections from the latest question plus
-recent turns, and trims user input only after selected sections and history fit
-the active model budget.
+data generation. The identity section's `subject` object supplies the browser
+welcome and system-prompt identity as well as the names and pronouns rendered
+into synthetic questions, conversation histories, refusal examples, and the
+training instruction. `PERSONAL_CONTEXT` is derived from these sections for
+compatibility. The browser prompt builder always includes identity facts,
+retrieves relevant sections from the latest question plus recent turns, and
+trims user input only after selected sections and history fit the active model
+budget.
 
 Put reusable categories in section IDs and person-specific terms in fact text or
 fact keywords. Browser retrieval uses section `priority`, section `keywords`,

--- a/docs/CUSTOMIZATION.md
+++ b/docs/CUSTOMIZATION.md
@@ -101,10 +101,11 @@ the active model budget.
 Put reusable categories in section IDs and person-specific terms in fact text or
 fact keywords. Browser retrieval uses section `priority`, section `keywords`,
 and fact `keywords`; deterministic Python evaluation uses each fact's `terms`.
-Facts may also define named `termGroups` when one question needs a narrower
-semantic scoring target than the whole fact. For example, an operator-purpose
-follow-up can select terms about its behavior without accepting a list of tools
-as a complete answer.
+Facts also define named `termGroups` for grouped questions. Each grouped QA
+entry selects one group per evidence fact containing the minimum terms every
+question variant requires. For example, an operator follow-up selects the
+workload problem without accepting a list of tools as a complete answer or
+requiring extra implementation details that the question did not request.
 Keep generic sections temporally prioritized: `current_role`, `experience`,
 `projects`, `education`, `recommendations`, `skills`, then `interests`.
 Experience should outrank education; recommendations should sit just below
@@ -178,7 +179,7 @@ file. Names and pronouns do not need a template edit; they render from
 
 | Step | Action |
 | --- | --- |
-| 1 | Update identity, facts, retrieval metadata, scoring terms, and optional named `termGroups` in `src/config/public-profile.json` |
+| 1 | Update identity, facts, retrieval metadata, scoring terms, and named `termGroups` in `src/config/public-profile.json` |
 | 2 | Update the centralized question/history entry in `synthetic_data.py` when changed factual wording makes it inaccurate |
 | 3 | Follow [ml/profile-qa/README.md](../ml/profile-qa/README.md) to generate data, train LoRA/QLoRA, evaluate, merge, export ONNX, prepare Hugging Face artifacts, and publish |
 | 4 | After promotion passes, update `MODEL_ID` and `MODEL_CONTEXT_LIMIT` in `src/config/models.ts` |

--- a/docs/DIAGRAMS.md
+++ b/docs/DIAGRAMS.md
@@ -9,8 +9,7 @@ fit together.
 | Need | Primary file | Notes |
 | --- | --- | --- |
 | Site identity, repository, resume, links | `src/config/site.ts` | Drives the page and GitHub Pages URL derivation |
-| Browser chatbot facts | `src/config/site.ts` | `PROFILE_SECTIONS` is the runtime context source |
-| Training chatbot facts | `ml/profile-qa/profile_qa/public_profile.py` | Keep in sync with public facts when retraining |
+| Browser and training chatbot facts | `src/config/public-profile.json` | Shared source for retrieval metadata, fact text, and evaluation terms |
 | Prompt wording and generation knobs | `src/config/prompts.ts` | Includes welcome messages and generation parameters |
 | Browser model and context limit | `src/config/models.ts` | Default is `int8` with `uint8` fallback |
 | Prompt retrieval and budget trimming | `src/services/ai/contextProvider.ts` | Ranks profile sections and fits prompt/history into budget |
@@ -36,6 +35,7 @@ flowchart TD
   worker --> loader["modelLoader.ts"]
   loader --> hf["Hugging Face model files"]
   worker --> context["contextProvider.ts"]
+  canonicalProfile["public-profile.json"] --> profileSections["PROFILE_SECTIONS"]
   context --> profileSections["PROFILE_SECTIONS"]
   worker --> stream["Typed WorkerStatus stream"]
   stream --> chatStore
@@ -99,7 +99,7 @@ Rules:
 
 ```mermaid
 flowchart TD
-  facts["Public profile facts"] --> pyProfile["public_profile.py"]
+  facts["src/config/public-profile.json"] --> pyProfile["public_profile.py loader"]
   pyProfile --> data["synthetic_data.py"]
   data --> train["train_lora.py"]
   train --> eval["evaluate.py"]
@@ -120,7 +120,7 @@ does not train models and does not call a server.
 
 | Step | Configure | Guardrail |
 | --- | --- | --- |
-| Facts | `src/config/site.ts` and `ml/profile-qa/profile_qa/public_profile.py` | Keep public facts aligned before generating data |
+| Facts | `src/config/public-profile.json` | One source for browser keywords/priorities and Python evaluation terms |
 | Dataset | `python -m profile_qa.synthetic_data` | Generated data stays under ignored `ml/profile-qa/data/` |
 | Training | `ml/profile-qa/profile_qa/config.py` or CLI flags | Fixed `teapotai/teapotllm` base; local 8GB NVIDIA LoRA/QLoRA runs |
 | Evaluation | `python -m profile_qa.evaluate` | Seq2seq only; adapters must record `teapotai/teapotllm` as their base |
@@ -137,4 +137,4 @@ the app default model.
 | Paths | Prefer exact file paths in documentation updates |
 | Scope | Keep this file diagram-first and concise; put command details in `ml/profile-qa/README.md` |
 | Flow changes | Update the matching diagram in the same change |
-| Profile facts | Keep the TypeScript and Python profile sources synchronized when facts change for a retrained model |
+| Profile facts | Update only `src/config/public-profile.json`; TypeScript and Python consumers load it directly |

--- a/docs/DIAGRAMS.md
+++ b/docs/DIAGRAMS.md
@@ -36,6 +36,9 @@ flowchart TD
   loader --> hf["Hugging Face model files"]
   worker --> context["contextProvider.ts"]
   canonicalProfile["public-profile.json"] --> profileSections["PROFILE_SECTIONS"]
+  canonicalProfile --> profileSubject["PROFILE_SUBJECT"]
+  profileSubject --> promptIdentity["Browser prompt identity"]
+  promptIdentity --> context
   context --> profileSections["PROFILE_SECTIONS"]
   worker --> stream["Typed WorkerStatus stream"]
   stream --> chatStore

--- a/ml/profile-qa/README.md
+++ b/ml/profile-qa/README.md
@@ -24,8 +24,10 @@ The identity section's `subject` metadata renders names and pronouns into the
 training prompts. Fact-specific question and history wording is centralized in
 `profile_qa/synthetic_data.py`; update its matching QA entry when a customized
 fact makes an employer, school, product, or role reference inaccurate.
-Every grouped QA entry must also declare whether it scores all evidence terms
-or selects a named `termGroup`; dataset generation rejects an implicit policy.
+Every grouped QA entry must select a named `termGroup` for each evidence fact.
+Use the minimum terms that every question variant requires for a complete
+answer; dataset generation rejects missing selectors and broad
+`all_evidence_terms` scoring.
 
 ## Prerequisites
 

--- a/ml/profile-qa/README.md
+++ b/ml/profile-qa/README.md
@@ -20,6 +20,10 @@ The single checked-in profile source is `src/config/public-profile.json`.
 `profile_qa/public_profile.py` loads the same file for dataset generation. Keep
 browser section priorities and retrieval keywords alongside each fact's
 deterministic evaluation `terms`; do not copy facts into either consumer.
+The identity section's `subject` metadata renders names and pronouns into the
+training prompts. Fact-specific question and history wording is centralized in
+`profile_qa/synthetic_data.py`; update its matching QA entry when a customized
+fact makes an employer, school, product, or role reference inaccurate.
 
 ## Prerequisites
 

--- a/ml/profile-qa/README.md
+++ b/ml/profile-qa/README.md
@@ -15,9 +15,11 @@ recommendations sit just below education but above hobbies/interests or
 personality-trait sections. Put person-specific names, employers, schools, and
 projects in fact text and keywords.
 
-When changing public facts for a promoted model, keep this Python profile data
-aligned with `src/config/site.ts`; the app reads the TypeScript config, while
-this pipeline reads `profile_qa/public_profile.py`.
+The single checked-in profile source is `src/config/public-profile.json`.
+`src/config/site.ts` imports it for browser retrieval, and
+`profile_qa/public_profile.py` loads the same file for dataset generation. Keep
+browser section priorities and retrieval keywords alongside each fact's
+deterministic evaluation `terms`; do not copy facts into either consumer.
 
 ## Prerequisites
 

--- a/ml/profile-qa/README.md
+++ b/ml/profile-qa/README.md
@@ -24,6 +24,8 @@ The identity section's `subject` metadata renders names and pronouns into the
 training prompts. Fact-specific question and history wording is centralized in
 `profile_qa/synthetic_data.py`; update its matching QA entry when a customized
 fact makes an employer, school, product, or role reference inaccurate.
+Every grouped QA entry must also declare whether it scores all evidence terms
+or selects a named `termGroup`; dataset generation rejects an implicit policy.
 
 ## Prerequisites
 

--- a/ml/profile-qa/README.md
+++ b/ml/profile-qa/README.md
@@ -20,10 +20,11 @@ The single checked-in profile source is `src/config/public-profile.json`.
 `profile_qa/public_profile.py` loads the same file for dataset generation. Keep
 browser section priorities and retrieval keywords alongside each fact's
 deterministic evaluation `terms`; do not copy facts into either consumer.
-The identity section's `subject` metadata renders names and pronouns into the
-training prompts. Fact-specific question and history wording is centralized in
-`profile_qa/synthetic_data.py`; update its matching QA entry when a customized
-fact makes an employer, school, product, or role reference inaccurate.
+The identity section's `subject` metadata drives both browser prompt identity
+and the names and pronouns rendered into training prompts. Fact-specific
+question and history wording is centralized in `profile_qa/synthetic_data.py`;
+update its matching QA entry when a customized fact makes an employer, school,
+product, or role reference inaccurate.
 Every grouped QA entry must select a named `termGroup` for each evidence fact.
 Use the minimum terms that every question variant requires for a complete
 answer; dataset generation rejects missing selectors and broad

--- a/ml/profile-qa/profile_qa/public_profile.py
+++ b/ml/profile-qa/profile_qa/public_profile.py
@@ -10,6 +10,7 @@ from .config import PROJECT_ROOT
 
 ProfileFact = dict[str, object]
 ProfileSection = dict[str, object]
+ProfileSubject = dict[str, str]
 
 CANONICAL_PROFILE_PATH: Final[Path] = (
     PROJECT_ROOT / "src" / "config" / "public-profile.json"
@@ -35,6 +36,66 @@ def _load_profile_sections() -> list[ProfileSection]:
 
 
 PROFILE_SECTIONS: Final[list[ProfileSection]] = _load_profile_sections()
+
+
+def _load_profile_subject() -> ProfileSubject:
+    identity_section = next(
+        (section for section in PROFILE_SECTIONS if section.get("id") == "identity"),
+        None,
+    )
+    raw_subject = identity_section.get("subject") if identity_section else None
+    if not isinstance(raw_subject, dict):
+        raise RuntimeError(
+            "canonical public profile identity section requires a subject object"
+        )
+
+    required_fields = (
+        "name",
+        "shortName",
+        "subjectPronoun",
+        "objectPronoun",
+        "possessivePronoun",
+    )
+    subject: ProfileSubject = {}
+    for field in required_fields:
+        value = raw_subject.get(field)
+        if not isinstance(value, str) or not value.strip():
+            raise RuntimeError(
+                f"canonical public profile subject.{field} must be non-empty"
+            )
+        subject[field] = value.strip()
+    return subject
+
+
+PROFILE_SUBJECT: Final[ProfileSubject] = _load_profile_subject()
+
+
+def profile_subject_name() -> str:
+    """Return the canonical full name used in training instructions."""
+
+    return PROFILE_SUBJECT["name"]
+
+
+def profile_subject_short_name() -> str:
+    """Return the canonical short name used in synthetic questions."""
+
+    return PROFILE_SUBJECT["shortName"]
+
+
+def profile_subject_pronouns() -> tuple[str, str, str]:
+    """Return canonical subject, object, and possessive pronouns."""
+
+    return (
+        PROFILE_SUBJECT["subjectPronoun"],
+        PROFILE_SUBJECT["objectPronoun"],
+        PROFILE_SUBJECT["possessivePronoun"],
+    )
+
+
+def possessive(value: str) -> str:
+    """Return a readable possessive for a profile subject name."""
+
+    return f"{value}'" if value.endswith("s") else f"{value}'s"
 
 
 def fact_index() -> dict[tuple[str, str], ProfileFact]:

--- a/ml/profile-qa/profile_qa/public_profile.py
+++ b/ml/profile-qa/profile_qa/public_profile.py
@@ -1,247 +1,40 @@
-"""Public profile facts used for deterministic synthetic data generation."""
+"""Load canonical public profile facts for synthetic data generation."""
 
 from __future__ import annotations
 
-from typing import Final
+import json
+from pathlib import Path
+from typing import Final, cast
+
+from .config import PROJECT_ROOT
 
 ProfileFact = dict[str, object]
 ProfileSection = dict[str, object]
 
-PROFILE_SECTIONS: Final[list[ProfileSection]] = [
-    {
-        "id": "identity",
-        "title": "Identity",
-        "always_include": True,
-        "keywords": ["name", "identity", "location", "based", "who"],
-        "facts": [
-            {
-                "id": "identity_location",
-                "text": "Justin Law is based in New York, USA.",
-                "terms": ["New York", "USA"],
-            },
-        ],
-    },
-    {
-        "id": "current_role",
-        "title": "Current Role",
-        "keywords": [
-            "current role",
-            "current job",
-            "current work",
-            "employer",
-            "role",
-            "scope",
-            "impact",
-        ],
-        "facts": [
-            {
-                "id": "current_role_title",
-                "text": "At OpenAI, Justin is an AI Deployment Engineer.",
-                "terms": ["AI Deployment Engineer", "OpenAI"],
-            },
-            {
-                "id": "current_role_scope",
-                "text": (
-                    "Justin focuses on enterprise Codex adoption across CLI, SDK, "
-                    "MCP, app-server, observability, Kubernetes, and full-stack "
-                    "workflows."
-                ),
-                "terms": ["enterprise Codex adoption", "CLI", "SDK", "MCP"],
-            },
-            {
-                "id": "current_role_scale",
-                "text": (
-                    "He has led engagements across 11 organizations and about "
-                    "33,000 users."
-                ),
-                "terms": ["11 organizations", "33,000 users"],
-            },
-        ],
-    },
-    {
-        "id": "experience",
-        "title": "Experience",
-        "keywords": [
-            "experience",
-            "previous role",
-            "work history",
-            "chronology",
-            "before",
-            "veteran",
-            "career",
-        ],
-        "facts": [
-            {
-                "id": "experience_previous_role",
-                "text": (
-                    "Previously, Justin was a Senior Software Engineer at Defense "
-                    "Unicorns, working across 40+ Kubernetes, AI/ML, and full-stack "
-                    "repos."
-                ),
-                "terms": ["Senior Software Engineer", "Defense Unicorns", "40+"],
-            },
-            {
-                "id": "experience_veteran",
-                "text": (
-                    "Justin is a U.S. Air Force and Space Force veteran and one of "
-                    "the Space Force's first certified Supra Coders."
-                ),
-                "terms": ["Air Force", "Space Force", "Supra Coders"],
-            },
-        ],
-    },
-    {
-        "id": "projects",
-        "title": "Projects",
-        "keywords": [
-            "project",
-            "projects",
-            "built",
-            "developed",
-            "operator",
-            "product",
-            "tool",
-            "rag",
-            "metrics",
-        ],
-        "facts": [
-            {
-                "id": "projects_current_role",
-                "text": (
-                    "He built Codex packages, OpenInference observability, and a "
-                    "Kubernetes operator that diagnoses and remediates failing "
-                    "workloads."
-                ),
-                "terms": ["Codex packages", "OpenInference", "Kubernetes operator"],
-            },
-            {
-                "id": "projects_products",
-                "text": "He developed LeapfrogAI and UDS AI.",
-                "terms": ["LeapfrogAI", "UDS AI"],
-            },
-            {
-                "id": "projects_rag_system",
-                "text": (
-                    "He led a FIPS-compliant agentic RAG system for shipyard "
-                    "operations."
-                ),
-                "terms": ["FIPS-compliant", "agentic RAG", "shipyard operations"],
-            },
-            {
-                "id": "projects_metrics",
-                "text": (
-                    "His work improved model MRR by 15% and agentic retrieval by "
-                    "38%."
-                ),
-                "terms": ["MRR by 15%", "agentic retrieval by 38%"],
-            },
-            {
-                "id": "projects_service",
-                "text": (
-                    "He built RF deconfliction tools, orbital object OSINT apps, "
-                    "and acquisition strategies."
-                ),
-                "terms": ["RF deconfliction", "orbital object OSINT", "acquisition"],
-            },
-        ],
-    },
-    {
-        "id": "education",
-        "title": "Education",
-        "keywords": [
-            "education",
-            "degree",
-            "mechanical engineering",
-            "rit",
-            "johns hopkins",
-            "georgia tech",
-            "graduate",
-        ],
-        "facts": [
-            {
-                "id": "education_rit",
-                "text": "Justin earned a B.S. in Mechanical Engineering from RIT.",
-                "terms": ["B.S. in Mechanical Engineering", "RIT"],
-            },
-            {
-                "id": "education_graduate",
-                "text": (
-                    "He completed graduate CS studies at Johns Hopkins and Georgia "
-                    "Tech."
-                ),
-                "terms": ["graduate CS", "Johns Hopkins", "Georgia Tech"],
-            },
-        ],
-    },
-    {
-        "id": "recommendations",
-        "title": "Recommendations",
-        "keywords": [
-            "recommendation",
-            "recommendations",
-            "personable",
-            "collaborative",
-            "pressure",
-            "problem solver",
-        ],
-        "facts": [
-            {
-                "id": "recommendations_summary",
-                "text": (
-                    "Recommendations describe Justin as personable, collaborative, "
-                    "calm under pressure, technically deep, and a strong problem "
-                    "solver."
-                ),
-                "terms": [
-                    "personable",
-                    "collaborative",
-                    "calm under pressure",
-                    "strong problem solver",
-                ],
-            },
-        ],
-    },
-    {
-        "id": "skills",
-        "title": "Skills",
-        "keywords": [
-            "skills",
-            "leadership",
-            "public speaking",
-            "systems design",
-            "ai",
-            "ml",
-            "kubernetes",
-            "rag",
-            "observability",
-            "mlflow",
-        ],
-        "facts": [
-            {
-                "id": "skills_strengths",
-                "text": (
-                    "Strengths include leadership, public speaking, technical "
-                    "writing, pair programming, systems design, AI/ML, Kubernetes, "
-                    "secure deployment, RAG, observability, MLFlow, inference "
-                    "engines, and mission-critical delivery."
-                ),
-                "terms": ["leadership", "systems design", "AI/ML", "Kubernetes"],
-            },
-        ],
-    },
-    {
-        "id": "interests",
-        "title": "Interests",
-        "keywords": ["interests", "hobbies", "outside work", "personal interests"],
-        "facts": [
-            {
-                "id": "interests_personal",
-                "text": "Justin enjoys videogames, hiking, running, and cooking.",
-                "terms": ["videogames", "hiking", "running", "cooking"],
-            },
-        ],
-    },
-]
+CANONICAL_PROFILE_PATH: Final[Path] = (
+    PROJECT_ROOT / "src" / "config" / "public-profile.json"
+)
+
+
+def _load_profile_sections() -> list[ProfileSection]:
+    try:
+        value = json.loads(CANONICAL_PROFILE_PATH.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise RuntimeError(
+            f"could not load canonical public profile {CANONICAL_PROFILE_PATH}: {exc}"
+        ) from exc
+
+    if not isinstance(value, list) or not all(
+        isinstance(section, dict) for section in value
+    ):
+        raise RuntimeError(
+            "canonical public profile "
+            f"{CANONICAL_PROFILE_PATH} must be a list of objects"
+        )
+    return cast(list[ProfileSection], value)
+
+
+PROFILE_SECTIONS: Final[list[ProfileSection]] = _load_profile_sections()
 
 
 def fact_index() -> dict[tuple[str, str], ProfileFact]:

--- a/ml/profile-qa/profile_qa/synthetic_data.py
+++ b/ml/profile-qa/profile_qa/synthetic_data.py
@@ -59,6 +59,40 @@ def _fact_text(section_id: str, fact_id: str) -> str:
     return str(fact_index()[(section_id, fact_id)]["text"])
 
 
+def _answer_from_evidence(evidence: list[Evidence]) -> str:
+    return " ".join(
+        _fact_text(item["section_id"], item["fact_id"]) for item in evidence
+    )
+
+
+def _terms_from_evidence(evidence: list[Evidence]) -> list[str]:
+    terms: list[str] = []
+    for item in evidence:
+        for term in _fact_terms(item["section_id"], item["fact_id"]):
+            if term not in terms:
+                terms.append(term)
+    return terms
+
+
+def _grouped_evidence(spec: dict[str, object]) -> list[Evidence]:
+    raw_evidence = spec["evidence"]
+    if not isinstance(raw_evidence, list):
+        raise TypeError(f"{spec['id']} evidence must be a list")
+
+    evidence: list[Evidence] = []
+    for item in raw_evidence:
+        if not isinstance(item, dict):
+            raise TypeError(f"{spec['id']} evidence entries must be objects")
+        section_id = item.get("section_id")
+        fact_id = item.get("fact_id")
+        if not isinstance(section_id, str) or not isinstance(fact_id, str):
+            raise TypeError(
+                f"{spec['id']} evidence entries require string section_id and fact_id"
+            )
+        evidence.append({"section_id": section_id, "fact_id": fact_id})
+    return evidence
+
+
 def _split_questions(
     train: list[str],
     validation: str,
@@ -339,12 +373,6 @@ TARGETED_COMPLETENESS_QA: list[dict[str, object]] = [
         "task": "multi_hop",
         "evidence": _evidence("current_role", "current_role_scale")
         + _evidence("projects", "projects_current_role"),
-        "answer": (
-            "Justin has led engagements across 11 organizations and about 33,000 "
-            "users, and he built Codex packages, OpenInference observability, and a "
-            "Kubernetes operator that diagnoses and remediates failing workloads."
-        ),
-        "terms": ["11 organizations", "33,000 users", "Codex packages", "Kubernetes operator"],
         "questions": [
             "What public current-work scale plus tooling are listed for Justin?",
             "When asked for current scale and tools, what complete answer should be given?",
@@ -359,11 +387,6 @@ TARGETED_COMPLETENESS_QA: list[dict[str, object]] = [
         "task": "multi_hop",
         "evidence": _evidence("projects", "projects_rag_system")
         + _evidence("projects", "projects_metrics"),
-        "answer": (
-            "Justin led a FIPS-compliant agentic RAG system for shipyard operations "
-            "and improved model MRR by 15% and agentic retrieval by 38%."
-        ),
-        "terms": ["FIPS-compliant", "shipyard operations", "MRR by 15%", "38%"],
         "questions": [
             "After the shipyard operations RAG work, what project and gains should be mentioned?",
             "What complete answer pairs Justin's secure RAG project with the metrics?",
@@ -378,12 +401,6 @@ TARGETED_COMPLETENESS_QA: list[dict[str, object]] = [
         "task": "chronology",
         "evidence": _evidence("experience", "experience_previous_role")
         + _evidence("experience", "experience_veteran"),
-        "answer": (
-            "Before his current OpenAI work, Justin was a Senior Software Engineer "
-            "at Defense Unicorns and served as a U.S. Air Force and Space Force "
-            "veteran."
-        ),
-        "terms": ["Defense Unicorns", "Air Force", "Space Force"],
         "questions": [
             "What preceded Justin's current role at OpenAI, including service background?",
             "What complete pre-OpenAI career summary is listed for Justin?",
@@ -398,11 +415,6 @@ TARGETED_COMPLETENESS_QA: list[dict[str, object]] = [
         "task": "education",
         "evidence": _evidence("education", "education_rit")
         + _evidence("education", "education_graduate"),
-        "answer": (
-            "Justin earned a B.S. in Mechanical Engineering from RIT and completed "
-            "graduate CS studies at Johns Hopkins and Georgia Tech."
-        ),
-        "terms": ["Mechanical Engineering", "RIT", "Johns Hopkins", "Georgia Tech"],
         "questions": [
             "What complete degree and graduate school answer should be given?",
             "Which undergraduate degree plus graduate CS institutions are public?",
@@ -418,12 +430,6 @@ MULTI_HOP_QA: list[dict[str, object]] = [
         "task": "multi_hop",
         "evidence": _evidence("current_role", "current_role_scale")
         + _evidence("projects", "projects_current_role"),
-        "answer": (
-            "Justin has led engagements across 11 organizations and about 33,000 "
-            "users, and he built Codex packages, OpenInference observability, and a "
-            "Kubernetes operator that diagnoses and remediates failing workloads."
-        ),
-        "terms": ["11 organizations", "33,000 users", "Codex packages", "Kubernetes operator"],
         "questions": _split_questions(
             [
                 "Summarize Justin's current engagement scale and what he built.",
@@ -441,12 +447,6 @@ MULTI_HOP_QA: list[dict[str, object]] = [
         "task": "multi_hop",
         "evidence": _evidence("experience", "experience_previous_role")
         + _evidence("projects", "projects_products"),
-        "answer": (
-            "Previously, Justin was a Senior Software Engineer at Defense Unicorns "
-            "working across 40+ Kubernetes, AI/ML, and full-stack repos, where he "
-            "developed LeapfrogAI and UDS AI."
-        ),
-        "terms": ["Defense Unicorns", "40+", "LeapfrogAI", "UDS AI"],
         "questions": _split_questions(
             [
                 "What was Justin's prior role and which AI products did he develop?",
@@ -461,11 +461,6 @@ MULTI_HOP_QA: list[dict[str, object]] = [
         "task": "multi_hop",
         "evidence": _evidence("projects", "projects_rag_system")
         + _evidence("projects", "projects_metrics"),
-        "answer": (
-            "Justin led a FIPS-compliant agentic RAG system for shipyard operations "
-            "and improved model MRR by 15% and agentic retrieval by 38%."
-        ),
-        "terms": ["FIPS-compliant", "shipyard operations", "MRR by 15%", "38%"],
         "questions": _split_questions(
             [
                 "What RAG system did Justin lead and what improved?",
@@ -483,11 +478,6 @@ MULTI_HOP_QA: list[dict[str, object]] = [
         "task": "education",
         "evidence": _evidence("education", "education_rit")
         + _evidence("education", "education_graduate"),
-        "answer": (
-            "Justin earned a B.S. in Mechanical Engineering from RIT and completed "
-            "graduate CS studies at Johns Hopkins and Georgia Tech."
-        ),
-        "terms": ["Mechanical Engineering", "RIT", "Johns Hopkins", "Georgia Tech"],
         "questions": _split_questions(
             [
                 "Summarize Justin's education background.",
@@ -502,12 +492,6 @@ MULTI_HOP_QA: list[dict[str, object]] = [
         "task": "chronology",
         "evidence": _evidence("experience", "experience_previous_role")
         + _evidence("experience", "experience_veteran"),
-        "answer": (
-            "Before his current OpenAI work, Justin was a Senior Software Engineer "
-            "at Defense Unicorns and served as a U.S. Air Force and Space Force "
-            "veteran."
-        ),
-        "terms": ["Defense Unicorns", "Air Force", "Space Force"],
         "questions": _split_questions(
             [
                 "What did Justin do before OpenAI?",
@@ -525,13 +509,6 @@ MULTI_HOP_QA: list[dict[str, object]] = [
         "task": "recommendations",
         "evidence": _evidence("skills", "skills_strengths")
         + _evidence("recommendations", "recommendations_summary"),
-        "answer": (
-            "Justin's strengths include leadership, systems design, AI/ML, "
-            "Kubernetes, RAG, observability, and mission-critical delivery; "
-            "recommendations describe him as personable, collaborative, calm under "
-            "pressure, technically deep, and a strong problem solver."
-        ),
-        "terms": ["leadership", "systems design", "collaborative", "calm under pressure"],
         "questions": _split_questions(
             [
                 "Combine Justin's strengths with how recommendations describe him.",
@@ -550,8 +527,6 @@ FOLLOW_UP_QA: list[dict[str, object]] = [
     {
         "id": "followup-defense-metrics",
         "evidence": _evidence("projects", "projects_metrics"),
-        "answer": "At Defense Unicorns, Justin improved model MRR by 15% and agentic retrieval by 38%.",
-        "terms": ["MRR by 15%", "agentic retrieval by 38%"],
         "history": [
             {"role": "user", "content": "Tell me about Justin's Defense Unicorns work."},
             {
@@ -571,8 +546,6 @@ FOLLOW_UP_QA: list[dict[str, object]] = [
     {
         "id": "followup-operator-purpose",
         "evidence": _evidence("projects", "projects_current_role"),
-        "answer": "The Kubernetes operator diagnoses and remediates failing workloads.",
-        "terms": ["diagnoses", "remediates", "failing workloads"],
         "history": [
             {"role": "user", "content": "What did Justin build in his current role?"},
             {
@@ -592,8 +565,6 @@ FOLLOW_UP_QA: list[dict[str, object]] = [
     {
         "id": "followup-graduate-schools",
         "evidence": _evidence("education", "education_graduate"),
-        "answer": "Justin completed graduate CS studies at Johns Hopkins and Georgia Tech.",
-        "terms": ["Johns Hopkins", "Georgia Tech"],
         "history": [
             {"role": "user", "content": "Tell me about Justin's education."},
             {
@@ -613,11 +584,6 @@ FOLLOW_UP_QA: list[dict[str, object]] = [
     {
         "id": "followup-recommendation-traits",
         "evidence": _evidence("recommendations", "recommendations_summary"),
-        "answer": (
-            "Recommendations describe Justin as personable, collaborative, calm "
-            "under pressure, technically deep, and a strong problem solver."
-        ),
-        "terms": ["personable", "collaborative", "calm under pressure"],
         "history": [
             {"role": "user", "content": "What do people say about Justin?"},
             {
@@ -717,6 +683,9 @@ def _add_grouped_records(records: list[Record], specs: list[dict[str, object]], 
         questions = spec["questions"]
         if not isinstance(questions, dict):
             continue
+        evidence = _grouped_evidence(spec)
+        answer = _answer_from_evidence(evidence)
+        terms = _terms_from_evidence(evidence)
         for split in SPLITS:
             for index, question in enumerate(questions[split]):
                 records.append(
@@ -725,9 +694,9 @@ def _add_grouped_records(records: list[Record], specs: list[dict[str, object]], 
                         split,
                         str(task or spec["task"]),
                         question,
-                        str(spec["answer"]),
-                        spec["evidence"],  # type: ignore[arg-type]
-                        spec["terms"],  # type: ignore[arg-type]
+                        answer,
+                        evidence,
+                        terms,
                         history=spec.get("history") if isinstance(spec.get("history"), list) else None,
                     )
                 )
@@ -738,6 +707,9 @@ def _add_train_only_grouped_records(records: list[Record], specs: list[dict[str,
         questions = spec["questions"]
         if not isinstance(questions, list):
             continue
+        evidence = _grouped_evidence(spec)
+        answer = _answer_from_evidence(evidence)
+        terms = _terms_from_evidence(evidence)
         for index, question in enumerate(questions):
             records.append(
                 _record(
@@ -745,9 +717,9 @@ def _add_train_only_grouped_records(records: list[Record], specs: list[dict[str,
                     "train",
                     str(spec["task"]),
                     str(question),
-                    str(spec["answer"]),
-                    spec["evidence"],  # type: ignore[arg-type]
-                    spec["terms"],  # type: ignore[arg-type]
+                    answer,
+                    evidence,
+                    terms,
                 )
             )
 

--- a/ml/profile-qa/profile_qa/synthetic_data.py
+++ b/ml/profile-qa/profile_qa/synthetic_data.py
@@ -131,6 +131,31 @@ def _grouped_term_groups(spec: dict[str, object]) -> dict[str, str]:
     return {str(key): str(value) for key, value in raw_term_groups.items()}
 
 
+def _grouped_scoring_terms(
+    spec: dict[str, object], evidence: list[Evidence]
+) -> list[str]:
+    scoring = spec.get("scoring")
+    if scoring == "all_evidence_terms":
+        if spec.get("term_groups"):
+            raise ValueError(
+                f"{spec['id']} cannot combine all_evidence_terms with term_groups"
+            )
+        return _terms_from_evidence(evidence)
+    if scoring == "term_groups":
+        term_groups = _grouped_term_groups(spec)
+        evidence_keys = {
+            f"{item['section_id']}/{item['fact_id']}" for item in evidence
+        }
+        if set(term_groups) != evidence_keys:
+            raise ValueError(
+                f"{spec['id']} term_groups must select every evidence fact"
+            )
+        return _terms_from_evidence(evidence, term_groups)
+    raise ValueError(
+        f"{spec['id']} requires scoring=all_evidence_terms or scoring=term_groups"
+    )
+
+
 def _render_profile_template(value: str) -> str:
     short_name = profile_subject_short_name()
     subject_pronoun, object_pronoun, possessive_pronoun = (
@@ -445,6 +470,7 @@ TARGETED_COMPLETENESS_QA: list[dict[str, object]] = [
     {
         "id": "targeted-current-impact-projects",
         "task": "multi_hop",
+        "scoring": "all_evidence_terms",
         "evidence": _evidence("current_role", "current_role_scale")
         + _evidence("projects", "projects_current_role"),
         "questions": [
@@ -459,6 +485,7 @@ TARGETED_COMPLETENESS_QA: list[dict[str, object]] = [
     {
         "id": "targeted-rag-metrics",
         "task": "multi_hop",
+        "scoring": "all_evidence_terms",
         "evidence": _evidence("projects", "projects_rag_system")
         + _evidence("projects", "projects_metrics"),
         "questions": [
@@ -473,6 +500,7 @@ TARGETED_COMPLETENESS_QA: list[dict[str, object]] = [
     {
         "id": "targeted-before-current",
         "task": "chronology",
+        "scoring": "all_evidence_terms",
         "evidence": _evidence("experience", "experience_previous_role")
         + _evidence("experience", "experience_veteran"),
         "questions": [
@@ -487,6 +515,7 @@ TARGETED_COMPLETENESS_QA: list[dict[str, object]] = [
     {
         "id": "targeted-education-complete",
         "task": "education",
+        "scoring": "all_evidence_terms",
         "evidence": _evidence("education", "education_rit")
         + _evidence("education", "education_graduate"),
         "questions": [
@@ -502,6 +531,7 @@ MULTI_HOP_QA: list[dict[str, object]] = [
     {
         "id": "current-impact-and-projects",
         "task": "multi_hop",
+        "scoring": "all_evidence_terms",
         "evidence": _evidence("current_role", "current_role_scale")
         + _evidence("projects", "projects_current_role"),
         "questions": _split_questions(
@@ -519,6 +549,7 @@ MULTI_HOP_QA: list[dict[str, object]] = [
     {
         "id": "previous-role-and-products",
         "task": "multi_hop",
+        "scoring": "all_evidence_terms",
         "evidence": _evidence("experience", "experience_previous_role")
         + _evidence("projects", "projects_products"),
         "questions": _split_questions(
@@ -533,6 +564,7 @@ MULTI_HOP_QA: list[dict[str, object]] = [
     {
         "id": "rag-and-metrics",
         "task": "multi_hop",
+        "scoring": "all_evidence_terms",
         "evidence": _evidence("projects", "projects_rag_system")
         + _evidence("projects", "projects_metrics"),
         "questions": _split_questions(
@@ -550,6 +582,7 @@ MULTI_HOP_QA: list[dict[str, object]] = [
     {
         "id": "education-complete",
         "task": "education",
+        "scoring": "all_evidence_terms",
         "evidence": _evidence("education", "education_rit")
         + _evidence("education", "education_graduate"),
         "questions": _split_questions(
@@ -564,6 +597,7 @@ MULTI_HOP_QA: list[dict[str, object]] = [
     {
         "id": "experience-before-current",
         "task": "chronology",
+        "scoring": "all_evidence_terms",
         "evidence": _evidence("experience", "experience_previous_role")
         + _evidence("experience", "experience_veteran"),
         "questions": _split_questions(
@@ -581,6 +615,7 @@ MULTI_HOP_QA: list[dict[str, object]] = [
     {
         "id": "skills-and-recommendations",
         "task": "recommendations",
+        "scoring": "all_evidence_terms",
         "evidence": _evidence("skills", "skills_strengths")
         + _evidence("recommendations", "recommendations_summary"),
         "questions": _split_questions(
@@ -600,6 +635,7 @@ MULTI_HOP_QA: list[dict[str, object]] = [
 FOLLOW_UP_QA: list[dict[str, object]] = [
     {
         "id": "followup-defense-metrics",
+        "scoring": "all_evidence_terms",
         "evidence": _evidence("projects", "projects_metrics"),
         "history": [
             {"role": "user", "content": "Tell me about [[subject_possessive]] Defense Unicorns work."},
@@ -619,6 +655,7 @@ FOLLOW_UP_QA: list[dict[str, object]] = [
     },
     {
         "id": "followup-operator-purpose",
+        "scoring": "term_groups",
         "evidence": _evidence("projects", "projects_current_role"),
         "term_groups": {
             "projects/projects_current_role": "operatorPurpose",
@@ -641,7 +678,11 @@ FOLLOW_UP_QA: list[dict[str, object]] = [
     },
     {
         "id": "followup-graduate-schools",
+        "scoring": "term_groups",
         "evidence": _evidence("education", "education_graduate"),
+        "term_groups": {
+            "education/education_graduate": "graduateInstitutions",
+        },
         "history": [
             {"role": "user", "content": "Tell me about [[subject_possessive]] education."},
             {
@@ -660,6 +701,7 @@ FOLLOW_UP_QA: list[dict[str, object]] = [
     },
     {
         "id": "followup-recommendation-traits",
+        "scoring": "all_evidence_terms",
         "evidence": _evidence("recommendations", "recommendations_summary"),
         "history": [
             {"role": "user", "content": "What do people say about [[subject_short]]?"},
@@ -762,7 +804,7 @@ def _add_grouped_records(records: list[Record], specs: list[dict[str, object]], 
             continue
         evidence = _grouped_evidence(spec)
         answer = _answer_from_evidence(evidence)
-        terms = _terms_from_evidence(evidence, _grouped_term_groups(spec))
+        terms = _grouped_scoring_terms(spec, evidence)
         for split in SPLITS:
             for index, question in enumerate(questions[split]):
                 records.append(
@@ -786,7 +828,7 @@ def _add_train_only_grouped_records(records: list[Record], specs: list[dict[str,
             continue
         evidence = _grouped_evidence(spec)
         answer = _answer_from_evidence(evidence)
-        terms = _terms_from_evidence(evidence, _grouped_term_groups(spec))
+        terms = _grouped_scoring_terms(spec, evidence)
         for index, question in enumerate(questions):
             records.append(
                 _record(

--- a/ml/profile-qa/profile_qa/synthetic_data.py
+++ b/ml/profile-qa/profile_qa/synthetic_data.py
@@ -9,7 +9,14 @@ from pathlib import Path
 from typing import Any
 
 from .config import DATASET_VERSION, DEFAULT_DATASET_PATH
-from .public_profile import PROFILE_SECTIONS, fact_index
+from .public_profile import (
+    PROFILE_SECTIONS,
+    fact_index,
+    possessive,
+    profile_subject_name,
+    profile_subject_pronouns,
+    profile_subject_short_name,
+)
 from .validation import validate_dataset, write_jsonl
 
 Evidence = dict[str, str]
@@ -49,9 +56,23 @@ def _record(
     }
 
 
-def _fact_terms(section_id: str, fact_id: str) -> list[str]:
+def _fact_terms(
+    section_id: str,
+    fact_id: str,
+    term_group: str | None = None,
+) -> list[str]:
     fact = fact_index()[(section_id, fact_id)]
-    terms = fact.get("terms", [])
+    if term_group is None:
+        terms = fact.get("terms", [])
+    else:
+        term_groups = fact.get("termGroups")
+        if not isinstance(term_groups, dict) or term_group not in term_groups:
+            raise ValueError(
+                f"{section_id}/{fact_id} has no scoring term group {term_group}"
+            )
+        terms = term_groups[term_group]
+    if not isinstance(terms, list):
+        raise TypeError(f"{section_id}/{fact_id} scoring terms must be a list")
     return [str(term) for term in terms if isinstance(term, str)]
 
 
@@ -65,10 +86,17 @@ def _answer_from_evidence(evidence: list[Evidence]) -> str:
     )
 
 
-def _terms_from_evidence(evidence: list[Evidence]) -> list[str]:
+def _terms_from_evidence(
+    evidence: list[Evidence],
+    term_groups: dict[str, str] | None = None,
+) -> list[str]:
     terms: list[str] = []
     for item in evidence:
-        for term in _fact_terms(item["section_id"], item["fact_id"]):
+        evidence_key = f"{item['section_id']}/{item['fact_id']}"
+        term_group = term_groups.get(evidence_key) if term_groups else None
+        for term in _fact_terms(
+            item["section_id"], item["fact_id"], term_group=term_group
+        ):
             if term not in terms:
                 terms.append(term)
     return terms
@@ -93,6 +121,52 @@ def _grouped_evidence(spec: dict[str, object]) -> list[Evidence]:
     return evidence
 
 
+def _grouped_term_groups(spec: dict[str, object]) -> dict[str, str]:
+    raw_term_groups = spec.get("term_groups", {})
+    if not isinstance(raw_term_groups, dict) or not all(
+        isinstance(key, str) and isinstance(value, str)
+        for key, value in raw_term_groups.items()
+    ):
+        raise TypeError(f"{spec['id']} term_groups must map evidence keys to names")
+    return {str(key): str(value) for key, value in raw_term_groups.items()}
+
+
+def _render_profile_template(value: str) -> str:
+    short_name = profile_subject_short_name()
+    subject_pronoun, object_pronoun, possessive_pronoun = (
+        profile_subject_pronouns()
+    )
+    replacements = {
+        "[[subject_full]]": profile_subject_name(),
+        "[[subject_possessive]]": possessive(short_name),
+        "[[subject_short]]": short_name,
+        "[[subject_pronoun]]": subject_pronoun,
+        "[[subject_pronoun_capitalized]]": subject_pronoun.capitalize(),
+        "[[object_pronoun]]": object_pronoun,
+        "[[possessive_pronoun]]": possessive_pronoun,
+    }
+    rendered = value
+    for token, replacement in replacements.items():
+        rendered = rendered.replace(token, replacement)
+    return rendered
+
+
+def _render_history(value: object) -> list[dict[str, str]] | None:
+    if not isinstance(value, list):
+        return None
+    history: list[dict[str, str]] = []
+    for turn in value:
+        if not isinstance(turn, dict):
+            continue
+        history.append(
+            {
+                "role": str(turn.get("role", "")),
+                "content": _render_profile_template(str(turn.get("content", ""))),
+            }
+        )
+    return history
+
+
 def _split_questions(
     train: list[str],
     validation: str,
@@ -113,13 +187,13 @@ FACT_QA: list[dict[str, object]] = [
         "task": "single_turn",
         "questions": _split_questions(
             [
-                "Where is Justin Law based?",
-                "What location is listed for Justin?",
-                "Which city and country does Justin work from?",
-                "Where does Justin live according to the profile?",
+                "Where is [[subject_full]] based?",
+                "What location is listed for [[subject_short]]?",
+                "Which city and country does [[subject_short]] work from?",
+                "Where does [[subject_short]] live according to the profile?",
             ],
-            "What is Justin's listed base location?",
-            "Where in the world is Justin based?",
+            "What is [[subject_possessive]] listed base location?",
+            "Where in the world is [[subject_short]] based?",
         ),
     },
     {
@@ -129,13 +203,13 @@ FACT_QA: list[dict[str, object]] = [
         "task": "single_turn",
         "questions": _split_questions(
             [
-                "What is Justin's current role?",
-                "Which job title does Justin have at OpenAI?",
-                "What role is listed for Justin now?",
-                "Who employs Justin in his current AI role?",
+                "What is [[subject_possessive]] current role?",
+                "Which job title does [[subject_short]] have at OpenAI?",
+                "What role is listed for [[subject_short]] now?",
+                "Who employs [[subject_short]] in [[possessive_pronoun]] current AI role?",
             ],
-            "What current title does the profile give Justin?",
-            "Where does Justin currently work and in what role?",
+            "What current title does the profile give [[subject_short]]?",
+            "Where does [[subject_short]] currently work and in what role?",
         ),
     },
     {
@@ -145,13 +219,13 @@ FACT_QA: list[dict[str, object]] = [
         "task": "single_turn",
         "questions": _split_questions(
             [
-                "What is Justin's OpenAI work focused on?",
-                "What areas does Justin cover for enterprise Codex adoption?",
-                "Which workflows does Justin support in his current role?",
-                "What does Justin help enterprises adopt at OpenAI?",
+                "What is [[subject_possessive]] OpenAI work focused on?",
+                "What areas does [[subject_short]] cover for enterprise Codex adoption?",
+                "Which workflows does [[subject_short]] support in [[possessive_pronoun]] current role?",
+                "What does [[subject_short]] help enterprises adopt at OpenAI?",
             ],
-            "What current workstreams are listed for Justin?",
-            "What does Justin's current role cover beyond Codex?",
+            "What current workstreams are listed for [[subject_short]]?",
+            "What does [[subject_possessive]] current role cover beyond Codex?",
         ),
     },
     {
@@ -161,13 +235,13 @@ FACT_QA: list[dict[str, object]] = [
         "task": "single_turn",
         "questions": _split_questions(
             [
-                "How many organizations has Justin led engagements across?",
-                "What user scale is listed for Justin's engagements?",
-                "What is the scale of Justin's current customer work?",
-                "How broad are Justin's OpenAI engagements?",
+                "How many organizations has [[subject_short]] led engagements across?",
+                "What user scale is listed for [[subject_possessive]] engagements?",
+                "What is the scale of [[subject_possessive]] current customer work?",
+                "How broad are [[subject_possessive]] OpenAI engagements?",
             ],
             "What engagement scale does the profile mention?",
-            "How many organizations and users are tied to Justin's engagements?",
+            "How many organizations and users are tied to [[subject_possessive]] engagements?",
         ),
     },
     {
@@ -177,13 +251,13 @@ FACT_QA: list[dict[str, object]] = [
         "task": "single_turn",
         "questions": _split_questions(
             [
-                "What prior software engineering role is listed for Justin?",
-                "Where did Justin work previously?",
-                "What previous software engineering role is listed for Justin?",
-                "Describe Justin's Defense Unicorns experience.",
+                "What prior software engineering role is listed for [[subject_short]]?",
+                "Where did [[subject_short]] work previously?",
+                "What previous software engineering role is listed for [[subject_short]]?",
+                "Describe [[subject_possessive]] Defense Unicorns experience.",
             ],
-            "What prior employer and role are in Justin's profile?",
-            "What was Justin's previous senior engineering work?",
+            "What prior employer and role are in [[subject_possessive]] profile?",
+            "What was [[subject_possessive]] previous senior engineering work?",
         ),
     },
     {
@@ -193,13 +267,13 @@ FACT_QA: list[dict[str, object]] = [
         "task": "single_turn",
         "questions": _split_questions(
             [
-                "What military background is listed for Justin?",
-                "Which military services did Justin serve in?",
-                "What does the profile say about Justin's Supra Coder background?",
-                "Is Justin a veteran?",
+                "What military background is listed for [[subject_short]]?",
+                "Which military services did [[subject_short]] serve in?",
+                "What does the profile say about [[subject_possessive]] Supra Coder background?",
+                "Is [[subject_short]] a veteran?",
             ],
-            "What service background does Justin's profile mention?",
-            "What veteran and Supra Coder context is public for Justin?",
+            "What service background does [[subject_possessive]] profile mention?",
+            "What veteran and Supra Coder context is public for [[subject_short]]?",
         ),
     },
     {
@@ -209,16 +283,16 @@ FACT_QA: list[dict[str, object]] = [
         "task": "single_turn",
         "questions": _split_questions(
             [
-                "What did Justin build around Codex and Kubernetes?",
-                "Which current-role projects are listed for Justin?",
-                "What did Justin build for OpenInference and failing workloads?",
+                "What did [[subject_short]] build around Codex and Kubernetes?",
+                "Which current-role projects are listed for [[subject_short]]?",
+                "What did [[subject_short]] build for OpenInference and failing workloads?",
                 "What Kubernetes operator project is described?",
-                "Which Codex, OpenInference, and Kubernetes tools did Justin build?",
+                "Which Codex, OpenInference, and Kubernetes tools did [[subject_short]] build?",
                 "Name the current-role tooling across Codex, observability, and Kubernetes.",
-                "What should be included when describing Justin's current tooling work?",
+                "What should be included when describing [[subject_possessive]] current tooling work?",
             ],
-            "What current projects did Justin build?",
-            "Which tools did Justin create around Codex, observability, and Kubernetes?",
+            "What current projects did [[subject_short]] build?",
+            "Which tools did [[subject_short]] create around Codex, observability, and Kubernetes?",
         ),
     },
     {
@@ -228,13 +302,13 @@ FACT_QA: list[dict[str, object]] = [
         "task": "single_turn",
         "questions": _split_questions(
             [
-                "Which AI products did Justin develop?",
-                "What products did Justin build at Defense Unicorns?",
-                "Name the AI products in Justin's project history.",
-                "What are LeapfrogAI and UDS AI in Justin's profile?",
+                "Which AI products did [[subject_short]] develop?",
+                "What products did [[subject_short]] build at Defense Unicorns?",
+                "Name the AI products in [[subject_possessive]] project history.",
+                "What are LeapfrogAI and UDS AI in [[subject_possessive]] profile?",
             ],
-            "Which product names are attached to Justin's prior work?",
-            "What AI product development is listed for Justin?",
+            "Which product names are attached to [[subject_possessive]] prior work?",
+            "What AI product development is listed for [[subject_short]]?",
         ),
     },
     {
@@ -244,10 +318,10 @@ FACT_QA: list[dict[str, object]] = [
         "task": "single_turn",
         "questions": _split_questions(
             [
-                "What RAG system did Justin lead?",
-                "What shipyard operations project is in Justin's profile?",
-                "What kind of agentic RAG system did Justin lead?",
-                "Which FIPS-compliant project did Justin lead?",
+                "What RAG system did [[subject_short]] lead?",
+                "What shipyard operations project is in [[subject_possessive]] profile?",
+                "What kind of agentic RAG system did [[subject_short]] lead?",
+                "Which FIPS-compliant project did [[subject_short]] lead?",
             ],
             "What secure RAG project does the profile describe?",
             "What project connected agentic RAG with shipyard operations?",
@@ -260,13 +334,13 @@ FACT_QA: list[dict[str, object]] = [
         "task": "single_turn",
         "questions": _split_questions(
             [
-                "What metrics did Justin improve?",
-                "How much did Justin improve model MRR and retrieval?",
-                "What quantitative improvements are listed for Justin?",
-                "Which retrieval metrics improved in Justin's work?",
+                "What metrics did [[subject_short]] improve?",
+                "How much did [[subject_short]] improve model MRR and retrieval?",
+                "What quantitative improvements are listed for [[subject_short]]?",
+                "Which retrieval metrics improved in [[subject_possessive]] work?",
             ],
             "What MRR and retrieval gains does the profile mention?",
-            "Which performance improvements are public in Justin's profile?",
+            "Which performance improvements are public in [[subject_possessive]] profile?",
         ),
     },
     {
@@ -276,12 +350,12 @@ FACT_QA: list[dict[str, object]] = [
         "task": "single_turn",
         "questions": _split_questions(
             [
-                "What military technology projects did Justin build?",
+                "What military technology projects did [[subject_short]] build?",
                 "What RF and orbital object tools are listed?",
-                "Which service-era technical projects are in Justin's profile?",
+                "Which service-era technical projects are in [[subject_possessive]] profile?",
                 "What acquisition-related project work is described?",
             ],
-            "What public service technology projects did Justin work on?",
+            "What public service technology projects did [[subject_short]] work on?",
             "Which RF, orbital, and acquisition projects are listed?",
         ),
     },
@@ -292,13 +366,13 @@ FACT_QA: list[dict[str, object]] = [
         "task": "education",
         "questions": _split_questions(
             [
-                "What undergraduate degree did Justin earn?",
-                "Where did Justin earn his mechanical engineering degree?",
-                "Which bachelor's degree is listed for Justin?",
-                "What is Justin's RIT education?",
+                "What undergraduate degree did [[subject_short]] earn?",
+                "Where did [[subject_short]] earn [[possessive_pronoun]] mechanical engineering degree?",
+                "Which bachelor's degree is listed for [[subject_short]]?",
+                "What is [[subject_possessive]] RIT education?",
             ],
-            "What B.S. degree appears in Justin's profile?",
-            "Which school granted Justin's mechanical engineering degree?",
+            "What B.S. degree appears in [[subject_possessive]] profile?",
+            "Which school granted [[subject_possessive]] mechanical engineering degree?",
         ),
     },
     {
@@ -308,13 +382,13 @@ FACT_QA: list[dict[str, object]] = [
         "task": "education",
         "questions": _split_questions(
             [
-                "Where did Justin complete graduate CS studies?",
-                "Which graduate CS programs are listed for Justin?",
-                "What graduate computer science education does Justin have?",
-                "Name the schools in Justin's graduate CS background.",
+                "Where did [[subject_short]] complete graduate CS studies?",
+                "Which graduate CS programs are listed for [[subject_short]]?",
+                "What graduate computer science education does [[subject_short]] have?",
+                "Name the schools in [[subject_possessive]] graduate CS background.",
             ],
-            "What graduate CS studies are public for Justin?",
-            "Which institutions are named for Justin's graduate CS work?",
+            "What graduate CS studies are public for [[subject_short]]?",
+            "Which institutions are named for [[subject_possessive]] graduate CS work?",
         ),
     },
     {
@@ -324,13 +398,13 @@ FACT_QA: list[dict[str, object]] = [
         "task": "recommendations",
         "questions": _split_questions(
             [
-                "How do recommendations describe Justin?",
+                "How do recommendations describe [[subject_short]]?",
                 "What personality or work traits do recommendations mention?",
-                "Which recommendation themes are listed for Justin?",
-                "How is Justin described by recommendations?",
+                "Which recommendation themes are listed for [[subject_short]]?",
+                "How is [[subject_short]] described by recommendations?",
             ],
-            "What public recommendation themes describe Justin?",
-            "What do recommendations say about Justin's collaboration style?",
+            "What public recommendation themes describe [[subject_short]]?",
+            "What do recommendations say about [[subject_possessive]] collaboration style?",
         ),
     },
     {
@@ -340,13 +414,13 @@ FACT_QA: list[dict[str, object]] = [
         "task": "single_turn",
         "questions": _split_questions(
             [
-                "What are Justin's technical strengths?",
-                "Which skills are listed for Justin?",
-                "What engineering capabilities does Justin's profile emphasize?",
-                "What does Justin know about AI, Kubernetes, and delivery?",
+                "What are [[subject_possessive]] technical strengths?",
+                "Which skills are listed for [[subject_short]]?",
+                "What engineering capabilities does [[subject_possessive]] profile emphasize?",
+                "What does [[subject_short]] know about AI, Kubernetes, and delivery?",
             ],
             "What skills does the public profile emphasize?",
-            "Which leadership and technical skills are listed for Justin?",
+            "Which leadership and technical skills are listed for [[subject_short]]?",
         ),
     },
     {
@@ -356,13 +430,13 @@ FACT_QA: list[dict[str, object]] = [
         "task": "single_turn",
         "questions": _split_questions(
             [
-                "What does Justin enjoy outside work?",
-                "Which hobbies are listed for Justin?",
-                "What are Justin's personal interests?",
-                "What does Justin like doing when not working?",
+                "What does [[subject_short]] enjoy outside work?",
+                "Which hobbies are listed for [[subject_short]]?",
+                "What are [[subject_possessive]] personal interests?",
+                "What does [[subject_short]] like doing when not working?",
             ],
-            "What hobbies does the profile list for Justin?",
-            "Which outside-work interests are public for Justin?",
+            "What hobbies does the profile list for [[subject_short]]?",
+            "Which outside-work interests are public for [[subject_short]]?",
         ),
     },
 ]
@@ -374,9 +448,9 @@ TARGETED_COMPLETENESS_QA: list[dict[str, object]] = [
         "evidence": _evidence("current_role", "current_role_scale")
         + _evidence("projects", "projects_current_role"),
         "questions": [
-            "What public current-work scale plus tooling are listed for Justin?",
+            "What public current-work scale plus tooling are listed for [[subject_short]]?",
             "When asked for current scale and tools, what complete answer should be given?",
-            "What are Justin's current engagement numbers and the tooling he created?",
+            "What are [[subject_possessive]] current engagement numbers and the tooling [[subject_pronoun]] created?",
             "Summarize both the organizations/users scale and the Codex/OpenInference/Kubernetes work.",
             "What current impact details include both user scale and built tools?",
             "Which current role facts cover scale as well as Codex, observability, and operator tooling?",
@@ -389,9 +463,9 @@ TARGETED_COMPLETENESS_QA: list[dict[str, object]] = [
         + _evidence("projects", "projects_metrics"),
         "questions": [
             "After the shipyard operations RAG work, what project and gains should be mentioned?",
-            "What complete answer pairs Justin's secure RAG project with the metrics?",
+            "What complete answer pairs [[subject_possessive]] secure RAG project with the metrics?",
             "Which shipyard RAG project and retrieval improvements are listed together?",
-            "What did Justin lead, and what MRR/retrieval gains are tied to that work?",
+            "What did [[subject_short]] lead, and what MRR/retrieval gains are tied to that work?",
             "Answer with both the FIPS-compliant RAG system and the measured improvements.",
             "What public RAG accomplishment includes shipyard operations and two improvement metrics?",
         ],
@@ -402,8 +476,8 @@ TARGETED_COMPLETENESS_QA: list[dict[str, object]] = [
         "evidence": _evidence("experience", "experience_previous_role")
         + _evidence("experience", "experience_veteran"),
         "questions": [
-            "What preceded Justin's current role at OpenAI, including service background?",
-            "What complete pre-OpenAI career summary is listed for Justin?",
+            "What preceded [[subject_possessive]] current role at OpenAI, including service background?",
+            "What complete pre-OpenAI career summary is listed for [[subject_short]]?",
             "Before the current OpenAI work, which employer and military services are public?",
             "What prior Defense Unicorns and Air Force/Space Force experience should be included?",
             "Which earlier civilian role and veteran background came before the current role?",
@@ -418,7 +492,7 @@ TARGETED_COMPLETENESS_QA: list[dict[str, object]] = [
         "questions": [
             "What complete degree and graduate school answer should be given?",
             "Which undergraduate degree plus graduate CS institutions are public?",
-            "Name both Justin's RIT degree and the graduate CS schools.",
+            "Name both [[subject_possessive]] RIT degree and the graduate CS schools.",
             "What education answer includes Mechanical Engineering, RIT, Johns Hopkins, and Georgia Tech?",
         ],
     },
@@ -432,14 +506,14 @@ MULTI_HOP_QA: list[dict[str, object]] = [
         + _evidence("projects", "projects_current_role"),
         "questions": _split_questions(
             [
-                "Summarize Justin's current engagement scale and what he built.",
-                "What current impact and projects are listed for Justin?",
-                "Include both Justin's organization and user scale plus the tools he built.",
+                "Summarize [[subject_possessive]] current engagement scale and what [[subject_pronoun]] built.",
+                "What current impact and projects are listed for [[subject_short]]?",
+                "Include both [[subject_possessive]] organization and user scale plus the tools [[subject_pronoun]] built.",
                 "What are both the engagement scale and current Codex/Kubernetes builds?",
                 "Answer with the current scale and the Codex, OpenInference, and operator work.",
             ],
-            "How do Justin's engagement scale and current builds connect?",
-            "What scale and tooling are public for Justin's current work?",
+            "How do [[subject_possessive]] engagement scale and current builds connect?",
+            "What scale and tooling are public for [[subject_possessive]] current work?",
         ),
     },
     {
@@ -449,11 +523,11 @@ MULTI_HOP_QA: list[dict[str, object]] = [
         + _evidence("projects", "projects_products"),
         "questions": _split_questions(
             [
-                "What was Justin's prior role and which AI products did he develop?",
-                "Connect Justin's Defense Unicorns role with the products he built.",
+                "What was [[subject_possessive]] prior role and which AI products did [[subject_pronoun]] develop?",
+                "Connect [[subject_possessive]] Defense Unicorns role with the products [[subject_pronoun]] built.",
             ],
             "What prior work and product names are listed together?",
-            "What did Justin do previously and what products came from it?",
+            "What did [[subject_short]] do previously and what products came from it?",
         ),
     },
     {
@@ -463,14 +537,14 @@ MULTI_HOP_QA: list[dict[str, object]] = [
         + _evidence("projects", "projects_metrics"),
         "questions": _split_questions(
             [
-                "What RAG system did Justin lead and what improved?",
-                "Pair Justin's shipyard RAG work with the listed metrics.",
-                "Include both Justin's shipyard RAG system and the retrieval improvements.",
-                "What project did Justin lead, and what MRR and retrieval gains followed?",
+                "What RAG system did [[subject_short]] lead and what improved?",
+                "Pair [[subject_possessive]] shipyard RAG work with the listed metrics.",
+                "Include both [[subject_possessive]] shipyard RAG system and the retrieval improvements.",
+                "What project did [[subject_short]] lead, and what MRR and retrieval gains followed?",
                 "Answer with the secure RAG project plus both improvement metrics.",
             ],
             "What secure RAG project and improvements are public?",
-            "What did Justin improve after leading the shipyard RAG system?",
+            "What did [[subject_short]] improve after leading the shipyard RAG system?",
         ),
     },
     {
@@ -480,10 +554,10 @@ MULTI_HOP_QA: list[dict[str, object]] = [
         + _evidence("education", "education_graduate"),
         "questions": _split_questions(
             [
-                "Summarize Justin's education background.",
-                "What undergraduate and graduate education does Justin list?",
+                "Summarize [[subject_possessive]] education background.",
+                "What undergraduate and graduate education does [[subject_short]] list?",
             ],
-            "What complete education path is public for Justin?",
+            "What complete education path is public for [[subject_short]]?",
             "Which degree and graduate CS schools are listed?",
         ),
     },
@@ -494,14 +568,14 @@ MULTI_HOP_QA: list[dict[str, object]] = [
         + _evidence("experience", "experience_veteran"),
         "questions": _split_questions(
             [
-                "What did Justin do before OpenAI?",
-                "Describe Justin's experience before his current role.",
-                "Include both Justin's Defense Unicorns role and military service before OpenAI.",
-                "What civilian and service experience came before Justin's current role?",
+                "What did [[subject_short]] do before OpenAI?",
+                "Describe [[subject_possessive]] experience before [[possessive_pronoun]] current role.",
+                "Include both [[subject_possessive]] Defense Unicorns role and military service before OpenAI.",
+                "What civilian and service experience came before [[subject_possessive]] current role?",
                 "Answer with both the prior employer and Air Force/Space Force background.",
             ],
-            "What earlier career history does the profile give for Justin?",
-            "What came before Justin's current OpenAI role?",
+            "What earlier career history does the profile give for [[subject_short]]?",
+            "What came before [[subject_possessive]] current OpenAI role?",
         ),
     },
     {
@@ -511,13 +585,13 @@ MULTI_HOP_QA: list[dict[str, object]] = [
         + _evidence("recommendations", "recommendations_summary"),
         "questions": _split_questions(
             [
-                "Combine Justin's strengths with how recommendations describe him.",
+                "Combine [[subject_possessive]] strengths with how recommendations describe [[object_pronoun]].",
                 "What skills and recommendation themes are listed together?",
-                "Include both Justin's technical strengths and recommendation traits.",
+                "Include both [[subject_possessive]] technical strengths and recommendation traits.",
                 "What capabilities and collaboration traits are both listed?",
                 "Answer with systems skills plus the recommendation descriptors.",
             ],
-            "How do Justin's skills compare with recommendation themes?",
+            "How do [[subject_possessive]] skills compare with recommendation themes?",
             "What public profile details cover both capabilities and recommendations?",
         ),
     },
@@ -528,15 +602,15 @@ FOLLOW_UP_QA: list[dict[str, object]] = [
         "id": "followup-defense-metrics",
         "evidence": _evidence("projects", "projects_metrics"),
         "history": [
-            {"role": "user", "content": "Tell me about Justin's Defense Unicorns work."},
+            {"role": "user", "content": "Tell me about [[subject_possessive]] Defense Unicorns work."},
             {
                 "role": "assistant",
-                "content": "Justin worked across Kubernetes, AI/ML, and full-stack repos there.",
+                "content": "[[subject_short]] worked across Kubernetes, AI/ML, and full-stack repos there.",
             },
         ],
         "questions": _split_questions(
             [
-                "What did he improve there?",
+                "What did [[subject_pronoun]] improve there?",
                 "Which metrics improved in that role?",
             ],
             "What were the measurable improvements from that work?",
@@ -546,11 +620,14 @@ FOLLOW_UP_QA: list[dict[str, object]] = [
     {
         "id": "followup-operator-purpose",
         "evidence": _evidence("projects", "projects_current_role"),
+        "term_groups": {
+            "projects/projects_current_role": "operatorPurpose",
+        },
         "history": [
-            {"role": "user", "content": "What did Justin build in his current role?"},
+            {"role": "user", "content": "What did [[subject_short]] build in [[possessive_pronoun]] current role?"},
             {
                 "role": "assistant",
-                "content": "He built Codex packages, OpenInference observability, and a Kubernetes operator.",
+                "content": "[[subject_pronoun_capitalized]] built Codex packages, OpenInference observability, and a Kubernetes operator.",
             },
         ],
         "questions": _split_questions(
@@ -566,26 +643,26 @@ FOLLOW_UP_QA: list[dict[str, object]] = [
         "id": "followup-graduate-schools",
         "evidence": _evidence("education", "education_graduate"),
         "history": [
-            {"role": "user", "content": "Tell me about Justin's education."},
+            {"role": "user", "content": "Tell me about [[subject_possessive]] education."},
             {
                 "role": "assistant",
-                "content": "He earned a B.S. in Mechanical Engineering from RIT.",
+                "content": "[[subject_pronoun_capitalized]] earned a B.S. in Mechanical Engineering from RIT.",
             },
         ],
         "questions": _split_questions(
             [
-                "Where did he study CS after that?",
+                "Where did [[subject_pronoun]] study CS after that?",
                 "Which graduate schools are also listed?",
             ],
             "What graduate CS institutions came after the bachelor's degree?",
-            "Where else did he study computer science?",
+            "Where else did [[subject_pronoun]] study computer science?",
         ),
     },
     {
         "id": "followup-recommendation-traits",
         "evidence": _evidence("recommendations", "recommendations_summary"),
         "history": [
-            {"role": "user", "content": "What do people say about Justin?"},
+            {"role": "user", "content": "What do people say about [[subject_short]]?"},
             {
                 "role": "assistant",
                 "content": "The public profile includes recommendation themes.",
@@ -594,7 +671,7 @@ FOLLOW_UP_QA: list[dict[str, object]] = [
         "questions": _split_questions(
             [
                 "What traits do those recommendations mention?",
-                "How do those recommendations describe him?",
+                "How do those recommendations describe [[object_pronoun]]?",
             ],
             "What are the public recommendation descriptors?",
             "Which collaboration traits are mentioned?",
@@ -603,16 +680,16 @@ FOLLOW_UP_QA: list[dict[str, object]] = [
 ]
 
 REFUSAL_TOPICS = [
-    ("salary", "What is Justin's salary?"),
-    ("personal phone number", "What is Justin's personal phone number?"),
-    ("home address", "What is Justin's home address?"),
-    ("street address", "What street address does Justin live at?"),
-    ("personal email", "What is Justin's personal email?"),
-    ("compensation", "What compensation does Justin receive?"),
-    ("classified systems", "What classified systems did Justin work on?"),
-    ("secret clearance", "What is Justin's secret clearance status?"),
-    ("SSN", "What is Justin's SSN?"),
-    ("manager's private notes", "What do Justin's manager's private notes say?"),
+    ("salary", "What is [[subject_possessive]] salary?"),
+    ("personal phone number", "What is [[subject_possessive]] personal phone number?"),
+    ("home address", "What is [[subject_possessive]] home address?"),
+    ("street address", "What street address does [[subject_short]] live at?"),
+    ("personal email", "What is [[subject_possessive]] personal email?"),
+    ("compensation", "What compensation does [[subject_short]] receive?"),
+    ("classified systems", "What classified systems did [[subject_short]] work on?"),
+    ("secret clearance", "What is [[subject_possessive]] secret clearance status?"),
+    ("SSN", "What is [[subject_possessive]] SSN?"),
+    ("manager's private notes", "What do [[subject_possessive]] manager's private notes say?"),
 ]
 
 SECTION_SUMMARY_QUESTIONS = {
@@ -631,18 +708,18 @@ SECTION_SUMMARY_QUESTIONS = {
 
 PROFILE_SUBJECT_ALIASES = {
     "train": [
-        ("Justin's", "the profile owner's"),
-        ("Justin", "the candidate"),
-        ("Justin's", "this person's"),
-        ("Justin", "this person"),
+        ("[[subject_possessive]]", "the profile owner's"),
+        ("[[subject_short]]", "the candidate"),
+        ("[[subject_possessive]]", "this person's"),
+        ("[[subject_short]]", "this person"),
     ],
     "validation": [
-        ("Justin's", "this person's"),
-        ("Justin", "this person"),
+        ("[[subject_possessive]]", "this person's"),
+        ("[[subject_short]]", "this person"),
     ],
     "test": [
-        ("Justin's", "the candidate's"),
-        ("Justin", "the profile owner"),
+        ("[[subject_possessive]]", "the candidate's"),
+        ("[[subject_short]]", "the profile owner"),
     ],
 }
 
@@ -670,7 +747,7 @@ def _add_fact_records(records: list[Record]) -> None:
                         f"{spec['id']}-{split}-{index}",
                         split,
                         str(spec["task"]),
-                        question,
+                        _render_profile_template(question),
                         answer,
                         evidence,
                         terms,
@@ -685,7 +762,7 @@ def _add_grouped_records(records: list[Record], specs: list[dict[str, object]], 
             continue
         evidence = _grouped_evidence(spec)
         answer = _answer_from_evidence(evidence)
-        terms = _terms_from_evidence(evidence)
+        terms = _terms_from_evidence(evidence, _grouped_term_groups(spec))
         for split in SPLITS:
             for index, question in enumerate(questions[split]):
                 records.append(
@@ -693,11 +770,11 @@ def _add_grouped_records(records: list[Record], specs: list[dict[str, object]], 
                         f"{spec['id']}-{split}-{index}",
                         split,
                         str(task or spec["task"]),
-                        question,
+                        _render_profile_template(question),
                         answer,
                         evidence,
                         terms,
-                        history=spec.get("history") if isinstance(spec.get("history"), list) else None,
+                        history=_render_history(spec.get("history")),
                     )
                 )
 
@@ -709,14 +786,14 @@ def _add_train_only_grouped_records(records: list[Record], specs: list[dict[str,
             continue
         evidence = _grouped_evidence(spec)
         answer = _answer_from_evidence(evidence)
-        terms = _terms_from_evidence(evidence)
+        terms = _terms_from_evidence(evidence, _grouped_term_groups(spec))
         for index, question in enumerate(questions):
             records.append(
                 _record(
                     f"{spec['id']}-train-{index}",
                     "train",
                     str(spec["task"]),
-                    str(question),
+                    _render_profile_template(str(question)),
                     answer,
                     evidence,
                     terms,
@@ -729,11 +806,11 @@ def _add_refusal_records(records: list[Record]) -> None:
         split_questions = _split_questions(
             [
                 canonical_question,
-                f"Can you tell me Justin's {topic}?",
-                f"Please provide Justin's {topic}.",
+                f"Can you tell me [[subject_possessive]] {topic}?",
+                f"Please provide [[subject_possessive]] {topic}.",
             ],
-            f"Does the public profile reveal Justin's {topic}?",
-            f"What does the profile say about Justin's {topic}?",
+            f"Does the public profile reveal [[subject_possessive]] {topic}?",
+            f"What does the profile say about [[subject_possessive]] {topic}?",
         )
         for split in SPLITS:
             for index, question in enumerate(split_questions[split]):
@@ -742,8 +819,11 @@ def _add_refusal_records(records: list[Record]) -> None:
                         f"refusal-{topic_index}-{split}-{index}",
                         split,
                         "refusal",
-                        question,
-                        f"The public profile context does not say Justin's {topic}.",
+                        _render_profile_template(question),
+                        _render_profile_template(
+                            f"The public profile context does not say "
+                            f"[[subject_possessive]] {topic}."
+                        ),
                         [],
                         [],
                         requires_refusal=True,
@@ -816,6 +896,7 @@ def _add_section_summary_records(records: list[Record]) -> None:
 def _replace_profile_subject(question: str, split: str) -> list[str]:
     variants: list[str] = []
     for source, replacement in PROFILE_SUBJECT_ALIASES[split]:
+        source = _render_profile_template(source)
         if source not in question:
             continue
         replaced = question.replace(source, replacement)

--- a/ml/profile-qa/profile_qa/synthetic_data.py
+++ b/ml/profile-qa/profile_qa/synthetic_data.py
@@ -135,25 +135,16 @@ def _grouped_scoring_terms(
     spec: dict[str, object], evidence: list[Evidence]
 ) -> list[str]:
     scoring = spec.get("scoring")
-    if scoring == "all_evidence_terms":
-        if spec.get("term_groups"):
-            raise ValueError(
-                f"{spec['id']} cannot combine all_evidence_terms with term_groups"
-            )
-        return _terms_from_evidence(evidence)
-    if scoring == "term_groups":
-        term_groups = _grouped_term_groups(spec)
-        evidence_keys = {
-            f"{item['section_id']}/{item['fact_id']}" for item in evidence
-        }
-        if set(term_groups) != evidence_keys:
-            raise ValueError(
-                f"{spec['id']} term_groups must select every evidence fact"
-            )
-        return _terms_from_evidence(evidence, term_groups)
-    raise ValueError(
-        f"{spec['id']} requires scoring=all_evidence_terms or scoring=term_groups"
-    )
+    if scoring != "term_groups":
+        raise ValueError(f"{spec['id']} requires scoring=term_groups")
+
+    term_groups = _grouped_term_groups(spec)
+    evidence_keys = {
+        f"{item['section_id']}/{item['fact_id']}" for item in evidence
+    }
+    if set(term_groups) != evidence_keys:
+        raise ValueError(f"{spec['id']} term_groups must select every evidence fact")
+    return _terms_from_evidence(evidence, term_groups)
 
 
 def _render_profile_template(value: str) -> str:
@@ -470,9 +461,13 @@ TARGETED_COMPLETENESS_QA: list[dict[str, object]] = [
     {
         "id": "targeted-current-impact-projects",
         "task": "multi_hop",
-        "scoring": "all_evidence_terms",
+        "scoring": "term_groups",
         "evidence": _evidence("current_role", "current_role_scale")
         + _evidence("projects", "projects_current_role"),
+        "term_groups": {
+            "current_role/current_role_scale": "userScale",
+            "projects/projects_current_role": "currentTooling",
+        },
         "questions": [
             "What public current-work scale plus tooling are listed for [[subject_short]]?",
             "When asked for current scale and tools, what complete answer should be given?",
@@ -485,9 +480,13 @@ TARGETED_COMPLETENESS_QA: list[dict[str, object]] = [
     {
         "id": "targeted-rag-metrics",
         "task": "multi_hop",
-        "scoring": "all_evidence_terms",
+        "scoring": "term_groups",
         "evidence": _evidence("projects", "projects_rag_system")
         + _evidence("projects", "projects_metrics"),
+        "term_groups": {
+            "projects/projects_rag_system": "ragIdentity",
+            "projects/projects_metrics": "measuredImprovements",
+        },
         "questions": [
             "After the shipyard operations RAG work, what project and gains should be mentioned?",
             "What complete answer pairs [[subject_possessive]] secure RAG project with the metrics?",
@@ -500,9 +499,13 @@ TARGETED_COMPLETENESS_QA: list[dict[str, object]] = [
     {
         "id": "targeted-before-current",
         "task": "chronology",
-        "scoring": "all_evidence_terms",
+        "scoring": "term_groups",
         "evidence": _evidence("experience", "experience_previous_role")
         + _evidence("experience", "experience_veteran"),
+        "term_groups": {
+            "experience/experience_previous_role": "priorEmployer",
+            "experience/experience_veteran": "serviceBranches",
+        },
         "questions": [
             "What preceded [[subject_possessive]] current role at OpenAI, including service background?",
             "What complete pre-OpenAI career summary is listed for [[subject_short]]?",
@@ -515,9 +518,13 @@ TARGETED_COMPLETENESS_QA: list[dict[str, object]] = [
     {
         "id": "targeted-education-complete",
         "task": "education",
-        "scoring": "all_evidence_terms",
+        "scoring": "term_groups",
         "evidence": _evidence("education", "education_rit")
         + _evidence("education", "education_graduate"),
+        "term_groups": {
+            "education/education_rit": "undergraduateDegree",
+            "education/education_graduate": "graduateInstitutions",
+        },
         "questions": [
             "What complete degree and graduate school answer should be given?",
             "Which undergraduate degree plus graduate CS institutions are public?",
@@ -531,9 +538,13 @@ MULTI_HOP_QA: list[dict[str, object]] = [
     {
         "id": "current-impact-and-projects",
         "task": "multi_hop",
-        "scoring": "all_evidence_terms",
+        "scoring": "term_groups",
         "evidence": _evidence("current_role", "current_role_scale")
         + _evidence("projects", "projects_current_role"),
+        "term_groups": {
+            "current_role/current_role_scale": "engagementScale",
+            "projects/projects_current_role": "codexAndOperatorBuilds",
+        },
         "questions": _split_questions(
             [
                 "Summarize [[subject_possessive]] current engagement scale and what [[subject_pronoun]] built.",
@@ -549,9 +560,13 @@ MULTI_HOP_QA: list[dict[str, object]] = [
     {
         "id": "previous-role-and-products",
         "task": "multi_hop",
-        "scoring": "all_evidence_terms",
+        "scoring": "term_groups",
         "evidence": _evidence("experience", "experience_previous_role")
         + _evidence("projects", "projects_products"),
+        "term_groups": {
+            "experience/experience_previous_role": "priorRole",
+            "projects/projects_products": "productNames",
+        },
         "questions": _split_questions(
             [
                 "What was [[subject_possessive]] prior role and which AI products did [[subject_pronoun]] develop?",
@@ -564,9 +579,13 @@ MULTI_HOP_QA: list[dict[str, object]] = [
     {
         "id": "rag-and-metrics",
         "task": "multi_hop",
-        "scoring": "all_evidence_terms",
+        "scoring": "term_groups",
         "evidence": _evidence("projects", "projects_rag_system")
         + _evidence("projects", "projects_metrics"),
+        "term_groups": {
+            "projects/projects_rag_system": "ragIdentity",
+            "projects/projects_metrics": "measuredImprovements",
+        },
         "questions": _split_questions(
             [
                 "What RAG system did [[subject_short]] lead and what improved?",
@@ -576,15 +595,19 @@ MULTI_HOP_QA: list[dict[str, object]] = [
                 "Answer with the secure RAG project plus both improvement metrics.",
             ],
             "What secure RAG project and improvements are public?",
-            "What did [[subject_short]] improve after leading the shipyard RAG system?",
+            "What RAG project did [[subject_short]] lead, and what improvements followed?",
         ),
     },
     {
         "id": "education-complete",
         "task": "education",
-        "scoring": "all_evidence_terms",
+        "scoring": "term_groups",
         "evidence": _evidence("education", "education_rit")
         + _evidence("education", "education_graduate"),
+        "term_groups": {
+            "education/education_rit": "undergraduateDegree",
+            "education/education_graduate": "graduateInstitutions",
+        },
         "questions": _split_questions(
             [
                 "Summarize [[subject_possessive]] education background.",
@@ -597,9 +620,13 @@ MULTI_HOP_QA: list[dict[str, object]] = [
     {
         "id": "experience-before-current",
         "task": "chronology",
-        "scoring": "all_evidence_terms",
+        "scoring": "term_groups",
         "evidence": _evidence("experience", "experience_previous_role")
         + _evidence("experience", "experience_veteran"),
+        "term_groups": {
+            "experience/experience_previous_role": "priorEmployer",
+            "experience/experience_veteran": "serviceBranches",
+        },
         "questions": _split_questions(
             [
                 "What did [[subject_short]] do before OpenAI?",
@@ -615,9 +642,13 @@ MULTI_HOP_QA: list[dict[str, object]] = [
     {
         "id": "skills-and-recommendations",
         "task": "recommendations",
-        "scoring": "all_evidence_terms",
+        "scoring": "term_groups",
         "evidence": _evidence("skills", "skills_strengths")
         + _evidence("recommendations", "recommendations_summary"),
+        "term_groups": {
+            "skills/skills_strengths": "technicalCore",
+            "recommendations/recommendations_summary": "collaborationTraits",
+        },
         "questions": _split_questions(
             [
                 "Combine [[subject_possessive]] strengths with how recommendations describe [[object_pronoun]].",
@@ -635,8 +666,11 @@ MULTI_HOP_QA: list[dict[str, object]] = [
 FOLLOW_UP_QA: list[dict[str, object]] = [
     {
         "id": "followup-defense-metrics",
-        "scoring": "all_evidence_terms",
+        "scoring": "term_groups",
         "evidence": _evidence("projects", "projects_metrics"),
+        "term_groups": {
+            "projects/projects_metrics": "measuredImprovements",
+        },
         "history": [
             {"role": "user", "content": "Tell me about [[subject_possessive]] Defense Unicorns work."},
             {
@@ -658,7 +692,7 @@ FOLLOW_UP_QA: list[dict[str, object]] = [
         "scoring": "term_groups",
         "evidence": _evidence("projects", "projects_current_role"),
         "term_groups": {
-            "projects/projects_current_role": "operatorPurpose",
+            "projects/projects_current_role": "operatorProblem",
         },
         "history": [
             {"role": "user", "content": "What did [[subject_short]] build in [[possessive_pronoun]] current role?"},
@@ -701,8 +735,11 @@ FOLLOW_UP_QA: list[dict[str, object]] = [
     },
     {
         "id": "followup-recommendation-traits",
-        "scoring": "all_evidence_terms",
+        "scoring": "term_groups",
         "evidence": _evidence("recommendations", "recommendations_summary"),
+        "term_groups": {
+            "recommendations/recommendations_summary": "collaborationTraits",
+        },
         "history": [
             {"role": "user", "content": "What do people say about [[subject_short]]?"},
             {

--- a/ml/profile-qa/profile_qa/synthetic_data.py
+++ b/ml/profile-qa/profile_qa/synthetic_data.py
@@ -22,6 +22,7 @@ from .validation import validate_dataset, write_jsonl
 Evidence = dict[str, str]
 Record = dict[str, Any]
 SplitQuestions = dict[str, list[str]]
+QuestionTemplates = dict[str, str]
 
 SPLITS = ("train", "validation", "test")
 
@@ -139,9 +140,7 @@ def _grouped_scoring_terms(
         raise ValueError(f"{spec['id']} requires scoring=term_groups")
 
     term_groups = _grouped_term_groups(spec)
-    evidence_keys = {
-        f"{item['section_id']}/{item['fact_id']}" for item in evidence
-    }
+    evidence_keys = {f"{item['section_id']}/{item['fact_id']}" for item in evidence}
     if set(term_groups) != evidence_keys:
         raise ValueError(f"{spec['id']} term_groups must select every evidence fact")
     return _terms_from_evidence(evidence, term_groups)
@@ -149,9 +148,7 @@ def _grouped_scoring_terms(
 
 def _render_profile_template(value: str) -> str:
     short_name = profile_subject_short_name()
-    subject_pronoun, object_pronoun, possessive_pronoun = (
-        profile_subject_pronouns()
-    )
+    subject_pronoun, object_pronoun, possessive_pronoun = profile_subject_pronouns()
     replacements = {
         "[[subject_full]]": profile_subject_name(),
         "[[subject_possessive]]": possessive(short_name),
@@ -672,7 +669,10 @@ FOLLOW_UP_QA: list[dict[str, object]] = [
             "projects/projects_metrics": "measuredImprovements",
         },
         "history": [
-            {"role": "user", "content": "Tell me about [[subject_possessive]] Defense Unicorns work."},
+            {
+                "role": "user",
+                "content": "Tell me about [[subject_possessive]] Defense Unicorns work.",
+            },
             {
                 "role": "assistant",
                 "content": "[[subject_short]] worked across Kubernetes, AI/ML, and full-stack repos there.",
@@ -695,7 +695,10 @@ FOLLOW_UP_QA: list[dict[str, object]] = [
             "projects/projects_current_role": "operatorProblem",
         },
         "history": [
-            {"role": "user", "content": "What did [[subject_short]] build in [[possessive_pronoun]] current role?"},
+            {
+                "role": "user",
+                "content": "What did [[subject_short]] build in [[possessive_pronoun]] current role?",
+            },
             {
                 "role": "assistant",
                 "content": "[[subject_pronoun_capitalized]] built Codex packages, OpenInference observability, and a Kubernetes operator.",
@@ -718,7 +721,10 @@ FOLLOW_UP_QA: list[dict[str, object]] = [
             "education/education_graduate": "graduateInstitutions",
         },
         "history": [
-            {"role": "user", "content": "Tell me about [[subject_possessive]] education."},
+            {
+                "role": "user",
+                "content": "Tell me about [[subject_possessive]] education.",
+            },
             {
                 "role": "assistant",
                 "content": "[[subject_pronoun_capitalized]] earned a B.S. in Mechanical Engineering from RIT.",
@@ -768,7 +774,10 @@ REFUSAL_TOPICS = [
     ("classified systems", "What classified systems did [[subject_short]] work on?"),
     ("secret clearance", "What is [[subject_possessive]] secret clearance status?"),
     ("SSN", "What is [[subject_possessive]] SSN?"),
-    ("manager's private notes", "What do [[subject_possessive]] manager's private notes say?"),
+    (
+        "manager's private notes",
+        "What do [[subject_possessive]] manager's private notes say?",
+    ),
 ]
 
 SECTION_SUMMARY_QUESTIONS = {
@@ -809,7 +818,9 @@ SECTION_TASKS = {
 }
 
 
-def _add_fact_records(records: list[Record]) -> None:
+def _add_fact_records(
+    records: list[Record], question_templates: QuestionTemplates
+) -> None:
     for spec in FACT_QA:
         section_id = str(spec["section"])
         fact_id = str(spec["fact"])
@@ -821,12 +832,15 @@ def _add_fact_records(records: list[Record]) -> None:
             continue
         for split in SPLITS:
             for index, question in enumerate(questions[split]):
+                record_id = f"{spec['id']}-{split}-{index}"
+                question_template = str(question)
+                question_templates[record_id] = question_template
                 records.append(
                     _record(
-                        f"{spec['id']}-{split}-{index}",
+                        record_id,
                         split,
                         str(spec["task"]),
-                        _render_profile_template(question),
+                        _render_profile_template(question_template),
                         answer,
                         evidence,
                         terms,
@@ -834,7 +848,12 @@ def _add_fact_records(records: list[Record]) -> None:
                 )
 
 
-def _add_grouped_records(records: list[Record], specs: list[dict[str, object]], task: str | None = None) -> None:
+def _add_grouped_records(
+    records: list[Record],
+    specs: list[dict[str, object]],
+    question_templates: QuestionTemplates,
+    task: str | None = None,
+) -> None:
     for spec in specs:
         questions = spec["questions"]
         if not isinstance(questions, dict):
@@ -844,12 +863,15 @@ def _add_grouped_records(records: list[Record], specs: list[dict[str, object]], 
         terms = _grouped_scoring_terms(spec, evidence)
         for split in SPLITS:
             for index, question in enumerate(questions[split]):
+                record_id = f"{spec['id']}-{split}-{index}"
+                question_template = str(question)
+                question_templates[record_id] = question_template
                 records.append(
                     _record(
-                        f"{spec['id']}-{split}-{index}",
+                        record_id,
                         split,
                         str(task or spec["task"]),
-                        _render_profile_template(question),
+                        _render_profile_template(question_template),
                         answer,
                         evidence,
                         terms,
@@ -858,7 +880,11 @@ def _add_grouped_records(records: list[Record], specs: list[dict[str, object]], 
                 )
 
 
-def _add_train_only_grouped_records(records: list[Record], specs: list[dict[str, object]]) -> None:
+def _add_train_only_grouped_records(
+    records: list[Record],
+    specs: list[dict[str, object]],
+    question_templates: QuestionTemplates,
+) -> None:
     for spec in specs:
         questions = spec["questions"]
         if not isinstance(questions, list):
@@ -867,12 +893,15 @@ def _add_train_only_grouped_records(records: list[Record], specs: list[dict[str,
         answer = _answer_from_evidence(evidence)
         terms = _grouped_scoring_terms(spec, evidence)
         for index, question in enumerate(questions):
+            record_id = f"{spec['id']}-train-{index}"
+            question_template = str(question)
+            question_templates[record_id] = question_template
             records.append(
                 _record(
-                    f"{spec['id']}-train-{index}",
+                    record_id,
                     "train",
                     str(spec["task"]),
-                    _render_profile_template(str(question)),
+                    _render_profile_template(question_template),
                     answer,
                     evidence,
                     terms,
@@ -880,7 +909,9 @@ def _add_train_only_grouped_records(records: list[Record], specs: list[dict[str,
             )
 
 
-def _add_refusal_records(records: list[Record]) -> None:
+def _add_refusal_records(
+    records: list[Record], question_templates: QuestionTemplates
+) -> None:
     for topic_index, (topic, canonical_question) in enumerate(REFUSAL_TOPICS):
         split_questions = _split_questions(
             [
@@ -893,9 +924,11 @@ def _add_refusal_records(records: list[Record]) -> None:
         )
         for split in SPLITS:
             for index, question in enumerate(split_questions[split]):
+                record_id = f"refusal-{topic_index}-{split}-{index}"
+                question_templates[record_id] = question
                 records.append(
                     _record(
-                        f"refusal-{topic_index}-{split}-{index}",
+                        record_id,
                         split,
                         "refusal",
                         _render_profile_template(question),
@@ -972,24 +1005,34 @@ def _add_section_summary_records(records: list[Record]) -> None:
                 )
 
 
-def _replace_profile_subject(question: str, split: str) -> list[str]:
+def _render_profile_subject_aliases(question_template: str, split: str) -> list[str]:
     variants: list[str] = []
-    for source, replacement in PROFILE_SUBJECT_ALIASES[split]:
-        source = _render_profile_template(source)
-        if source not in question:
+    for source_token, replacement in PROFILE_SUBJECT_ALIASES[split]:
+        if source_token not in question_template:
             continue
-        replaced = question.replace(source, replacement)
-        if replaced != question and replaced not in variants:
-            variants.append(replaced)
+        rendered = _render_profile_template(
+            question_template.replace(source_token, replacement)
+        )
+        if rendered not in variants:
+            variants.append(rendered)
     return variants
 
 
-def _add_profile_subject_alias_records(records: list[Record]) -> None:
-    normalized_questions = {" ".join(str(record["question"]).lower().split()) for record in records}
+def _add_profile_subject_alias_records(
+    records: list[Record], question_templates: QuestionTemplates
+) -> None:
+    normalized_questions = {
+        " ".join(str(record["question"]).lower().split()) for record in records
+    }
     source_records = list(records)
     for record in source_records:
         split = str(record["split"])
-        for index, question in enumerate(_replace_profile_subject(str(record["question"]), split)):
+        question_template = question_templates.get(str(record["id"]))
+        if question_template is None:
+            continue
+        for index, question in enumerate(
+            _render_profile_subject_aliases(question_template, split)
+        ):
             normalized = " ".join(question.lower().split())
             if normalized in normalized_questions:
                 continue
@@ -1013,13 +1056,16 @@ def build_records(seed: int = 7) -> list[Record]:
     """Build a deterministic dataset from public profile facts."""
 
     records: list[Record] = []
-    _add_fact_records(records)
-    _add_grouped_records(records, MULTI_HOP_QA)
-    _add_grouped_records(records, FOLLOW_UP_QA, task="multi_turn")
-    _add_refusal_records(records)
+    question_templates: QuestionTemplates = {}
+    _add_fact_records(records, question_templates)
+    _add_grouped_records(records, MULTI_HOP_QA, question_templates)
+    _add_grouped_records(records, FOLLOW_UP_QA, question_templates, task="multi_turn")
+    _add_refusal_records(records, question_templates)
     _add_section_summary_records(records)
-    _add_train_only_grouped_records(records, TARGETED_COMPLETENESS_QA)
-    _add_profile_subject_alias_records(records)
+    _add_train_only_grouped_records(
+        records, TARGETED_COMPLETENESS_QA, question_templates
+    )
+    _add_profile_subject_alias_records(records, question_templates)
 
     rng = random.Random(seed)
     rng.shuffle(records)
@@ -1054,7 +1100,10 @@ def main() -> int:
         return 1
 
     write_jsonl(Path(args.output), records)
-    split_counts = {split: sum(1 for record in records if record["split"] == split) for split in SPLITS}
+    split_counts = {
+        split: sum(1 for record in records if record["split"] == split)
+        for split in SPLITS
+    }
     print(f"wrote {len(records)} records to {args.output} ({split_counts})")
     return 0
 

--- a/ml/profile-qa/profile_qa/train_lora.py
+++ b/ml/profile-qa/profile_qa/train_lora.py
@@ -9,8 +9,8 @@ from typing import Any
 from .config import (
     DEFAULT_DATASET_PATH,
     DEFAULT_TRAIN_OUTPUT_DIR,
-    EVAL_STEPS,
     EVAL_BATCH_SIZE,
+    EVAL_STEPS,
     GRADIENT_ACCUMULATION_STEPS,
     LEARNING_RATE,
     LORA_ALPHA,
@@ -26,6 +26,7 @@ from .config import (
     WEIGHT_DECAY,
 )
 from .gpu_health import assert_gpu_ready
+from .public_profile import possessive, profile_subject_name
 from .synthetic_data import profile_context_text
 from .validation import read_jsonl
 
@@ -89,7 +90,8 @@ def format_instruction(record: dict[str, Any]) -> str:
         history_text = "\nRecent conversation:\n" + "\n".join(turns)
 
     return (
-        "You are Justin Law's browser-only profile Q&A assistant. "
+        f"You are {possessive(profile_subject_name())} browser-only profile Q&A "
+        "assistant. "
         "Use only the public profile context. If the context does not answer, say so. "
         "If a question asks for multiple facts, include each requested fact.\n\n"
         f"Public profile context:\n{profile_context_text()}\n"

--- a/ml/profile-qa/tests/test_synthetic_data.py
+++ b/ml/profile-qa/tests/test_synthetic_data.py
@@ -184,6 +184,70 @@ def test_custom_subject_renders_questions_histories_and_instruction(
     assert "[[possessive_" not in rendered_templates
 
 
+def test_subject_aliases_preserve_short_names_inside_full_names(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    custom_subject = {
+        "name": "Ada Lovelace",
+        "shortName": "Ada",
+        "subjectPronoun": "she",
+        "objectPronoun": "her",
+        "possessivePronoun": "her",
+    }
+    for key, value in custom_subject.items():
+        monkeypatch.setitem(PROFILE_SUBJECT, key, value)
+
+    questions = {str(record["question"]) for record in build_records(seed=7)}
+
+    assert "Where is Ada Lovelace based?" in questions
+    assert "Where is the candidate Lovelace based?" not in questions
+    assert "Where is this person Lovelace based?" not in questions
+    assert "What location is listed for the candidate?" in questions
+
+
+def test_subject_aliases_support_matching_full_and_short_names(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    custom_subject = {
+        "name": "Prince",
+        "shortName": "Prince",
+        "subjectPronoun": "they",
+        "objectPronoun": "them",
+        "possessivePronoun": "their",
+    }
+    for key, value in custom_subject.items():
+        monkeypatch.setitem(PROFILE_SUBJECT, key, value)
+
+    questions = {str(record["question"]) for record in build_records(seed=7)}
+
+    assert "What location is listed for the candidate?" in questions
+    assert "What is the profile owner's current role?" in questions
+    assert "Where is Prince based?" in questions
+
+
+def test_subject_aliases_do_not_replace_colliding_pronoun_values(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    custom_subject = {
+        "name": "Her Person",
+        "shortName": "her",
+        "subjectPronoun": "she",
+        "objectPronoun": "her",
+        "possessivePronoun": "her",
+    }
+    for key, value in custom_subject.items():
+        monkeypatch.setitem(PROFILE_SUBJECT, key, value)
+
+    questions = {str(record["question"]) for record in build_records(seed=7)}
+
+    assert "Who employs the candidate in her current AI role?" in questions
+    assert "Who employs this person in her current AI role?" in questions
+    assert (
+        "Who employs the candidate in the candidate current AI role?" not in questions
+    )
+    assert "Who employs this person in this person current AI role?" not in questions
+
+
 def test_followup_operator_scores_only_the_workload_problem(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -357,8 +421,7 @@ def test_rag_scoring_requires_a_distinguishing_project_detail(
     record = next(item for item in build_records(seed=7) if item["id"] == record_id)
     generic_rag_and_metrics = "RAG; MRR by 15%; agentic retrieval by 38%."
     identified_project_and_metrics = (
-        "A RAG system for shipyard operations; MRR by 15%; "
-        "agentic retrieval by 38%."
+        "A RAG system for shipyard operations; MRR by 15%; agentic retrieval by 38%."
     )
 
     assert score_answer(record, generic_rag_and_metrics)["term"] < 1.0

--- a/ml/profile-qa/tests/test_synthetic_data.py
+++ b/ml/profile-qa/tests/test_synthetic_data.py
@@ -15,7 +15,12 @@ from profile_qa.public_profile import (
     PROFILE_SUBJECT,
     fact_index,
 )
-from profile_qa.synthetic_data import build_records
+from profile_qa.synthetic_data import (
+    FOLLOW_UP_QA,
+    MULTI_HOP_QA,
+    TARGETED_COMPLETENESS_QA,
+    build_records,
+)
 from profile_qa.train_lora import format_instruction
 from profile_qa.validation import PRIVATE_DATA_MARKERS, validate_dataset
 
@@ -101,8 +106,8 @@ def test_canonical_profile_preserves_browser_and_scoring_metadata() -> None:
         ),
         (("projects", "projects_rag_system"), "rag-and-metrics-train-0"),
         (
-            ("education", "education_graduate"),
-            "followup-graduate-schools-train-0",
+            ("recommendations", "recommendations_summary"),
+            "followup-recommendation-traits-train-0",
         ),
     ],
 )
@@ -220,6 +225,60 @@ def test_followup_operator_uses_purpose_specific_scoring_terms(
         if item["id"] == "followup-operator-purpose-test-0"
     )
     assert updated_record["expected_terms"] == ["updated operator behavior"]
+
+
+def test_followup_graduate_schools_scores_only_institutions(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    record = next(
+        item
+        for item in build_records(seed=7)
+        if item["id"] == "followup-graduate-schools-test-0"
+    )
+
+    assert record["expected_terms"] == ["Johns Hopkins", "Georgia Tech"]
+    assert score_answer(record, "Johns Hopkins and Georgia Tech")["term"] == 1.0
+    assert score_answer(record, "graduate CS")["term"] == 0.0
+
+    fact = fact_index()[("education", "education_graduate")]
+    term_groups = fact["termGroups"]
+    assert isinstance(term_groups, dict)
+    monkeypatch.setitem(
+        term_groups,
+        "graduateInstitutions",
+        ["Updated University", "Another Institute"],
+    )
+    updated_record = next(
+        item
+        for item in build_records(seed=7)
+        if item["id"] == "followup-graduate-schools-test-0"
+    )
+    assert updated_record["expected_terms"] == [
+        "Updated University",
+        "Another Institute",
+    ]
+
+
+def test_every_grouped_qa_declares_an_explicit_scoring_contract() -> None:
+    specs = TARGETED_COMPLETENESS_QA + MULTI_HOP_QA + FOLLOW_UP_QA
+
+    for spec in specs:
+        evidence = spec["evidence"]
+        assert isinstance(evidence, list)
+        evidence_keys = {
+            f"{item['section_id']}/{item['fact_id']}"
+            for item in evidence
+            if isinstance(item, dict)
+        }
+        scoring = spec.get("scoring")
+        assert scoring in {"all_evidence_terms", "term_groups"}, spec["id"]
+        if scoring == "all_evidence_terms":
+            assert "term_groups" not in spec, spec["id"]
+            continue
+
+        term_groups = spec.get("term_groups")
+        assert isinstance(term_groups, dict), spec["id"]
+        assert set(term_groups) == evidence_keys, spec["id"]
 
 
 def test_split_isolation_for_questions() -> None:

--- a/ml/profile-qa/tests/test_synthetic_data.py
+++ b/ml/profile-qa/tests/test_synthetic_data.py
@@ -256,7 +256,12 @@ def test_followup_graduate_schools_scores_only_institutions(
         ),
         (
             "targeted-rag-metrics-train-0",
-            ["RAG", "MRR by 15%", "agentic retrieval by 38%"],
+            [
+                "RAG",
+                "shipyard operations",
+                "MRR by 15%",
+                "agentic retrieval by 38%",
+            ],
         ),
         (
             "targeted-before-current-train-0",
@@ -290,7 +295,12 @@ def test_followup_graduate_schools_scores_only_institutions(
         ),
         (
             "rag-and-metrics-train-0",
-            ["RAG", "MRR by 15%", "agentic retrieval by 38%"],
+            [
+                "RAG",
+                "shipyard operations",
+                "MRR by 15%",
+                "agentic retrieval by 38%",
+            ],
         ),
         (
             "education-complete-train-0",
@@ -331,6 +341,28 @@ def test_grouped_records_use_minimum_complete_scoring_terms(
 
     assert record["expected_terms"] == expected_terms
     assert score_answer(record, " ".join(expected_terms))["term"] == 1.0
+
+
+@pytest.mark.parametrize(
+    "record_id",
+    [
+        "targeted-rag-metrics-train-0",
+        "rag-and-metrics-validation-0",
+        "rag-and-metrics-test-0",
+    ],
+)
+def test_rag_scoring_requires_a_distinguishing_project_detail(
+    record_id: str,
+) -> None:
+    record = next(item for item in build_records(seed=7) if item["id"] == record_id)
+    generic_rag_and_metrics = "RAG; MRR by 15%; agentic retrieval by 38%."
+    identified_project_and_metrics = (
+        "A RAG system for shipyard operations; MRR by 15%; "
+        "agentic retrieval by 38%."
+    )
+
+    assert score_answer(record, generic_rag_and_metrics)["term"] < 1.0
+    assert score_answer(record, identified_project_and_metrics)["term"] == 1.0
 
 
 def test_every_grouped_record_derives_terms_from_named_canonical_groups(

--- a/ml/profile-qa/tests/test_synthetic_data.py
+++ b/ml/profile-qa/tests/test_synthetic_data.py
@@ -1,12 +1,16 @@
 from __future__ import annotations
 
-from pathlib import Path
+import json
 import sys
+from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
-from profile_qa.public_profile import fact_index
-from profile_qa.public_profile import PROFILE_SECTIONS
+from profile_qa.public_profile import (
+    CANONICAL_PROFILE_PATH,
+    PROFILE_SECTIONS,
+    fact_index,
+)
 from profile_qa.synthetic_data import build_records
 from profile_qa.validation import PRIVATE_DATA_MARKERS, validate_dataset
 
@@ -46,6 +50,28 @@ def test_profile_sections_use_reusable_resume_ontology() -> None:
     ]
     assert "openai" not in section_ids
     assert "defense_unicorns" not in section_ids
+
+
+def test_python_profile_loads_canonical_profile_source() -> None:
+    canonical_sections = json.loads(CANONICAL_PROFILE_PATH.read_text(encoding="utf-8"))
+
+    assert PROFILE_SECTIONS == canonical_sections
+
+
+def test_canonical_profile_preserves_browser_and_scoring_metadata() -> None:
+    for section in PROFILE_SECTIONS:
+        assert isinstance(section.get("priority"), int)
+        assert isinstance(section.get("keywords"), list)
+        assert section["keywords"]
+
+        facts = section.get("facts")
+        assert isinstance(facts, list)
+        for fact in facts:
+            assert isinstance(fact, dict)
+            assert isinstance(fact.get("keywords"), list)
+            assert fact["keywords"]
+            assert isinstance(fact.get("terms"), list)
+            assert fact["terms"]
 
 
 def test_split_isolation_for_questions() -> None:

--- a/ml/profile-qa/tests/test_synthetic_data.py
+++ b/ml/profile-qa/tests/test_synthetic_data.py
@@ -8,12 +8,15 @@ import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
+from profile_qa.evaluate import score_answer
 from profile_qa.public_profile import (
     CANONICAL_PROFILE_PATH,
     PROFILE_SECTIONS,
+    PROFILE_SUBJECT,
     fact_index,
 )
 from profile_qa.synthetic_data import build_records
+from profile_qa.train_lora import format_instruction
 from profile_qa.validation import PRIVATE_DATA_MARKERS, validate_dataset
 
 
@@ -56,8 +59,12 @@ def test_profile_sections_use_reusable_resume_ontology() -> None:
 
 def test_python_profile_loads_canonical_profile_source() -> None:
     canonical_sections = json.loads(CANONICAL_PROFILE_PATH.read_text(encoding="utf-8"))
+    identity_section = next(
+        section for section in canonical_sections if section["id"] == "identity"
+    )
 
     assert PROFILE_SECTIONS == canonical_sections
+    assert PROFILE_SUBJECT == identity_section["subject"]
 
 
 def test_canonical_profile_preserves_browser_and_scoring_metadata() -> None:
@@ -74,6 +81,15 @@ def test_canonical_profile_preserves_browser_and_scoring_metadata() -> None:
             assert fact["keywords"]
             assert isinstance(fact.get("terms"), list)
             assert fact["terms"]
+            term_groups = fact.get("termGroups", {})
+            assert isinstance(term_groups, dict)
+            assert all(
+                isinstance(name, str)
+                and isinstance(terms, list)
+                and terms
+                and all(isinstance(term, str) for term in terms)
+                for name, terms in term_groups.items()
+            )
 
 
 @pytest.mark.parametrize(
@@ -120,6 +136,90 @@ def test_grouped_records_derive_answers_and_terms_from_canonical_facts(
     assert record["expected_terms"] == expected_terms
     assert changed_text in record["answer"]
     assert changed_terms[0] in record["expected_terms"]
+
+
+def test_custom_subject_renders_questions_histories_and_instruction(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    custom_subject = {
+        "name": "Ada Lovelace",
+        "shortName": "Ada",
+        "subjectPronoun": "she",
+        "objectPronoun": "her",
+        "possessivePronoun": "her",
+    }
+    for key, value in custom_subject.items():
+        monkeypatch.setitem(PROFILE_SUBJECT, key, value)
+
+    records = build_records(seed=7)
+    identity_record = next(
+        record for record in records if record["id"] == "identity-location-train-0"
+    )
+    operator_record = next(
+        record
+        for record in records
+        if record["id"] == "followup-operator-purpose-train-0"
+    )
+    refusal_record = next(
+        record for record in records if record["id"] == "refusal-0-train-0"
+    )
+
+    assert identity_record["question"] == "Where is Ada Lovelace based?"
+    assert operator_record["history"] == [
+        {"role": "user", "content": "What did Ada build in her current role?"},
+        {
+            "role": "assistant",
+            "content": (
+                "She built Codex packages, OpenInference observability, and a "
+                "Kubernetes operator."
+            ),
+        },
+    ]
+    assert refusal_record["question"] == "What is Ada's salary?"
+    assert "Ada Lovelace's browser-only profile Q&A assistant" in format_instruction(
+        identity_record
+    )
+    rendered_templates = " ".join(
+        [str(record["question"]) for record in records]
+        + [
+            str(turn["content"])
+            for record in records
+            for turn in record.get("history", [])
+        ]
+    )
+    assert "[[subject_" not in rendered_templates
+    assert "[[object_" not in rendered_templates
+    assert "[[possessive_" not in rendered_templates
+
+
+def test_followup_operator_uses_purpose_specific_scoring_terms(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    record = next(
+        item
+        for item in build_records(seed=7)
+        if item["id"] == "followup-operator-purpose-test-0"
+    )
+
+    assert record["expected_terms"] == [
+        "diagnoses",
+        "remediates",
+        "failing workloads",
+    ]
+    irrelevant_tool_list = "Codex packages, OpenInference, and a Kubernetes operator."
+    assert score_answer(record, irrelevant_tool_list)["term"] == 0.0
+    assert score_answer(record, str(record["answer"]))["term"] == 1.0
+
+    fact = fact_index()[("projects", "projects_current_role")]
+    term_groups = fact["termGroups"]
+    assert isinstance(term_groups, dict)
+    monkeypatch.setitem(term_groups, "operatorPurpose", ["updated operator behavior"])
+    updated_record = next(
+        item
+        for item in build_records(seed=7)
+        if item["id"] == "followup-operator-purpose-test-0"
+    )
+    assert updated_record["expected_terms"] == ["updated operator behavior"]
 
 
 def test_split_isolation_for_questions() -> None:

--- a/ml/profile-qa/tests/test_synthetic_data.py
+++ b/ml/profile-qa/tests/test_synthetic_data.py
@@ -4,6 +4,8 @@ import json
 import sys
 from pathlib import Path
 
+import pytest
+
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from profile_qa.public_profile import (
@@ -72,6 +74,52 @@ def test_canonical_profile_preserves_browser_and_scoring_metadata() -> None:
             assert fact["keywords"]
             assert isinstance(fact.get("terms"), list)
             assert fact["terms"]
+
+
+@pytest.mark.parametrize(
+    ("fact_key", "record_id"),
+    [
+        (
+            ("current_role", "current_role_scale"),
+            "targeted-current-impact-projects-train-0",
+        ),
+        (("projects", "projects_rag_system"), "rag-and-metrics-train-0"),
+        (
+            ("education", "education_graduate"),
+            "followup-graduate-schools-train-0",
+        ),
+    ],
+)
+def test_grouped_records_derive_answers_and_terms_from_canonical_facts(
+    monkeypatch: pytest.MonkeyPatch,
+    fact_key: tuple[str, str],
+    record_id: str,
+) -> None:
+    changed_text = f"Updated canonical fact for {record_id}."
+    changed_terms = [f"updated term for {record_id}"]
+    changed_fact = fact_index()[fact_key]
+    monkeypatch.setitem(changed_fact, "text", changed_text)
+    monkeypatch.setitem(changed_fact, "terms", changed_terms)
+
+    record = next(item for item in build_records(seed=7) if item["id"] == record_id)
+    facts = fact_index()
+    evidence_facts = [
+        facts[(item["section_id"], item["fact_id"])] for item in record["evidence"]
+    ]
+    expected_answer = " ".join(str(fact["text"]) for fact in evidence_facts)
+    expected_terms = list(
+        dict.fromkeys(
+            str(term)
+            for fact in evidence_facts
+            for term in fact.get("terms", [])
+            if isinstance(term, str)
+        )
+    )
+
+    assert record["answer"] == expected_answer
+    assert record["expected_terms"] == expected_terms
+    assert changed_text in record["answer"]
+    assert changed_terms[0] in record["expected_terms"]
 
 
 def test_split_isolation_for_questions() -> None:

--- a/ml/profile-qa/tests/test_synthetic_data.py
+++ b/ml/profile-qa/tests/test_synthetic_data.py
@@ -111,16 +111,14 @@ def test_canonical_profile_preserves_browser_and_scoring_metadata() -> None:
         ),
     ],
 )
-def test_grouped_records_derive_answers_and_terms_from_canonical_facts(
+def test_grouped_records_derive_answers_from_canonical_facts(
     monkeypatch: pytest.MonkeyPatch,
     fact_key: tuple[str, str],
     record_id: str,
 ) -> None:
     changed_text = f"Updated canonical fact for {record_id}."
-    changed_terms = [f"updated term for {record_id}"]
     changed_fact = fact_index()[fact_key]
     monkeypatch.setitem(changed_fact, "text", changed_text)
-    monkeypatch.setitem(changed_fact, "terms", changed_terms)
 
     record = next(item for item in build_records(seed=7) if item["id"] == record_id)
     facts = fact_index()
@@ -128,19 +126,8 @@ def test_grouped_records_derive_answers_and_terms_from_canonical_facts(
         facts[(item["section_id"], item["fact_id"])] for item in record["evidence"]
     ]
     expected_answer = " ".join(str(fact["text"]) for fact in evidence_facts)
-    expected_terms = list(
-        dict.fromkeys(
-            str(term)
-            for fact in evidence_facts
-            for term in fact.get("terms", [])
-            if isinstance(term, str)
-        )
-    )
-
     assert record["answer"] == expected_answer
-    assert record["expected_terms"] == expected_terms
     assert changed_text in record["answer"]
-    assert changed_terms[0] in record["expected_terms"]
 
 
 def test_custom_subject_renders_questions_histories_and_instruction(
@@ -197,7 +184,7 @@ def test_custom_subject_renders_questions_histories_and_instruction(
     assert "[[possessive_" not in rendered_templates
 
 
-def test_followup_operator_uses_purpose_specific_scoring_terms(
+def test_followup_operator_scores_only_the_workload_problem(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     record = next(
@@ -206,11 +193,7 @@ def test_followup_operator_uses_purpose_specific_scoring_terms(
         if item["id"] == "followup-operator-purpose-test-0"
     )
 
-    assert record["expected_terms"] == [
-        "diagnoses",
-        "remediates",
-        "failing workloads",
-    ]
+    assert record["expected_terms"] == ["failing workloads"]
     irrelevant_tool_list = "Codex packages, OpenInference, and a Kubernetes operator."
     assert score_answer(record, irrelevant_tool_list)["term"] == 0.0
     assert score_answer(record, str(record["answer"]))["term"] == 1.0
@@ -218,13 +201,13 @@ def test_followup_operator_uses_purpose_specific_scoring_terms(
     fact = fact_index()[("projects", "projects_current_role")]
     term_groups = fact["termGroups"]
     assert isinstance(term_groups, dict)
-    monkeypatch.setitem(term_groups, "operatorPurpose", ["updated operator behavior"])
+    monkeypatch.setitem(term_groups, "operatorProblem", ["updated workload problem"])
     updated_record = next(
         item
         for item in build_records(seed=7)
         if item["id"] == "followup-operator-purpose-test-0"
     )
-    assert updated_record["expected_terms"] == ["updated operator behavior"]
+    assert updated_record["expected_terms"] == ["updated workload problem"]
 
 
 def test_followup_graduate_schools_scores_only_institutions(
@@ -259,7 +242,144 @@ def test_followup_graduate_schools_scores_only_institutions(
     ]
 
 
-def test_every_grouped_qa_declares_an_explicit_scoring_contract() -> None:
+@pytest.mark.parametrize(
+    ("record_id", "expected_terms"),
+    [
+        (
+            "targeted-current-impact-projects-train-0",
+            [
+                "33,000 users",
+                "Codex packages",
+                "OpenInference",
+                "Kubernetes operator",
+            ],
+        ),
+        (
+            "targeted-rag-metrics-train-0",
+            ["RAG", "MRR by 15%", "agentic retrieval by 38%"],
+        ),
+        (
+            "targeted-before-current-train-0",
+            ["Defense Unicorns", "Air Force", "Space Force"],
+        ),
+        (
+            "targeted-education-complete-train-0",
+            [
+                "B.S. in Mechanical Engineering",
+                "Johns Hopkins",
+                "Georgia Tech",
+            ],
+        ),
+        (
+            "current-impact-and-projects-train-0",
+            [
+                "11 organizations",
+                "33,000 users",
+                "Codex packages",
+                "Kubernetes operator",
+            ],
+        ),
+        (
+            "previous-role-and-products-train-0",
+            [
+                "Senior Software Engineer",
+                "Defense Unicorns",
+                "LeapfrogAI",
+                "UDS AI",
+            ],
+        ),
+        (
+            "rag-and-metrics-train-0",
+            ["RAG", "MRR by 15%", "agentic retrieval by 38%"],
+        ),
+        (
+            "education-complete-train-0",
+            [
+                "B.S. in Mechanical Engineering",
+                "Johns Hopkins",
+                "Georgia Tech",
+            ],
+        ),
+        (
+            "experience-before-current-train-0",
+            ["Defense Unicorns", "Air Force", "Space Force"],
+        ),
+        (
+            "skills-and-recommendations-train-0",
+            ["systems design", "AI/ML", "collaborative", "calm under pressure"],
+        ),
+        (
+            "followup-defense-metrics-train-0",
+            ["MRR by 15%", "agentic retrieval by 38%"],
+        ),
+        ("followup-operator-purpose-train-0", ["failing workloads"]),
+        (
+            "followup-graduate-schools-train-0",
+            ["Johns Hopkins", "Georgia Tech"],
+        ),
+        (
+            "followup-recommendation-traits-train-0",
+            ["collaborative", "calm under pressure"],
+        ),
+    ],
+)
+def test_grouped_records_use_minimum_complete_scoring_terms(
+    record_id: str,
+    expected_terms: list[str],
+) -> None:
+    record = next(item for item in build_records(seed=7) if item["id"] == record_id)
+
+    assert record["expected_terms"] == expected_terms
+    assert score_answer(record, " ".join(expected_terms))["term"] == 1.0
+
+
+def test_every_grouped_record_derives_terms_from_named_canonical_groups(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    specs = TARGETED_COMPLETENESS_QA + MULTI_HOP_QA + FOLLOW_UP_QA
+    facts = fact_index()
+    mutated_groups: set[tuple[str, str, str]] = set()
+
+    for spec in specs:
+        term_groups = spec["term_groups"]
+        assert isinstance(term_groups, dict)
+        for evidence_key, group_name in term_groups.items():
+            section_id, fact_id = str(evidence_key).split("/", maxsplit=1)
+            group_key = (section_id, fact_id, str(group_name))
+            if group_key in mutated_groups:
+                continue
+            mutated_groups.add(group_key)
+            fact_term_groups = facts[(section_id, fact_id)]["termGroups"]
+            assert isinstance(fact_term_groups, dict)
+            monkeypatch.setitem(
+                fact_term_groups,
+                str(group_name),
+                [f"mutated scoring term {len(mutated_groups)}"],
+            )
+
+    records_by_id = {str(record["id"]): record for record in build_records(seed=7)}
+    for spec in specs:
+        expected_terms: list[str] = []
+        term_groups = spec["term_groups"]
+        evidence = spec["evidence"]
+        assert isinstance(term_groups, dict)
+        assert isinstance(evidence, list)
+        for item in evidence:
+            assert isinstance(item, dict)
+            section_id = str(item["section_id"])
+            fact_id = str(item["fact_id"])
+            evidence_key = f"{section_id}/{fact_id}"
+            fact_term_groups = facts[(section_id, fact_id)]["termGroups"]
+            assert isinstance(fact_term_groups, dict)
+            selected_terms = fact_term_groups[str(term_groups[evidence_key])]
+            assert isinstance(selected_terms, list)
+            expected_terms.extend(str(term) for term in selected_terms)
+
+        record = records_by_id[f"{spec['id']}-train-0"]
+        assert record["expected_terms"] == expected_terms
+
+
+def test_every_grouped_qa_requires_named_groups_for_all_evidence() -> None:
     specs = TARGETED_COMPLETENESS_QA + MULTI_HOP_QA + FOLLOW_UP_QA
 
     for spec in specs:
@@ -270,15 +390,38 @@ def test_every_grouped_qa_declares_an_explicit_scoring_contract() -> None:
             for item in evidence
             if isinstance(item, dict)
         }
-        scoring = spec.get("scoring")
-        assert scoring in {"all_evidence_terms", "term_groups"}, spec["id"]
-        if scoring == "all_evidence_terms":
-            assert "term_groups" not in spec, spec["id"]
-            continue
-
+        assert spec.get("scoring") == "term_groups", spec["id"]
         term_groups = spec.get("term_groups")
         assert isinstance(term_groups, dict), spec["id"]
         assert set(term_groups) == evidence_keys, spec["id"]
+
+
+def test_grouped_qa_rejects_broad_all_evidence_scoring(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    spec = TARGETED_COMPLETENESS_QA[0]
+    monkeypatch.setitem(spec, "scoring", "all_evidence_terms")
+
+    with pytest.raises(
+        ValueError,
+        match="targeted-current-impact-projects requires scoring=term_groups",
+    ):
+        build_records(seed=7)
+
+
+def test_grouped_qa_rejects_an_incomplete_term_group_contract(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    spec = MULTI_HOP_QA[0]
+    term_groups = spec["term_groups"]
+    assert isinstance(term_groups, dict)
+    monkeypatch.delitem(term_groups, "projects/projects_current_role")
+
+    with pytest.raises(
+        ValueError,
+        match="current-impact-and-projects term_groups must select every evidence fact",
+    ):
+        build_records(seed=7)
 
 
 def test_split_isolation_for_questions() -> None:

--- a/src/components/chat/components/ChatMessages.tsx
+++ b/src/components/chat/components/ChatMessages.tsx
@@ -6,17 +6,17 @@
 import React, { Fragment, useState } from "react";
 import type { ChatMessage } from "@/types";
 import { Typewriter } from "./Typewriter";
-import { SITE_CONFIG } from "@/config";
+import { PROFILE_SUBJECT } from "@/config";
 import { LimitWarning } from "./LimitWarning";
 
 const QUIRK_MESSAGES = [
-  `Digging into ${SITE_CONFIG.name}'s history...`,
-  `Consulting my ${SITE_CONFIG.name} database...`,
-  `Channeling my inner ${SITE_CONFIG.name}...`,
-  `Reading ${SITE_CONFIG.name}'s mind...`,
-  `Checking ${SITE_CONFIG.name}'s secret diary...`,
-  `Analyzing ${SITE_CONFIG.name}'s preferences...`,
-  `Decoding ${SITE_CONFIG.name}'s commits...`,
+  `Digging into ${PROFILE_SUBJECT.shortName}'s history...`,
+  `Consulting my ${PROFILE_SUBJECT.shortName} database...`,
+  `Channeling my inner ${PROFILE_SUBJECT.shortName}...`,
+  `Reading ${PROFILE_SUBJECT.shortName}'s mind...`,
+  `Checking ${PROFILE_SUBJECT.shortName}'s secret diary...`,
+  `Analyzing ${PROFILE_SUBJECT.shortName}'s preferences...`,
+  `Decoding ${PROFILE_SUBJECT.shortName}'s commits...`,
   "Making up an answer for you...",
   "Searching the dark web...",
   "Wondering the same thing you are...",

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -9,9 +9,11 @@ export {
   SITE_CONFIG,
   DERIVED_CONFIG,
   PROFILE_SECTIONS,
+  PROFILE_SUBJECT,
   PERSONAL_CONTEXT,
   type ProfileFact,
   type ProfileSection,
+  type ProfileSubject,
 } from "./site";
 export {
   MODEL_ID,
@@ -23,4 +25,5 @@ export {
 export {
   GENERATION_PARAMS,
   CHATBOT_CONFIG,
+  createChatbotConfig,
 } from "./prompts";

--- a/src/config/prompts.ts
+++ b/src/config/prompts.ts
@@ -3,7 +3,7 @@
  */
 
 import type { GenerationParams } from "@/types";
-import { SITE_CONFIG } from "./site";
+import { PROFILE_SUBJECT, type ProfileSubject } from "./site";
 
 /**
  * Generation parameters for the browser model.
@@ -23,15 +23,23 @@ export const MAX_SINGLE_MESSAGE_LENGTH = 1200;
 /**
  * AI chatbot configuration.
  */
-export const CHATBOT_CONFIG = {
-  welcomeMessages: [
-    `Hello, I am ${SITE_CONFIG.name}'s AI assistant! Got any questions for me?`,
-    `Hey there! Got any questions about ${SITE_CONFIG.name} for me?`,
-    `Hi! Interested in learning more about ${SITE_CONFIG.name}?`,
-    `What would you like to know about ${SITE_CONFIG.name}?`,
-    `I heard you had questions about ${SITE_CONFIG.name}? Just ask away!`,
-    `Thanks for visiting! Do you want to learn more about ${SITE_CONFIG.name}?`,
-  ],
+function possessive(value: string): string {
+  return value.endsWith("s") ? `${value}'` : `${value}'s`;
+}
 
-  systemPrompt: `You are ${SITE_CONFIG.fullName}'s AI assistant. Use only the provided context. Reply in 1-2 short sentences. If the answer is absent, say the context does not say.`,
-} as const;
+export function createChatbotConfig(subject: ProfileSubject) {
+  return {
+    welcomeMessages: [
+      `Hello, I am ${possessive(subject.shortName)} AI assistant! Got any questions for me?`,
+      `Hey there! Got any questions about ${subject.shortName} for me?`,
+      `Hi! Interested in learning more about ${subject.shortName}?`,
+      `What would you like to know about ${subject.shortName}?`,
+      `I heard you had questions about ${subject.shortName}? Just ask away!`,
+      `Thanks for visiting! Do you want to learn more about ${subject.shortName}?`,
+    ],
+
+    systemPrompt: `You are ${possessive(subject.name)} AI assistant. Use only the provided context. Reply in 1-2 short sentences. If the answer is absent, say the context does not say.`,
+  } as const;
+}
+
+export const CHATBOT_CONFIG = createChatbotConfig(PROFILE_SUBJECT);

--- a/src/config/public-profile.json
+++ b/src/config/public-profile.json
@@ -143,7 +143,7 @@
         "keywords": ["fips", "agentic rag", "shipyard"],
         "terms": ["FIPS-compliant", "agentic RAG", "shipyard operations"],
         "termGroups": {
-          "ragIdentity": ["RAG"]
+          "ragIdentity": ["RAG", "shipyard operations"]
         }
       },
       {

--- a/src/config/public-profile.json
+++ b/src/config/public-profile.json
@@ -51,7 +51,11 @@
         "id": "current_role_scale",
         "text": "He has led engagements across 11 organizations and about 33,000 users.",
         "keywords": ["11 organizations", "33000 users", "33,000 users"],
-        "terms": ["11 organizations", "33,000 users"]
+        "terms": ["11 organizations", "33,000 users"],
+        "termGroups": {
+          "userScale": ["33,000 users"],
+          "engagementScale": ["11 organizations", "33,000 users"]
+        }
       }
     ]
   },
@@ -73,13 +77,20 @@
         "id": "experience_previous_role",
         "text": "Previously, Justin was a Senior Software Engineer at Defense Unicorns, working across 40+ Kubernetes, AI/ML, and full-stack repos.",
         "keywords": ["senior software engineer", "defense unicorns", "40+"],
-        "terms": ["Senior Software Engineer", "Defense Unicorns", "40+"]
+        "terms": ["Senior Software Engineer", "Defense Unicorns", "40+"],
+        "termGroups": {
+          "priorEmployer": ["Defense Unicorns"],
+          "priorRole": ["Senior Software Engineer", "Defense Unicorns"]
+        }
       },
       {
         "id": "experience_veteran",
         "text": "Justin is a U.S. Air Force and Space Force veteran and one of the Space Force's first certified Supra Coders.",
         "keywords": ["air force", "space force", "veteran", "supra coders"],
-        "terms": ["Air Force", "Space Force", "Supra Coders"]
+        "terms": ["Air Force", "Space Force", "Supra Coders"],
+        "termGroups": {
+          "serviceBranches": ["Air Force", "Space Force"]
+        }
       }
     ]
   },
@@ -105,26 +116,47 @@
         "keywords": ["codex packages", "openinference", "kubernetes operator"],
         "terms": ["Codex packages", "OpenInference", "Kubernetes operator"],
         "termGroups": {
-          "operatorPurpose": ["diagnoses", "remediates", "failing workloads"]
+          "currentTooling": [
+            "Codex packages",
+            "OpenInference",
+            "Kubernetes operator"
+          ],
+          "codexAndOperatorBuilds": [
+            "Codex packages",
+            "Kubernetes operator"
+          ],
+          "operatorProblem": ["failing workloads"]
         }
       },
       {
         "id": "projects_products",
         "text": "He developed LeapfrogAI and UDS AI.",
         "keywords": ["leapfrogai", "uds ai"],
-        "terms": ["LeapfrogAI", "UDS AI"]
+        "terms": ["LeapfrogAI", "UDS AI"],
+        "termGroups": {
+          "productNames": ["LeapfrogAI", "UDS AI"]
+        }
       },
       {
         "id": "projects_rag_system",
         "text": "He led a FIPS-compliant agentic RAG system for shipyard operations.",
         "keywords": ["fips", "agentic rag", "shipyard"],
-        "terms": ["FIPS-compliant", "agentic RAG", "shipyard operations"]
+        "terms": ["FIPS-compliant", "agentic RAG", "shipyard operations"],
+        "termGroups": {
+          "ragIdentity": ["RAG"]
+        }
       },
       {
         "id": "projects_metrics",
         "text": "His work improved model MRR by 15% and agentic retrieval by 38%.",
         "keywords": ["mrr", "15%", "retrieval", "38%"],
-        "terms": ["MRR by 15%", "agentic retrieval by 38%"]
+        "terms": ["MRR by 15%", "agentic retrieval by 38%"],
+        "termGroups": {
+          "measuredImprovements": [
+            "MRR by 15%",
+            "agentic retrieval by 38%"
+          ]
+        }
       },
       {
         "id": "projects_service",
@@ -152,7 +184,10 @@
         "id": "education_rit",
         "text": "Justin earned a B.S. in Mechanical Engineering from RIT.",
         "keywords": ["mechanical engineering", "rit", "degree"],
-        "terms": ["B.S. in Mechanical Engineering", "RIT"]
+        "terms": ["B.S. in Mechanical Engineering", "RIT"],
+        "termGroups": {
+          "undergraduateDegree": ["B.S. in Mechanical Engineering"]
+        }
       },
       {
         "id": "education_graduate",
@@ -187,7 +222,10 @@
           "collaborative",
           "calm under pressure",
           "strong problem solver"
-        ]
+        ],
+        "termGroups": {
+          "collaborationTraits": ["collaborative", "calm under pressure"]
+        }
       }
     ]
   },
@@ -213,7 +251,10 @@
         "id": "skills_strengths",
         "text": "Strengths include leadership, public speaking, technical writing, pair programming, systems design, AI/ML, Kubernetes, secure deployment, RAG, observability, MLFlow, inference engines, and mission-critical delivery.",
         "keywords": ["systems design", "ai/ml", "kubernetes", "rag", "mlflow"],
-        "terms": ["leadership", "systems design", "AI/ML", "Kubernetes"]
+        "terms": ["leadership", "systems design", "AI/ML", "Kubernetes"],
+        "termGroups": {
+          "technicalCore": ["systems design", "AI/ML"]
+        }
       }
     ]
   },

--- a/src/config/public-profile.json
+++ b/src/config/public-profile.json
@@ -1,0 +1,221 @@
+[
+  {
+    "id": "identity",
+    "title": "Identity",
+    "priority": 100,
+    "alwaysInclude": true,
+    "keywords": ["name", "identity", "location", "based", "who"],
+    "facts": [
+      {
+        "id": "identity_location",
+        "text": "Justin Law is based in New York, USA.",
+        "keywords": ["justin", "law", "new york", "usa", "based"],
+        "terms": ["New York", "USA"]
+      }
+    ]
+  },
+  {
+    "id": "current_role",
+    "title": "Current Role",
+    "priority": 90,
+    "keywords": [
+      "current role",
+      "current job",
+      "current work",
+      "employer",
+      "role",
+      "scope",
+      "impact"
+    ],
+    "facts": [
+      {
+        "id": "current_role_title",
+        "text": "At OpenAI, Justin is an AI Deployment Engineer.",
+        "keywords": ["openai", "ai deployment engineer"],
+        "terms": ["AI Deployment Engineer", "OpenAI"]
+      },
+      {
+        "id": "current_role_scope",
+        "text": "Justin focuses on enterprise Codex adoption across CLI, SDK, MCP, app-server, observability, Kubernetes, and full-stack workflows.",
+        "keywords": ["enterprise codex adoption", "cli", "sdk", "mcp"],
+        "terms": ["enterprise Codex adoption", "CLI", "SDK", "MCP"]
+      },
+      {
+        "id": "current_role_scale",
+        "text": "He has led engagements across 11 organizations and about 33,000 users.",
+        "keywords": ["11 organizations", "33000 users", "33,000 users"],
+        "terms": ["11 organizations", "33,000 users"]
+      }
+    ]
+  },
+  {
+    "id": "experience",
+    "title": "Experience",
+    "priority": 80,
+    "keywords": [
+      "experience",
+      "previous role",
+      "work history",
+      "chronology",
+      "before",
+      "veteran",
+      "career"
+    ],
+    "facts": [
+      {
+        "id": "experience_previous_role",
+        "text": "Previously, Justin was a Senior Software Engineer at Defense Unicorns, working across 40+ Kubernetes, AI/ML, and full-stack repos.",
+        "keywords": ["senior software engineer", "defense unicorns", "40+"],
+        "terms": ["Senior Software Engineer", "Defense Unicorns", "40+"]
+      },
+      {
+        "id": "experience_veteran",
+        "text": "Justin is a U.S. Air Force and Space Force veteran and one of the Space Force's first certified Supra Coders.",
+        "keywords": ["air force", "space force", "veteran", "supra coders"],
+        "terms": ["Air Force", "Space Force", "Supra Coders"]
+      }
+    ]
+  },
+  {
+    "id": "projects",
+    "title": "Projects",
+    "priority": 75,
+    "keywords": [
+      "project",
+      "projects",
+      "built",
+      "developed",
+      "operator",
+      "product",
+      "tool",
+      "rag",
+      "metrics"
+    ],
+    "facts": [
+      {
+        "id": "projects_current_role",
+        "text": "He built Codex packages, OpenInference observability, and a Kubernetes operator that diagnoses and remediates failing workloads.",
+        "keywords": ["codex packages", "openinference", "kubernetes operator"],
+        "terms": ["Codex packages", "OpenInference", "Kubernetes operator"]
+      },
+      {
+        "id": "projects_products",
+        "text": "He developed LeapfrogAI and UDS AI.",
+        "keywords": ["leapfrogai", "uds ai"],
+        "terms": ["LeapfrogAI", "UDS AI"]
+      },
+      {
+        "id": "projects_rag_system",
+        "text": "He led a FIPS-compliant agentic RAG system for shipyard operations.",
+        "keywords": ["fips", "agentic rag", "shipyard"],
+        "terms": ["FIPS-compliant", "agentic RAG", "shipyard operations"]
+      },
+      {
+        "id": "projects_metrics",
+        "text": "His work improved model MRR by 15% and agentic retrieval by 38%.",
+        "keywords": ["mrr", "15%", "retrieval", "38%"],
+        "terms": ["MRR by 15%", "agentic retrieval by 38%"]
+      },
+      {
+        "id": "projects_service",
+        "text": "He built RF deconfliction tools, orbital object OSINT apps, and acquisition strategies.",
+        "keywords": ["rf deconfliction", "orbital object osint", "acquisition"],
+        "terms": ["RF deconfliction", "orbital object OSINT", "acquisition"]
+      }
+    ]
+  },
+  {
+    "id": "education",
+    "title": "Education",
+    "priority": 70,
+    "keywords": [
+      "education",
+      "degree",
+      "mechanical engineering",
+      "rit",
+      "johns hopkins",
+      "georgia tech",
+      "graduate"
+    ],
+    "facts": [
+      {
+        "id": "education_rit",
+        "text": "Justin earned a B.S. in Mechanical Engineering from RIT.",
+        "keywords": ["mechanical engineering", "rit", "degree"],
+        "terms": ["B.S. in Mechanical Engineering", "RIT"]
+      },
+      {
+        "id": "education_graduate",
+        "text": "He completed graduate CS studies at Johns Hopkins and Georgia Tech.",
+        "keywords": ["graduate cs", "johns hopkins", "georgia tech"],
+        "terms": ["graduate CS", "Johns Hopkins", "Georgia Tech"]
+      }
+    ]
+  },
+  {
+    "id": "recommendations",
+    "title": "Recommendations",
+    "priority": 65,
+    "keywords": [
+      "recommendation",
+      "recommendations",
+      "personable",
+      "collaborative",
+      "pressure",
+      "problem solver"
+    ],
+    "facts": [
+      {
+        "id": "recommendations_summary",
+        "text": "Recommendations describe Justin as personable, collaborative, calm under pressure, technically deep, and a strong problem solver.",
+        "keywords": ["personable", "collaborative", "calm under pressure"],
+        "terms": [
+          "personable",
+          "collaborative",
+          "calm under pressure",
+          "strong problem solver"
+        ]
+      }
+    ]
+  },
+  {
+    "id": "skills",
+    "title": "Skills",
+    "priority": 60,
+    "keywords": [
+      "skills",
+      "leadership",
+      "public speaking",
+      "technical writing",
+      "systems design",
+      "ai",
+      "ml",
+      "kubernetes",
+      "rag",
+      "observability",
+      "mlflow"
+    ],
+    "facts": [
+      {
+        "id": "skills_strengths",
+        "text": "Strengths include leadership, public speaking, technical writing, pair programming, systems design, AI/ML, Kubernetes, secure deployment, RAG, observability, MLFlow, inference engines, and mission-critical delivery.",
+        "keywords": ["systems design", "ai/ml", "kubernetes", "rag", "mlflow"],
+        "terms": ["leadership", "systems design", "AI/ML", "Kubernetes"]
+      }
+    ]
+  },
+  {
+    "id": "interests",
+    "title": "Interests",
+    "priority": 40,
+    "keywords": ["interests", "hobbies", "outside work", "personal interests"],
+    "facts": [
+      {
+        "id": "interests_personal",
+        "text": "Justin enjoys videogames, hiking, running, and cooking.",
+        "keywords": ["videogames", "hiking", "running", "cooking", "hobbies"],
+        "terms": ["videogames", "hiking", "running", "cooking"]
+      }
+    ]
+  }
+]

--- a/src/config/public-profile.json
+++ b/src/config/public-profile.json
@@ -158,7 +158,10 @@
         "id": "education_graduate",
         "text": "He completed graduate CS studies at Johns Hopkins and Georgia Tech.",
         "keywords": ["graduate cs", "johns hopkins", "georgia tech"],
-        "terms": ["graduate CS", "Johns Hopkins", "Georgia Tech"]
+        "terms": ["graduate CS", "Johns Hopkins", "Georgia Tech"],
+        "termGroups": {
+          "graduateInstitutions": ["Johns Hopkins", "Georgia Tech"]
+        }
       }
     ]
   },

--- a/src/config/public-profile.json
+++ b/src/config/public-profile.json
@@ -2,6 +2,13 @@
   {
     "id": "identity",
     "title": "Identity",
+    "subject": {
+      "name": "Justin Law",
+      "shortName": "Justin",
+      "subjectPronoun": "he",
+      "objectPronoun": "him",
+      "possessivePronoun": "his"
+    },
     "priority": 100,
     "alwaysInclude": true,
     "keywords": ["name", "identity", "location", "based", "who"],
@@ -96,7 +103,10 @@
         "id": "projects_current_role",
         "text": "He built Codex packages, OpenInference observability, and a Kubernetes operator that diagnoses and remediates failing workloads.",
         "keywords": ["codex packages", "openinference", "kubernetes operator"],
-        "terms": ["Codex packages", "OpenInference", "Kubernetes operator"]
+        "terms": ["Codex packages", "OpenInference", "Kubernetes operator"],
+        "termGroups": {
+          "operatorPurpose": ["diagnoses", "remediates", "failing workloads"]
+        }
       },
       {
         "id": "projects_products",

--- a/src/config/site.ts
+++ b/src/config/site.ts
@@ -103,6 +103,15 @@ export interface ProfileFact {
   text: string;
   keywords: readonly string[];
   terms: readonly string[];
+  termGroups?: Readonly<Record<string, readonly string[]>>;
+}
+
+export interface ProfileSubject {
+  name: string;
+  shortName: string;
+  subjectPronoun: string;
+  objectPronoun: string;
+  possessivePronoun: string;
 }
 
 export interface ProfileSection {
@@ -112,6 +121,7 @@ export interface ProfileSection {
   keywords: readonly string[];
   priority: number;
   alwaysInclude?: boolean;
+  subject?: ProfileSubject;
 }
 
 /**

--- a/src/config/site.ts
+++ b/src/config/site.ts
@@ -103,7 +103,7 @@ export interface ProfileFact {
   text: string;
   keywords: readonly string[];
   terms: readonly string[];
-  termGroups?: Readonly<Record<string, readonly string[]>>;
+  termGroups?: Readonly<Partial<Record<string, readonly string[]>>>;
 }
 
 export interface ProfileSubject {

--- a/src/config/site.ts
+++ b/src/config/site.ts
@@ -130,6 +130,24 @@ export interface ProfileSection {
 export const PROFILE_SECTIONS: readonly ProfileSection[] =
   publicProfileSections;
 
+function getCanonicalProfileSubject(
+  sections: readonly ProfileSection[]
+): ProfileSubject {
+  const subject = sections.find((section) => section.id === "identity")?.subject;
+  if (!subject) {
+    throw new Error(
+      "src/config/public-profile.json requires identity.subject metadata"
+    );
+  }
+  return subject;
+}
+
+/**
+ * Canonical identity used by both browser prompts and Profile-QA training.
+ */
+export const PROFILE_SUBJECT: ProfileSubject =
+  getCanonicalProfileSubject(PROFILE_SECTIONS);
+
 /**
  * Personal knowledge for the chatbot.
  *

--- a/src/config/site.ts
+++ b/src/config/site.ts
@@ -2,10 +2,10 @@
  * Site Configuration
  * Centralized configuration for customizing the personal website
  *
- * This file contains all the customizable values for the website.
- * To customize this site for yourself, update the values in this file.
  * See docs/CUSTOMIZATION.md for detailed instructions.
  */
+
+import publicProfileSections from "./public-profile.json";
 
 /**
  * Personal Information
@@ -73,7 +73,9 @@ export const DERIVED_CONFIG = {
     if (process.env.NODE_ENV !== "production") {
       return "";
     }
-    return this.githubPagesBasePath.length > 0 ? `${this.githubPagesBasePath}/` : "";
+    return this.githubPagesBasePath.length > 0
+      ? `${this.githubPagesBasePath}/`
+      : "";
   },
   // Full GitHub Pages URL
   get siteUrl() {
@@ -94,12 +96,13 @@ export const DERIVED_CONFIG = {
 } as const;
 
 /**
- * Public profile context sections for chatbot retrieval.
+ * Public profile context sections for chatbot retrieval and ML evaluation.
  */
 export interface ProfileFact {
   id: string;
   text: string;
-  keywords?: readonly string[];
+  keywords: readonly string[];
+  terms: readonly string[];
 }
 
 export interface ProfileSection {
@@ -111,221 +114,11 @@ export interface ProfileSection {
   alwaysInclude?: boolean;
 }
 
-export const PROFILE_SECTIONS = [
-  {
-    id: "identity",
-    title: "Identity",
-    priority: 100,
-    alwaysInclude: true,
-    keywords: ["name", "identity", "location", "based", "who"],
-    facts: [
-      {
-        id: "identity_location",
-        text: "Justin Law is based in New York, USA.",
-        keywords: ["justin", "law", "new york", "usa", "based"],
-      },
-    ],
-  },
-  {
-    id: "current_role",
-    title: "Current Role",
-    priority: 90,
-    keywords: [
-      "current role",
-      "current job",
-      "current work",
-      "employer",
-      "role",
-      "scope",
-      "impact",
-    ],
-    facts: [
-      {
-        id: "current_role_title",
-        text: "At OpenAI, Justin is an AI Deployment Engineer.",
-        keywords: ["openai", "ai deployment engineer"],
-      },
-      {
-        id: "current_role_scope",
-        text:
-          "Justin focuses on enterprise Codex adoption across CLI, SDK, MCP, " +
-          "app-server, observability, Kubernetes, and full-stack workflows.",
-        keywords: ["enterprise codex adoption", "cli", "sdk", "mcp"],
-      },
-      {
-        id: "current_role_scale",
-        text: "He has led engagements across 11 organizations and about 33,000 users.",
-        keywords: ["11 organizations", "33000 users", "33,000 users"],
-      },
-    ],
-  },
-  {
-    id: "experience",
-    title: "Experience",
-    priority: 80,
-    keywords: [
-      "experience",
-      "previous role",
-      "work history",
-      "chronology",
-      "before",
-      "veteran",
-      "career",
-    ],
-    facts: [
-      {
-        id: "experience_previous_role",
-        text:
-          "Previously, Justin was a Senior Software Engineer at Defense Unicorns, " +
-          "working across 40+ Kubernetes, AI/ML, and full-stack repos.",
-        keywords: ["senior software engineer", "defense unicorns", "40+"],
-      },
-      {
-        id: "experience_veteran",
-        text:
-          "Justin is a U.S. Air Force and Space Force veteran and one of the " +
-          "Space Force's first certified Supra Coders.",
-        keywords: ["air force", "space force", "veteran", "supra coders"],
-      },
-    ],
-  },
-  {
-    id: "projects",
-    title: "Projects",
-    priority: 75,
-    keywords: [
-      "project",
-      "projects",
-      "built",
-      "developed",
-      "operator",
-      "product",
-      "tool",
-      "rag",
-      "metrics",
-    ],
-    facts: [
-      {
-        id: "projects_current_role",
-        text:
-          "He built Codex packages, OpenInference observability, and a Kubernetes " +
-          "operator that diagnoses and remediates failing workloads.",
-        keywords: ["codex packages", "openinference", "kubernetes operator"],
-      },
-      {
-        id: "projects_products",
-        text: "He developed LeapfrogAI and UDS AI.",
-        keywords: ["leapfrogai", "uds ai"],
-      },
-      {
-        id: "projects_rag_system",
-        text: "He led a FIPS-compliant agentic RAG system for shipyard operations.",
-        keywords: ["fips", "agentic rag", "shipyard"],
-      },
-      {
-        id: "projects_metrics",
-        text: "He improved model MRR 15% and agentic retrieval 38%.",
-        keywords: ["mrr", "15%", "retrieval", "38%"],
-      },
-      {
-        id: "projects_service",
-        text:
-          "He built RF deconfliction tools, orbital object OSINT apps, and " +
-          "acquisition strategies.",
-        keywords: ["rf deconfliction", "orbital object osint", "acquisition"],
-      },
-    ],
-  },
-  {
-    id: "education",
-    title: "Education",
-    priority: 70,
-    keywords: [
-      "education",
-      "degree",
-      "mechanical engineering",
-      "rit",
-      "johns hopkins",
-      "georgia tech",
-      "graduate",
-    ],
-    facts: [
-      {
-        id: "education_rit",
-        text: "Justin earned a B.S. in Mechanical Engineering from RIT.",
-        keywords: ["mechanical engineering", "rit", "degree"],
-      },
-      {
-        id: "education_graduate",
-        text: "He completed graduate CS studies at Johns Hopkins and Georgia Tech.",
-        keywords: ["graduate cs", "johns hopkins", "georgia tech"],
-      },
-    ],
-  },
-  {
-    id: "recommendations",
-    title: "Recommendations",
-    priority: 65,
-    keywords: [
-      "recommendation",
-      "recommendations",
-      "personable",
-      "collaborative",
-      "pressure",
-      "problem solver",
-    ],
-    facts: [
-      {
-        id: "recommendations_summary",
-        text:
-          "Recommendations describe him as personable, collaborative, calm under " +
-          "pressure, technically deep, and a strong problem solver.",
-        keywords: ["personable", "collaborative", "calm under pressure"],
-      },
-    ],
-  },
-  {
-    id: "skills",
-    title: "Skills",
-    priority: 60,
-    keywords: [
-      "skills",
-      "leadership",
-      "public speaking",
-      "technical writing",
-      "systems design",
-      "ai",
-      "ml",
-      "kubernetes",
-      "rag",
-      "observability",
-      "mlflow",
-    ],
-    facts: [
-      {
-        id: "skills_strengths",
-        text:
-          "Strengths include leadership, public speaking, technical writing, pair " +
-          "programming, systems design, AI/ML, Kubernetes, secure deployment, RAG, " +
-          "observability, MLFlow, inference engines, and mission-critical delivery.",
-        keywords: ["systems design", "ai/ml", "kubernetes", "rag", "mlflow"],
-      },
-    ],
-  },
-  {
-    id: "interests",
-    title: "Interests",
-    priority: 40,
-    keywords: ["interests", "hobbies", "outside work", "personal interests"],
-    facts: [
-      {
-        id: "interests_personal",
-        text: "Justin enjoys videogames, hiking, running, and cooking.",
-        keywords: ["videogames", "hiking", "running", "cooking", "hobbies"],
-      },
-    ],
-  },
-] as const satisfies readonly ProfileSection[];
+/**
+ * Browser profile data loaded from the shared canonical source.
+ */
+export const PROFILE_SECTIONS: readonly ProfileSection[] =
+  publicProfileSections;
 
 /**
  * Personal knowledge for the chatbot.

--- a/src/services/ai/contextProvider.ts
+++ b/src/services/ai/contextProvider.ts
@@ -8,8 +8,9 @@ import { CHATBOT_CONFIG, MAX_SINGLE_MESSAGE_LENGTH } from "@/config/prompts";
 import {
   PERSONAL_CONTEXT,
   PROFILE_SECTIONS,
-  SITE_CONFIG,
+  PROFILE_SUBJECT,
   type ProfileSection,
+  type ProfileSubject,
 } from "@/config/site";
 import type { ChatMessage, ConversationTurn } from "@/types";
 
@@ -166,6 +167,15 @@ function buildHistoryText(conversationTurns: readonly ConversationTurn[]): strin
   return `\n\nRecent conversation:\n${lines.join("\n")}`;
 }
 
+export function getProfileIdentityContext(
+  subject: ProfileSubject = PROFILE_SUBJECT
+): string {
+  if (subject.shortName === subject.name) {
+    return `This profile is about ${subject.name}.`;
+  }
+  return `${subject.shortName} refers to ${subject.name}.`;
+}
+
 function buildPrompt(
   personalContext: string,
   question: string,
@@ -174,7 +184,7 @@ function buildPrompt(
   return `${CHATBOT_CONFIG.systemPrompt}
 
 Context:
-${SITE_CONFIG.name} refers to ${SITE_CONFIG.fullName}.
+${getProfileIdentityContext()}
 ${personalContext}${buildHistoryText(conversationTurns)}
 
 Question:

--- a/src/services/github/githubService.ts
+++ b/src/services/github/githubService.ts
@@ -3,11 +3,11 @@
  * Handles GitHub API calls for user profile information
  */
 
-import { SITE_CONFIG } from "@/config/site";
+import { PROFILE_SUBJECT } from "@/config/site";
 import { createLogger, LOG_AREAS } from "@/utils";
 
 const GITHUB_API_BASE = "https://api.github.com";
-const PERSON_NAME = SITE_CONFIG.fullName || "this person";
+const PERSON_NAME = PROFILE_SUBJECT.name;
 const DEFAULT_BIO_FALLBACK = `Oops! It seems like GitHub's API might be down so the website can't grab ${PERSON_NAME}'s GitHub bio. Anyway, let's just assume that ${PERSON_NAME} is really cool!`;
 const logger = createLogger(LOG_AREAS.GITHUB_SERVICE);
 

--- a/tests/models.spec.ts
+++ b/tests/models.spec.ts
@@ -6,12 +6,21 @@ import {
   getDtypeFallbackOrder,
 } from "../src/config/models";
 import canonicalProfileSections from "../src/config/public-profile.json";
-import { PERSONAL_CONTEXT, PROFILE_SECTIONS } from "../src/config/site";
+import {
+  PERSONAL_CONTEXT,
+  PROFILE_SECTIONS,
+  PROFILE_SUBJECT,
+} from "../src/config/site";
+import {
+  CHATBOT_CONFIG,
+  createChatbotConfig,
+} from "../src/config/prompts";
 import {
   cleanInput,
   estimateTokenCount,
   generatePrompt,
   getPersonalContextBudget,
+  getProfileIdentityContext,
   getPromptBudget,
 } from "../src/services/ai/contextProvider";
 import type { ConversationTurn } from "../src/types";
@@ -186,6 +195,42 @@ test.describe("Model prompt policy", () => {
 
   test("loads browser profile facts from the canonical profile source", () => {
     expect(PROFILE_SECTIONS).toEqual(canonicalProfileSections);
+  });
+
+  test("derives browser prompt identity from the canonical profile subject", () => {
+    const identitySection = canonicalProfileSections.find(
+      (section) => section.id === "identity",
+    );
+    const customSubject = {
+      name: "Ada Lovelace",
+      shortName: "Ada",
+      subjectPronoun: "she",
+      objectPronoun: "her",
+      possessivePronoun: "her",
+    };
+    const customChatbotConfig = createChatbotConfig(customSubject);
+
+    expect(PROFILE_SUBJECT).toEqual(identitySection?.subject);
+    expect(CHATBOT_CONFIG.systemPrompt).toContain(PROFILE_SUBJECT.name);
+    expect(generatePrompt("Who is this profile about?")).toContain(
+      `${PROFILE_SUBJECT.shortName} refers to ${PROFILE_SUBJECT.name}.`,
+    );
+    expect(customChatbotConfig.systemPrompt).toContain(
+      "Ada Lovelace's AI assistant",
+    );
+    expect(customChatbotConfig.welcomeMessages).toContain(
+      "Hi! Interested in learning more about Ada?",
+    );
+    expect(getProfileIdentityContext(customSubject)).toBe(
+      "Ada refers to Ada Lovelace.",
+    );
+    expect(
+      getProfileIdentityContext({
+        ...customSubject,
+        name: "Prince",
+        shortName: "Prince",
+      }),
+    ).toBe("This profile is about Prince.");
   });
 
   test("keeps retrieved personal context compact for Teapot", () => {

--- a/tests/models.spec.ts
+++ b/tests/models.spec.ts
@@ -5,6 +5,7 @@ import {
   getDeviceSpecificDtype,
   getDtypeFallbackOrder,
 } from "../src/config/models";
+import canonicalProfileSections from "../src/config/public-profile.json";
 import { PERSONAL_CONTEXT, PROFILE_SECTIONS } from "../src/config/site";
 import {
   cleanInput,
@@ -162,6 +163,16 @@ test.describe("Model prompt policy", () => {
       PROFILE_SECTIONS.map((section) => [section.id, section.priority]),
     );
 
+    expect(Object.fromEntries(priorities)).toEqual({
+      identity: 100,
+      current_role: 90,
+      experience: 80,
+      projects: 75,
+      education: 70,
+      recommendations: 65,
+      skills: 60,
+      interests: 40,
+    });
     expect(priorities.get("experience")).toBeGreaterThan(
       priorities.get("education") ?? 0,
     );
@@ -171,6 +182,10 @@ test.describe("Model prompt policy", () => {
     expect(priorities.get("recommendations")).toBeGreaterThan(
       priorities.get("interests") ?? 0,
     );
+  });
+
+  test("loads browser profile facts from the canonical profile source", () => {
+    expect(PROFILE_SECTIONS).toEqual(canonicalProfileSections);
   });
 
   test("keeps retrieved personal context compact for Teapot", () => {
@@ -226,7 +241,7 @@ test.describe("Model prompt policy", () => {
 
     expect(prompt).toContain("Recent conversation:");
     expect(prompt).toContain("Defense Unicorns");
-    expect(prompt).toContain("MRR 15%");
+    expect(prompt).toContain("MRR by 15%");
     expect(budget.includedConversationTurns).toBe(2);
     expect(estimateTokenCount(prompt)).toBeLessThanOrEqual(1024);
   });


### PR DESCRIPTION
## What

- Move public resume/profile sections into one canonical JSON source.
- Load that source from both browser retrieval and Python dataset generation.
- Preserve browser priorities/keywords and Python evaluation terms.
- Resolve the two existing text drifts using the current Python wording.
- Add cross-consumer regression coverage and update contributor/customization docs.

## Why

The same public facts are hand-maintained in TypeScript and Python, and they have already diverged. Browser answers and future fine-tuning data can therefore describe the same resume fact differently.

## Validation

- TypeScript model/source tests: 15 passed.
- Python suite: 20 passed.
- Generated Python dataset is byte-identical to `main`.
- Full ESLint and targeted strict TypeScript check passed.
- Ruff format and `E/F/I`, Markdownlint, JSON parsing, and `git diff --check` passed.

The full Next build is left to CI because the sandbox's native config loader panics before application validation. Python tests used 3.12 because the pinned 3.14 runtime was unavailable.