### PR TITLE
Use trustworthy chatbot generation status copy

### DIFF
--- a/src/components/chat/components/ChatMessages.tsx
+++ b/src/components/chat/components/ChatMessages.tsx
@@ -11,7 +11,7 @@ import { LimitWarning } from "./LimitWarning";
 
 export const GENERATION_STATUS_MESSAGES = [
   `Reviewing ${SITE_CONFIG.name}'s public profile...`,
-  `Finding relevant details about ${SITE_CONFIG.name}...`,
+  `Finding relevant public details about ${SITE_CONFIG.name}...`,
   `Checking ${SITE_CONFIG.name}'s public resume context...`,
   `Reviewing ${SITE_CONFIG.name}'s public project history...`,
   "Preparing a profile-grounded answer...",

--- a/src/components/chat/components/ChatMessages.tsx
+++ b/src/components/chat/components/ChatMessages.tsx
@@ -9,18 +9,13 @@ import { Typewriter } from "./Typewriter";
 import { SITE_CONFIG } from "@/config";
 import { LimitWarning } from "./LimitWarning";
 
-const QUIRK_MESSAGES = [
-  `Digging into ${SITE_CONFIG.name}'s history...`,
-  `Consulting my ${SITE_CONFIG.name} database...`,
-  `Channeling my inner ${SITE_CONFIG.name}...`,
-  `Reading ${SITE_CONFIG.name}'s mind...`,
-  `Checking ${SITE_CONFIG.name}'s secret diary...`,
-  `Analyzing ${SITE_CONFIG.name}'s preferences...`,
-  `Decoding ${SITE_CONFIG.name}'s commits...`,
-  "Making up an answer for you...",
-  "Searching the dark web...",
-  "Wondering the same thing you are...",
-];
+export const GENERATION_STATUS_MESSAGES = [
+  `Reviewing ${SITE_CONFIG.name}'s public profile...`,
+  `Finding relevant details about ${SITE_CONFIG.name}...`,
+  `Checking ${SITE_CONFIG.name}'s public resume context...`,
+  `Reviewing ${SITE_CONFIG.name}'s public project history...`,
+  "Preparing a profile-grounded answer...",
+] as const;
 
 export interface ChatMessagesProps {
   messages: ChatMessage[];
@@ -45,8 +40,11 @@ export function ChatMessages({
   overBudgetPersonalContextCharacters,
   trimmedPersonalContextCharacters,
 }: ChatMessagesProps): React.ReactElement {
-  const [randomQuirkMessage] = useState(
-    () => QUIRK_MESSAGES[Math.floor(Math.random() * QUIRK_MESSAGES.length)]
+  const [generationStatusMessage] = useState(
+    () =>
+      GENERATION_STATUS_MESSAGES[
+        Math.floor(Math.random() * GENERATION_STATUS_MESSAGES.length)
+      ]
   );
   const showModelStatus =
     isLoading && !loadingMessage?.includes("Generating");
@@ -155,7 +153,7 @@ export function ChatMessages({
                   {!currentResponse ? (
                     <div className="flex items-center gap-2 text-gray-400 text-sm">
                       <div className="w-3 h-3 border-2 border-blue-200 border-t-blue-500 rounded-full animate-spin" />
-                      <span>{randomQuirkMessage}</span>
+                      <span>{generationStatusMessage}</span>
                     </div>
                   ) : (
                     <Fragment>

--- a/tests/chatbot.spec.ts
+++ b/tests/chatbot.spec.ts
@@ -3,11 +3,19 @@ import {
   getPersonalContextBudget,
   getPromptBudget,
 } from "../src/services/ai/contextProvider";
+import { GENERATION_STATUS_MESSAGES } from "../src/components/chat/components/ChatMessages";
 
 const HELD_LOADING_MESSAGE = "Downloading model... 83%";
 const HOLD_MODEL_LOADING_SESSION_KEY = "__holdModelLoading";
 const HOLD_GENERATION_SESSION_KEY = "__holdGeneration";
 const THROW_WORKER_SESSION_KEY = "__throwWorker";
+
+test("generation status messages describe only the public-profile workflow", () => {
+  expect(GENERATION_STATUS_MESSAGES).toHaveLength(5);
+  for (const message of GENERATION_STATUS_MESSAGES) {
+    expect(message).toMatch(/public|profile-grounded/);
+  }
+});
 
 interface MockWorkerInitOptions {
   heldLoadingMessage: string;


### PR DESCRIPTION
## What

- Replace status messages about reading minds, secret diaries, making up answers, and searching the dark web.
- Describe the actual local public-profile retrieval flow instead.
- Add a regression test constraining every status to public/profile-grounded behavior.

## Why

The assistant is positioned as a resume-grounded browser model, but its visible status copy claims undisclosed private sources and fabrication. Even as jokes, those messages undermine the privacy and grounding promises of the product.

## Validation

- Targeted ESLint passed.
- TypeScript no-emit check passed.
- `git diff --check` passed.
- GitHub Actions lint passed.
- GitHub Actions Playwright: 197 passed, 3 skipped across the configured browser projects.

The first CI run caught one message that did not explicitly say `public`; the copy and regression contract were aligned before the successful replacement run.