### PR TITLE
Derive model-card provenance from release inputs

### DIFF
--- a/docs/DIAGRAMS.md
+++ b/docs/DIAGRAMS.md
@@ -103,10 +103,17 @@ flowchart TD
   pyProfile --> data["synthetic_data.py"]
   data --> train["train_lora.py"]
   train --> eval["evaluate.py"]
+  eval --> reports["Reports with model lineage"]
   eval --> gate["Promotion gate"]
   gate --> merge["merge_adapter.py"]
+  merge --> lineage["Lineage plus adapter/merge digests"]
   merge --> export["export_onnx.py"]
-  export --> artifacts["prepare_hf_artifacts.py"]
+  lineage --> export
+  export --> browserArtifact["Browser files plus digest"]
+  browserArtifact --> artifacts["prepare_hf_artifacts.py"]
+  lineage --> artifacts
+  reports --> artifacts
+  releaseDate["Explicit release date"] --> artifacts
   artifacts --> publish["publish.py"]
   publish --> hfRepo["Hugging Face model repo"]
   hfRepo --> modelConfig["src/config/models.ts"]
@@ -123,8 +130,8 @@ does not train models and does not call a server.
 | Facts | `src/config/site.ts` and `ml/profile-qa/profile_qa/public_profile.py` | Keep public facts aligned before generating data |
 | Dataset | `python -m profile_qa.synthetic_data` | Generated data stays under ignored `ml/profile-qa/data/` |
 | Training | `ml/profile-qa/profile_qa/config.py` or CLI flags | Fixed `teapotai/teapotllm` base; local 8GB NVIDIA LoRA/QLoRA runs |
-| Evaluation | `python -m profile_qa.evaluate` | Seq2seq only; adapters must record `teapotai/teapotllm` as their base |
-| ONNX export | `python -m profile_qa.export_onnx` | Requires the merged Teapot lineage marker; rejects `.onnx.data`; publishes `int8` and `uint8` encoder/decoder artifacts |
+| Evaluation | `python -m profile_qa.evaluate` | Reports record the evaluated split and exact baseline revision or adapter/merged lineage digest |
+| ONNX export | `python -m profile_qa.export_onnx` | Verifies merged lineage/digest, preserves lineage through each artifact stage, rejects `.onnx.data`, and publishes `int8` and `uint8` encoder/decoder artifacts |
 | App promotion | `src/config/models.ts` | Update `MODEL_ID` and keep `MODEL_CONTEXT_LIMIT` honest |
 
 Promotion should satisfy the gate in `ml/profile-qa/README.md` before changing

--- a/docs/DIAGRAMS.md
+++ b/docs/DIAGRAMS.md
@@ -106,9 +106,11 @@ flowchart TD
   train --> eval["evaluate.py"]
   data --> datasetDigest["Canonical dataset digest"]
   eval --> promptDigest["Formatted prompt digest"]
-  eval --> reports["Reports with input and model lineage"]
+  eval --> scoringDigest["Scoring and generation contracts"]
+  eval --> reports["Reports with predictions and provenance"]
   datasetDigest --> reports
   promptDigest --> reports
+  scoringDigest --> reports
   eval --> gate["Promotion gate"]
   gate --> merge["merge_adapter.py"]
   baseRevision["Pinned base revision"] --> train
@@ -117,10 +119,13 @@ flowchart TD
   merge --> lineage["Portable label plus model digests"]
   merge --> export["export_onnx.py"]
   lineage --> export
-  export --> browserArtifact["Browser files plus digest"]
+  export --> fpArtifact["Full-precision files plus digest"]
+  fpArtifact --> quantized["Quantized files bound to FP digest"]
+  quantized --> browserArtifact["Browser files plus digest"]
   browserArtifact --> artifacts["prepare_hf_artifacts.py"]
   lineage --> artifacts
   reports --> artifacts
+  checkpointConfig["Digest-bound adapter config"] --> artifacts
   releaseDate["Explicit release date"] --> artifacts
   artifacts --> publish["publish.py"]
   publish --> hfRepo["Hugging Face model repo"]
@@ -138,8 +143,8 @@ does not train models and does not call a server.
 | Facts | `src/config/site.ts` and `ml/profile-qa/profile_qa/public_profile.py` | Keep public facts aligned before generating data |
 | Dataset | `python -m profile_qa.synthetic_data` | Generated data stays under ignored `ml/profile-qa/data/` |
 | Training | `ml/profile-qa/profile_qa/config.py` or CLI flags | Fixed `teapotai/teapotllm` base; local 8GB NVIDIA LoRA/QLoRA runs |
-| Evaluation | `python -m profile_qa.evaluate` | Reports bind the canonical published dataset, exact formatted prompts, split, pinned base revision, and model digest; saved predictions require matching provenance |
-| ONNX export | `python -m profile_qa.export_onnx` | Verifies the pinned revision and merged lineage/digest, preserves portable lineage without local paths, rejects `.onnx.data`, and publishes `int8` and `uint8` encoder/decoder artifacts |
+| Evaluation | `python -m profile_qa.evaluate` | Reports bind the canonical published dataset, exact formatted prompts, split, pinned base revision, model digest, generation contract, and scoring implementation; packaging recomputes scores from saved predictions |
+| ONNX export | `python -m profile_qa.export_onnx` | Verifies the pinned revision and merged lineage/digest, binds each quantized stage to its exact full-precision input, preserves portable lineage without local paths, rejects `.onnx.data`, and publishes `int8` and `uint8` encoder/decoder artifacts |
 | App promotion | `src/config/models.ts` | Update `MODEL_ID` and keep `MODEL_CONTEXT_LIMIT` honest |
 
 Promotion should satisfy the gate in `ml/profile-qa/README.md` before changing

--- a/docs/DIAGRAMS.md
+++ b/docs/DIAGRAMS.md
@@ -116,6 +116,9 @@ flowchart TD
   baseRevision["Pinned base revision"] --> train
   baseRevision --> eval
   baseRevision --> merge
+  train --> checkpointConfig["Adapter config with pinned revision"]
+  checkpointConfig --> eval
+  checkpointConfig --> merge
   merge --> lineage["Portable label plus model digests"]
   merge --> export["export_onnx.py"]
   lineage --> export
@@ -125,7 +128,7 @@ flowchart TD
   browserArtifact --> artifacts["prepare_hf_artifacts.py"]
   lineage --> artifacts
   reports --> artifacts
-  checkpointConfig["Digest-bound adapter config"] --> artifacts
+  checkpointConfig --> artifacts
   releaseDate["Explicit release date"] --> artifacts
   artifacts --> publish["publish.py"]
   publish --> hfRepo["Hugging Face model repo"]
@@ -142,8 +145,8 @@ does not train models and does not call a server.
 | --- | --- | --- |
 | Facts | `src/config/site.ts` and `ml/profile-qa/profile_qa/public_profile.py` | Keep public facts aligned before generating data |
 | Dataset | `python -m profile_qa.synthetic_data` | Generated data stays under ignored `ml/profile-qa/data/` |
-| Training | `ml/profile-qa/profile_qa/config.py` or CLI flags | Fixed `teapotai/teapotllm` base; local 8GB NVIDIA LoRA/QLoRA runs |
-| Evaluation | `python -m profile_qa.evaluate` | Reports bind the canonical published dataset, exact formatted prompts, split, pinned base revision, model digest, generation contract, and scoring implementation; packaging recomputes scores from saved predictions |
+| Training | `ml/profile-qa/profile_qa/config.py` or CLI flags | Fixed `teapotai/teapotllm` base; the pinned revision is persisted in and verified from each PEFT checkpoint |
+| Evaluation | `python -m profile_qa.evaluate` | Reports bind the canonical published dataset, exact formatted prompts, split, pinned base revision, model digest, generation contract, and scoring implementation; packaging recomputes scores and requires one promoted model representation |
 | ONNX export | `python -m profile_qa.export_onnx` | Verifies the pinned revision and merged lineage/digest, binds each quantized stage to its exact full-precision input, preserves portable lineage without local paths, rejects `.onnx.data`, and publishes `int8` and `uint8` encoder/decoder artifacts |
 | App promotion | `src/config/models.ts` | Update `MODEL_ID` and keep `MODEL_CONTEXT_LIMIT` honest |
 

--- a/docs/DIAGRAMS.md
+++ b/docs/DIAGRAMS.md
@@ -101,11 +101,14 @@ Rules:
 flowchart TD
   facts["Public profile facts"] --> pyProfile["public_profile.py"]
   pyProfile --> data["synthetic_data.py"]
+  pyProfile --> eval
   data --> train["train_lora.py"]
   train --> eval["evaluate.py"]
-  data --> datasetDigest["Dataset digest"]
-  eval --> reports["Reports with dataset and model lineage"]
+  data --> datasetDigest["Canonical dataset digest"]
+  eval --> promptDigest["Formatted prompt digest"]
+  eval --> reports["Reports with input and model lineage"]
   datasetDigest --> reports
+  promptDigest --> reports
   eval --> gate["Promotion gate"]
   gate --> merge["merge_adapter.py"]
   baseRevision["Pinned base revision"] --> train
@@ -135,7 +138,7 @@ does not train models and does not call a server.
 | Facts | `src/config/site.ts` and `ml/profile-qa/profile_qa/public_profile.py` | Keep public facts aligned before generating data |
 | Dataset | `python -m profile_qa.synthetic_data` | Generated data stays under ignored `ml/profile-qa/data/` |
 | Training | `ml/profile-qa/profile_qa/config.py` or CLI flags | Fixed `teapotai/teapotllm` base; local 8GB NVIDIA LoRA/QLoRA runs |
-| Evaluation | `python -m profile_qa.evaluate` | Reports record the evaluated dataset digest and split plus the pinned base revision and exact adapter/merged digest |
+| Evaluation | `python -m profile_qa.evaluate` | Reports bind the canonical published dataset, exact formatted prompts, split, pinned base revision, and model digest; saved predictions require matching provenance |
 | ONNX export | `python -m profile_qa.export_onnx` | Verifies the pinned revision and merged lineage/digest, preserves portable lineage without local paths, rejects `.onnx.data`, and publishes `int8` and `uint8` encoder/decoder artifacts |
 | App promotion | `src/config/models.ts` | Update `MODEL_ID` and keep `MODEL_CONTEXT_LIMIT` honest |
 

--- a/docs/DIAGRAMS.md
+++ b/docs/DIAGRAMS.md
@@ -103,10 +103,15 @@ flowchart TD
   pyProfile --> data["synthetic_data.py"]
   data --> train["train_lora.py"]
   train --> eval["evaluate.py"]
-  eval --> reports["Reports with model lineage"]
+  data --> datasetDigest["Dataset digest"]
+  eval --> reports["Reports with dataset and model lineage"]
+  datasetDigest --> reports
   eval --> gate["Promotion gate"]
   gate --> merge["merge_adapter.py"]
-  merge --> lineage["Lineage plus adapter/merge digests"]
+  baseRevision["Pinned base revision"] --> train
+  baseRevision --> eval
+  baseRevision --> merge
+  merge --> lineage["Portable label plus model digests"]
   merge --> export["export_onnx.py"]
   lineage --> export
   export --> browserArtifact["Browser files plus digest"]
@@ -130,8 +135,8 @@ does not train models and does not call a server.
 | Facts | `src/config/site.ts` and `ml/profile-qa/profile_qa/public_profile.py` | Keep public facts aligned before generating data |
 | Dataset | `python -m profile_qa.synthetic_data` | Generated data stays under ignored `ml/profile-qa/data/` |
 | Training | `ml/profile-qa/profile_qa/config.py` or CLI flags | Fixed `teapotai/teapotllm` base; local 8GB NVIDIA LoRA/QLoRA runs |
-| Evaluation | `python -m profile_qa.evaluate` | Reports record the evaluated split and exact baseline revision or adapter/merged lineage digest |
-| ONNX export | `python -m profile_qa.export_onnx` | Verifies merged lineage/digest, preserves lineage through each artifact stage, rejects `.onnx.data`, and publishes `int8` and `uint8` encoder/decoder artifacts |
+| Evaluation | `python -m profile_qa.evaluate` | Reports record the evaluated dataset digest and split plus the pinned base revision and exact adapter/merged digest |
+| ONNX export | `python -m profile_qa.export_onnx` | Verifies the pinned revision and merged lineage/digest, preserves portable lineage without local paths, rejects `.onnx.data`, and publishes `int8` and `uint8` encoder/decoder artifacts |
 | App promotion | `src/config/models.ts` | Update `MODEL_ID` and keep `MODEL_CONTEXT_LIMIT` honest |
 
 Promotion should satisfy the gate in `ml/profile-qa/README.md` before changing

--- a/ml/profile-qa/README.md
+++ b/ml/profile-qa/README.md
@@ -102,17 +102,20 @@ formatted-prompt digest, split, pinned base revision, local adapter or
 merged-model digest, generation settings and implementation digest, and a schema
 plus normalized-token digest of the scoring implementation. Artifact preparation
 recomputes every published metric from the report's saved per-record predictions
-with that current scorer. Merge records
-the pinned revision plus adapter and merged-model SHA-256 values; export verifies
-those values and carries the
-lineage plus a content digest through the full-precision, quantized, and browser
-artifact stages. Each quantized marker also names the exact full-precision
-artifact digest it consumed. Published reports and artifact markers use a
-portable checkpoint label and digest, never the private local checkpoint path
-retained by the merge workspace. Artifact preparation accepts reports only when their
-canonical dataset, live prompt context, base revision, checkpoint label, and
-model digests match the selected inputs and the browser marker matches the
-actual browser files.
+with that current scorer. Merge records the pinned revision plus adapter and
+merged-model SHA-256 values; export verifies those values and carries the lineage
+plus a content digest through the full-precision, quantized, and browser artifact
+stages. Each quantized marker also names the exact full-precision artifact digest
+it consumed. Published reports and artifact markers use a portable checkpoint
+label and digest, never the private local checkpoint path retained by the merge
+workspace. Artifact preparation accepts reports only when their canonical
+dataset, live prompt context, base revision, checkpoint label, and model digests
+match the selected inputs and the browser marker matches the actual browser files.
+
+The merge output must be disjoint from the selected adapter checkpoint. The
+merge command rejects equal, ancestor, descendant, and symlinked output paths,
+then replaces a valid disjoint output tree so stale files cannot enter its
+content digest.
 
 The export `--skip-export` and `--skip-quantize` recovery flags only reuse stage
 directories whose lineage marker and content digest still validate. Quantized

--- a/ml/profile-qa/README.md
+++ b/ml/profile-qa/README.md
@@ -97,13 +97,15 @@ checkpoints whose PEFT metadata records a different base model; export expects
 the merged model directory produced by `profile_qa.merge_adapter` and publishes
 the encoder plus merged decoder ONNX files for the T5 browser runtime.
 
-Evaluation reports record the exact baseline revision or local adapter/merged
-model digest and split. Merge records adapter and merged-model SHA-256 values;
-export verifies those values and carries the lineage plus a content digest
-through the full-precision, quantized, and browser artifact stages. Artifact
-preparation accepts reports only when their promoted adapter ID and digest match
-the selected merge lineage and the browser marker matches the actual browser
-files.
+Evaluation reports record the evaluated dataset SHA-256, split, pinned base
+revision, and local adapter or merged-model digest. Merge records that pinned
+revision plus adapter and merged-model SHA-256 values; export verifies those
+values and carries the lineage plus a content digest through the full-precision,
+quantized, and browser artifact stages. Published reports and artifact markers
+use a portable checkpoint label and digest, never the private local checkpoint
+path retained by the merge workspace. Artifact preparation accepts reports only
+when their dataset, base revision, checkpoint label, and model digests match the
+selected inputs and the browser marker matches the actual browser files.
 
 The export `--skip-export` and `--skip-quantize` recovery flags only reuse stage
 directories whose lineage marker and content digest still validate. Regenerate

--- a/ml/profile-qa/README.md
+++ b/ml/profile-qa/README.md
@@ -66,7 +66,21 @@ exporter supports Transformers 5.
 PYTHONPATH=ml/profile-qa python -m profile_qa.gpu_health
 PYTHONPATH=ml/profile-qa python -m profile_qa.synthetic_data --output ml/profile-qa/data/profile_qa.jsonl
 PYTHONPATH=ml/profile-qa python -m profile_qa.train_lora --dataset ml/profile-qa/data/profile_qa.jsonl
-PYTHONPATH=ml/profile-qa python -m profile_qa.evaluate --dataset ml/profile-qa/data/profile_qa.jsonl --model-id teapotai/teapotllm
+PYTHONPATH=ml/profile-qa python -m profile_qa.evaluate \
+  --dataset ml/profile-qa/data/profile_qa.jsonl \
+  --model-id teapotai/teapotllm \
+  --split test \
+  --output ml/profile-qa/reports/profile_qa_eval_baseline_test.json
+PYTHONPATH=ml/profile-qa python -m profile_qa.evaluate \
+  --dataset ml/profile-qa/data/profile_qa.jsonl \
+  --model-id ml/profile-qa/checkpoints/teapot-profile-qa-lora/checkpoint-400 \
+  --split validation \
+  --output ml/profile-qa/reports/profile_qa_eval_candidate_validation.json
+PYTHONPATH=ml/profile-qa python -m profile_qa.evaluate \
+  --dataset ml/profile-qa/data/profile_qa.jsonl \
+  --model-id ml/profile-qa/checkpoints/teapot-profile-qa-lora/checkpoint-400 \
+  --split test \
+  --output ml/profile-qa/reports/profile_qa_eval_candidate_test.json
 PYTHONPATH=ml/profile-qa python -m profile_qa.merge_adapter --adapter-model-id ml/profile-qa/checkpoints/teapot-profile-qa-lora/checkpoint-400 --output-dir ml/profile-qa/merged/teapot-profile-qa
 PYTHONPATH=ml/profile-qa ml/profile-qa/.venv-export/bin/python -m profile_qa.export_onnx --output-dir ml/profile-qa/onnx/candidate
 PYTHONPATH=ml/profile-qa python -m profile_qa.prepare_hf_artifacts \
@@ -83,11 +97,25 @@ checkpoints whose PEFT metadata records a different base model; export expects
 the merged model directory produced by `profile_qa.merge_adapter` and publishes
 the encoder plus merged decoder ONNX files for the T5 browser runtime.
 
-Artifact preparation derives the promoted checkpoint from the merge lineage and
-reads its latest train loss and best validation eval loss from the checkpoint's
-`trainer_state.json`. Pass the intended release date explicitly in ISO
-`YYYY-MM-DD` format. Missing or malformed provenance stops preparation before an
-existing model payload is replaced.
+Evaluation reports record the exact baseline revision or local adapter/merged
+model digest and split. Merge records adapter and merged-model SHA-256 values;
+export verifies those values and carries the lineage plus a content digest
+through the full-precision, quantized, and browser artifact stages. Artifact
+preparation accepts reports only when their promoted adapter ID and digest match
+the selected merge lineage and the browser marker matches the actual browser
+files.
+
+The export `--skip-export` and `--skip-quantize` recovery flags only reuse stage
+directories whose lineage marker and content digest still validate. Regenerate
+legacy or modified export directories instead of relabeling them.
+
+Artifact preparation derives the promoted checkpoint from that verified lineage
+and reads its latest train loss and best validation eval loss from the
+checkpoint's `trainer_state.json`. Pass the intended release date explicitly in
+ISO `YYYY-MM-DD` format. Missing, mismatched, or malformed provenance stops
+preparation before an existing model payload is replaced. When evaluating saved
+predictions with `--predictions-json`, still pass the `--model-id` whose outputs
+the file contains so the report is bound to the intended lineage.
 
 For targeted continuation from an existing LoRA adapter:
 

--- a/ml/profile-qa/README.md
+++ b/ml/profile-qa/README.md
@@ -97,15 +97,17 @@ checkpoints whose PEFT metadata records a different base model; export expects
 the merged model directory produced by `profile_qa.merge_adapter` and publishes
 the encoder plus merged decoder ONNX files for the T5 browser runtime.
 
-Evaluation reports record the evaluated dataset SHA-256, split, pinned base
-revision, and local adapter or merged-model digest. Merge records that pinned
-revision plus adapter and merged-model SHA-256 values; export verifies those
-values and carries the lineage plus a content digest through the full-precision,
-quantized, and browser artifact stages. Published reports and artifact markers
-use a portable checkpoint label and digest, never the private local checkpoint
-path retained by the merge workspace. Artifact preparation accepts reports only
-when their dataset, base revision, checkpoint label, and model digests match the
-selected inputs and the browser marker matches the actual browser files.
+Evaluation reports record the canonical published-dataset SHA-256, exact
+formatted-prompt digest, split, pinned base revision, and local adapter or
+merged-model digest. Merge records that pinned revision plus adapter and
+merged-model SHA-256 values; export verifies those values and carries the
+lineage plus a content digest through the full-precision, quantized, and browser
+artifact stages. Published reports and artifact markers use a portable
+checkpoint label and digest, never the private local checkpoint path retained
+by the merge workspace. Artifact preparation accepts reports only when their
+canonical dataset, live prompt context, base revision, checkpoint label, and
+model digests match the selected inputs and the browser marker matches the
+actual browser files.
 
 The export `--skip-export` and `--skip-quantize` recovery flags only reuse stage
 directories whose lineage marker and content digest still validate. Regenerate
@@ -115,9 +117,11 @@ Artifact preparation derives the promoted checkpoint from that verified lineage
 and reads its latest train loss and best validation eval loss from the
 checkpoint's `trainer_state.json`. Pass the intended release date explicitly in
 ISO `YYYY-MM-DD` format. Missing, mismatched, or malformed provenance stops
-preparation before an existing model payload is replaced. When evaluating saved
-predictions with `--predictions-json`, still pass the `--model-id` whose outputs
-the file contains so the report is bound to the intended lineage.
+preparation before an existing model payload is replaced. To reuse generated
+outputs, first write a provenance-bound bundle with `--save-predictions-json`.
+`--predictions-json` accepts only that bundle format and verifies its model,
+canonical dataset, split, formatted prompts, and exact record IDs before
+scoring; plain or stale prediction mappings are rejected.
 
 For targeted continuation from an existing LoRA adapter:
 

--- a/ml/profile-qa/README.md
+++ b/ml/profile-qa/README.md
@@ -92,10 +92,12 @@ PYTHONPATH=ml/profile-qa python -m profile_qa.publish --repo-type dataset --repo
 ```
 
 The training, continuation, merge, and export commands are Teapot-only. Training
-always starts from `teapotai/teapotllm`; adapter continuation and merge reject
-checkpoints whose PEFT metadata records a different base model; export expects
-the merged model directory produced by `profile_qa.merge_adapter` and publishes
-the encoder plus merged decoder ONNX files for the T5 browser runtime.
+always starts from `teapotai/teapotllm` and persists the pinned base revision in
+every PEFT checkpoint and final adapter. Continuation, resume, evaluation,
+generation, merge, and packaging reject adapters whose PEFT metadata omits that
+revision or names a different base model or revision. Export expects the merged
+model directory produced by `profile_qa.merge_adapter` and publishes the encoder
+plus merged decoder ONNX files for the T5 browser runtime.
 
 Evaluation reports record the canonical published-dataset SHA-256, exact
 formatted-prompt digest, split, pinned base revision, local adapter or
@@ -106,11 +108,14 @@ with that current scorer. Merge records the pinned revision plus adapter and
 merged-model SHA-256 values; export verifies those values and carries the lineage
 plus a content digest through the full-precision, quantized, and browser artifact
 stages. Each quantized marker also names the exact full-precision artifact digest
-it consumed. Published reports and artifact markers use a portable checkpoint
-label and digest, never the private local checkpoint path retained by the merge
-workspace. Artifact preparation accepts reports only when their canonical
-dataset, live prompt context, base revision, checkpoint label, and model digests
-match the selected inputs and the browser marker matches the actual browser files.
+it consumed. Published artifact markers derive their source-lineage digest from
+the sanitized public projection, so the private local checkpoint path neither
+leaves the merge workspace nor influences that digest. Artifact preparation
+accepts only the exact publishable report-provenance schema; its validation and
+test reports must identify the same adapter or merged representation, and their
+canonical dataset, live prompt context, base revision, checkpoint label, and
+model digests must match the selected inputs. The browser marker must also match
+the actual browser files.
 
 The merge output must be disjoint from the selected adapter checkpoint. The
 merge command rejects equal, ancestor, descendant, and symlinked output paths,

--- a/ml/profile-qa/README.md
+++ b/ml/profile-qa/README.md
@@ -69,7 +69,10 @@ PYTHONPATH=ml/profile-qa python -m profile_qa.train_lora --dataset ml/profile-qa
 PYTHONPATH=ml/profile-qa python -m profile_qa.evaluate --dataset ml/profile-qa/data/profile_qa.jsonl --model-id teapotai/teapotllm
 PYTHONPATH=ml/profile-qa python -m profile_qa.merge_adapter --adapter-model-id ml/profile-qa/checkpoints/teapot-profile-qa-lora/checkpoint-400 --output-dir ml/profile-qa/merged/teapot-profile-qa
 PYTHONPATH=ml/profile-qa ml/profile-qa/.venv-export/bin/python -m profile_qa.export_onnx --output-dir ml/profile-qa/onnx/candidate
-PYTHONPATH=ml/profile-qa python -m profile_qa.prepare_hf_artifacts --model-browser-dir ml/profile-qa/onnx/candidate/browser
+PYTHONPATH=ml/profile-qa python -m profile_qa.prepare_hf_artifacts \
+  --model-browser-dir ml/profile-qa/onnx/candidate/browser \
+  --lineage-file ml/profile-qa/merged/teapot-profile-qa/teapot_profile_qa_lineage.json \
+  --release-date YYYY-MM-DD
 PYTHONPATH=ml/profile-qa python -m profile_qa.publish --repo-id justinthelaw/teapot-profile-qa-browser-1024 --artifact-dir ml/profile-qa/hf/model
 PYTHONPATH=ml/profile-qa python -m profile_qa.publish --repo-type dataset --repo-id justinthelaw/profile-qa-synthetic-public-v1 --artifact-dir ml/profile-qa/hf/dataset
 ```
@@ -79,6 +82,12 @@ always starts from `teapotai/teapotllm`; adapter continuation and merge reject
 checkpoints whose PEFT metadata records a different base model; export expects
 the merged model directory produced by `profile_qa.merge_adapter` and publishes
 the encoder plus merged decoder ONNX files for the T5 browser runtime.
+
+Artifact preparation derives the promoted checkpoint from the merge lineage and
+reads its latest train loss and best validation eval loss from the checkpoint's
+`trainer_state.json`. Pass the intended release date explicitly in ISO
+`YYYY-MM-DD` format. Missing or malformed provenance stops preparation before an
+existing model payload is replaced.
 
 For targeted continuation from an existing LoRA adapter:
 

--- a/ml/profile-qa/README.md
+++ b/ml/profile-qa/README.md
@@ -98,30 +98,44 @@ the merged model directory produced by `profile_qa.merge_adapter` and publishes
 the encoder plus merged decoder ONNX files for the T5 browser runtime.
 
 Evaluation reports record the canonical published-dataset SHA-256, exact
-formatted-prompt digest, split, pinned base revision, and local adapter or
-merged-model digest. Merge records that pinned revision plus adapter and
-merged-model SHA-256 values; export verifies those values and carries the
+formatted-prompt digest, split, pinned base revision, local adapter or
+merged-model digest, generation settings and implementation digest, and a schema
+plus normalized-token digest of the scoring implementation. Artifact preparation
+recomputes every published metric from the report's saved per-record predictions
+with that current scorer. Merge records
+the pinned revision plus adapter and merged-model SHA-256 values; export verifies
+those values and carries the
 lineage plus a content digest through the full-precision, quantized, and browser
-artifact stages. Published reports and artifact markers use a portable
-checkpoint label and digest, never the private local checkpoint path retained
-by the merge workspace. Artifact preparation accepts reports only when their
+artifact stages. Each quantized marker also names the exact full-precision
+artifact digest it consumed. Published reports and artifact markers use a
+portable checkpoint label and digest, never the private local checkpoint path
+retained by the merge workspace. Artifact preparation accepts reports only when their
 canonical dataset, live prompt context, base revision, checkpoint label, and
 model digests match the selected inputs and the browser marker matches the
 actual browser files.
 
 The export `--skip-export` and `--skip-quantize` recovery flags only reuse stage
-directories whose lineage marker and content digest still validate. Regenerate
-legacy or modified export directories instead of relabeling them.
+directories whose lineage marker and content digest still validate. Quantized
+directories from a prior full-precision export are rejected even when both
+exports share the same merged-model lineage. Regenerate legacy or modified
+export directories instead of relabeling them.
 
 Artifact preparation derives the promoted checkpoint from that verified lineage
 and reads its latest train loss and best validation eval loss from the
-checkpoint's `trainer_state.json`. Pass the intended release date explicitly in
-ISO `YYYY-MM-DD` format. Missing, mismatched, or malformed provenance stops
-preparation before an existing model payload is replaced. To reuse generated
+checkpoint's `trainer_state.json`. Model-card LoRA rank, alpha, dropout, and
+target modules come from the digest-validated `adapter_config.json`; hardware,
+optimizer, training quantization, and batch-size claims are omitted because the
+checkpoint does not preserve trustworthy values for them. Pass the intended
+release date explicitly in ISO `YYYY-MM-DD` format. Missing, mismatched, stale,
+or malformed provenance stops preparation before an existing model payload is
+replaced. To reuse generated
 outputs, first write a provenance-bound bundle with `--save-predictions-json`.
 `--predictions-json` accepts only that bundle format and verifies its model,
 canonical dataset, split, formatted prompts, and exact record IDs before
-scoring; plain or stale prediction mappings are rejected.
+scoring; generation settings and implementation must also match, so plain or
+stale prediction mappings are rejected. Per-module rank or alpha patterns,
+DoRA/RS-LoRA, trained bias values, and saved extra modules fail closed rather
+than being flattened into an inaccurate simple-LoRA model-card claim.
 
 For targeted continuation from an existing LoRA adapter:
 

--- a/ml/profile-qa/profile_qa/evaluate.py
+++ b/ml/profile-qa/profile_qa/evaluate.py
@@ -35,6 +35,7 @@ from .provenance import (
     require_sha256,
 )
 from .train_lora import (
+    ensure_adapter_base_lineage,
     ensure_primary_base_model_id,
     ensure_teapot_seq2seq_config,
     evaluation_prompt_sha256,
@@ -53,6 +54,46 @@ GENERATION_DIGEST_FIELD = "generation_implementation_sha256"
 GENERATION_CONFIG_FIELD = "generation_config"
 GENERATION_MAX_NEW_TOKENS = 160
 GENERATION_DO_SAMPLE = False
+EVALUATION_REPORT_FIELDS = frozenset(
+    {
+        "by_task",
+        "macro",
+        "multi_turn_accuracy",
+        "provenance",
+        "records",
+        "refusal_accuracy",
+    }
+)
+
+
+def evaluation_provenance_fields(model_kind: str) -> frozenset[str]:
+    """Return the exact publishable provenance schema for one report kind."""
+
+    common_fields = frozenset(
+        {
+            "model_kind",
+            "model_id",
+            "base_model",
+            BASE_MODEL_REVISION_FIELD,
+            DATASET_DIGEST_FIELD,
+            PROMPT_DIGEST_FIELD,
+            SCORING_SCHEMA_FIELD,
+            SCORING_DIGEST_FIELD,
+            GENERATION_SCHEMA_FIELD,
+            GENERATION_DIGEST_FIELD,
+            GENERATION_CONFIG_FIELD,
+            "split",
+        }
+    )
+    if model_kind == "baseline":
+        return common_fields
+    if model_kind in {"adapter", "merged"}:
+        return common_fields | {
+            "model_sha256",
+            ADAPTER_CHECKPOINT_FIELD,
+            ADAPTER_DIGEST_FIELD,
+        }
+    raise ValueError(f"unsupported evaluation model kind {model_kind!r}")
 
 
 def score_answer(record: dict[str, Any], prediction: str) -> dict[str, float]:
@@ -176,6 +217,12 @@ def _adapter_base_model_id(model_id: str) -> str | None:
     if not adapter_config_path.exists():
         return None
     adapter_config = json.loads(adapter_config_path.read_text(encoding="utf-8"))
+    if not isinstance(adapter_config, dict):
+        raise RuntimeError(f"{adapter_config_path} must contain a JSON object")
+    ensure_adapter_base_lineage(
+        adapter_config,
+        source=f"{model_id} adapter",
+    )
     base_model_id = adapter_config.get("base_model_name_or_path")
     return str(base_model_id) if isinstance(base_model_id, str) else None
 

--- a/ml/profile-qa/profile_qa/evaluate.py
+++ b/ml/profile-qa/profile_qa/evaluate.py
@@ -17,10 +17,16 @@ from .config import (
 )
 from .export_onnx import ensure_teapot_export_model
 from .provenance import (
+    ADAPTER_CHECKPOINT_FIELD,
     ADAPTER_DIGEST_FIELD,
+    BASE_MODEL_REVISION_FIELD,
+    DATASET_DIGEST_FIELD,
     LINEAGE_FILENAME,
     MERGED_DIGEST_FIELD,
     directory_sha256,
+    file_sha256,
+    require_checkpoint_label,
+    require_sha256,
 )
 from .train_lora import (
     ensure_primary_base_model_id,
@@ -110,18 +116,28 @@ def _adapter_base_model_id(model_id: str) -> str | None:
     return str(base_model_id) if isinstance(base_model_id, str) else None
 
 
-def evaluation_provenance(model_id: str, split: str) -> dict[str, Any]:
+def evaluation_provenance(
+    model_id: str,
+    split: str,
+    dataset_sha256: str,
+) -> dict[str, Any]:
     """Describe the immutable model lineage used to create an eval report."""
 
     normalized_split = split.strip()
     if not normalized_split:
         raise RuntimeError("evaluation split must not be empty")
+    normalized_dataset_sha256 = require_sha256(
+        dataset_sha256,
+        field=DATASET_DIGEST_FIELD,
+        source=Path("evaluation dataset"),
+    )
     if model_id.rstrip("/") == PRIMARY_BASE_MODEL_ID:
         return {
             "model_kind": "baseline",
             "model_id": PRIMARY_BASE_MODEL_ID,
-            "model_revision": PRIMARY_BASE_MODEL_REVISION,
+            BASE_MODEL_REVISION_FIELD: PRIMARY_BASE_MODEL_REVISION,
             "base_model": PRIMARY_BASE_MODEL_ID,
+            DATASET_DIGEST_FIELD: normalized_dataset_sha256,
             "split": normalized_split,
         }
 
@@ -130,44 +146,50 @@ def evaluation_provenance(model_id: str, split: str) -> dict[str, Any]:
         source="evaluation model",
     ).resolve()
     canonical_model_id = str(model_path)
-    model_reference = Path(model_id).as_posix()
     adapter_base_model_id = _adapter_base_model_id(canonical_model_id)
     if adapter_base_model_id:
         ensure_primary_base_model_id(
             adapter_base_model_id,
             source=f"{canonical_model_id} adapter base",
         )
+        adapter_checkpoint = require_checkpoint_label(
+            model_path.name,
+            source=model_path,
+        )
         adapter_digest = directory_sha256(model_path)
         return {
             "model_kind": "adapter",
-            "model_id": model_reference,
+            "model_id": adapter_checkpoint,
             "model_sha256": adapter_digest,
-            "adapter_model_id": model_reference,
+            ADAPTER_CHECKPOINT_FIELD: adapter_checkpoint,
             ADAPTER_DIGEST_FIELD: adapter_digest,
             "base_model": PRIMARY_BASE_MODEL_ID,
+            BASE_MODEL_REVISION_FIELD: PRIMARY_BASE_MODEL_REVISION,
+            DATASET_DIGEST_FIELD: normalized_dataset_sha256,
             "split": normalized_split,
         }
 
     if (model_path / LINEAGE_FILENAME).exists():
         lineage = ensure_teapot_export_model(canonical_model_id).data
-        adapter_model_id = lineage.get("adapter_model_id")
+        adapter_checkpoint = require_checkpoint_label(
+            lineage.get(ADAPTER_CHECKPOINT_FIELD),
+            source=model_path / LINEAGE_FILENAME,
+        )
         adapter_digest = lineage.get(ADAPTER_DIGEST_FIELD)
-        if not isinstance(adapter_model_id, str) or not adapter_model_id.strip():
-            raise RuntimeError(
-                f"{model_path / LINEAGE_FILENAME} does not record an adapter_model_id"
-            )
         if not isinstance(adapter_digest, str):
             raise RuntimeError(
                 f"{model_path / LINEAGE_FILENAME} does not record "
                 f"{ADAPTER_DIGEST_FIELD}"
-            )
+        )
         return {
             "model_kind": "merged",
-            "model_id": model_reference,
+            "model_id": "merged-model",
             "model_sha256": lineage[MERGED_DIGEST_FIELD],
-            "adapter_model_id": Path(adapter_model_id).as_posix(),
+            ADAPTER_CHECKPOINT_FIELD: adapter_checkpoint,
             ADAPTER_DIGEST_FIELD: adapter_digest,
             "base_model": PRIMARY_BASE_MODEL_ID,
+            BASE_MODEL_REVISION_FIELD: lineage[BASE_MODEL_REVISION_FIELD],
+            DATASET_DIGEST_FIELD: normalized_dataset_sha256,
             "split": normalized_split,
         }
 
@@ -256,8 +278,10 @@ def main() -> int:
     parser.add_argument("--output", default=str(DEFAULT_EVAL_REPORT_PATH))
     args = parser.parse_args()
 
+    dataset_path = Path(args.dataset)
+    dataset_sha256 = file_sha256(dataset_path)
     records = [
-        record for record in read_jsonl(Path(args.dataset)) if record.get("split") == args.split
+        record for record in read_jsonl(dataset_path) if record.get("split") == args.split
     ]
     if args.predictions_json:
         predictions = json.loads(Path(args.predictions_json).read_text(encoding="utf-8"))
@@ -265,7 +289,11 @@ def main() -> int:
         predictions = generate_predictions(args.model_id, records)
 
     report = score_predictions(records, predictions)
-    report["provenance"] = evaluation_provenance(args.model_id, args.split)
+    report["provenance"] = evaluation_provenance(
+        args.model_id,
+        args.split,
+        dataset_sha256,
+    )
     output_path = Path(args.output)
     output_path.parent.mkdir(parents=True, exist_ok=True)
     output_path.write_text(json.dumps(report, indent=2, sort_keys=True), encoding="utf-8")

--- a/ml/profile-qa/profile_qa/evaluate.py
+++ b/ml/profile-qa/profile_qa/evaluate.py
@@ -23,19 +23,21 @@ from .provenance import (
     DATASET_DIGEST_FIELD,
     LINEAGE_FILENAME,
     MERGED_DIGEST_FIELD,
+    PROMPT_DIGEST_FIELD,
     directory_sha256,
-    file_sha256,
+    load_json_object,
     require_checkpoint_label,
     require_sha256,
 )
 from .train_lora import (
     ensure_primary_base_model_id,
     ensure_teapot_seq2seq_config,
+    evaluation_prompt_sha256,
     format_instruction,
     require_local_model_path,
     trusted_model_load_kwargs,
 )
-from .validation import read_jsonl
+from .validation import canonical_jsonl_sha256, read_jsonl
 
 
 def score_answer(record: dict[str, Any], prediction: str) -> dict[str, float]:
@@ -120,6 +122,7 @@ def evaluation_provenance(
     model_id: str,
     split: str,
     dataset_sha256: str,
+    prompt_sha256: str,
 ) -> dict[str, Any]:
     """Describe the immutable model lineage used to create an eval report."""
 
@@ -131,6 +134,11 @@ def evaluation_provenance(
         field=DATASET_DIGEST_FIELD,
         source=Path("evaluation dataset"),
     )
+    normalized_prompt_sha256 = require_sha256(
+        prompt_sha256,
+        field=PROMPT_DIGEST_FIELD,
+        source=Path("evaluation prompts"),
+    )
     if model_id.rstrip("/") == PRIMARY_BASE_MODEL_ID:
         return {
             "model_kind": "baseline",
@@ -138,6 +146,7 @@ def evaluation_provenance(
             BASE_MODEL_REVISION_FIELD: PRIMARY_BASE_MODEL_REVISION,
             "base_model": PRIMARY_BASE_MODEL_ID,
             DATASET_DIGEST_FIELD: normalized_dataset_sha256,
+            PROMPT_DIGEST_FIELD: normalized_prompt_sha256,
             "split": normalized_split,
         }
 
@@ -166,6 +175,7 @@ def evaluation_provenance(
             "base_model": PRIMARY_BASE_MODEL_ID,
             BASE_MODEL_REVISION_FIELD: PRIMARY_BASE_MODEL_REVISION,
             DATASET_DIGEST_FIELD: normalized_dataset_sha256,
+            PROMPT_DIGEST_FIELD: normalized_prompt_sha256,
             "split": normalized_split,
         }
 
@@ -190,6 +200,7 @@ def evaluation_provenance(
             "base_model": PRIMARY_BASE_MODEL_ID,
             BASE_MODEL_REVISION_FIELD: lineage[BASE_MODEL_REVISION_FIELD],
             DATASET_DIGEST_FIELD: normalized_dataset_sha256,
+            PROMPT_DIGEST_FIELD: normalized_prompt_sha256,
             "split": normalized_split,
         }
 
@@ -265,6 +276,87 @@ def generate_predictions(model_id: str, records: list[dict[str, Any]]) -> dict[s
     return predictions
 
 
+def write_prediction_bundle(
+    path: Path,
+    *,
+    predictions: dict[str, str],
+    provenance: dict[str, Any],
+) -> None:
+    """Persist predictions with the provenance needed for safe report reuse."""
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(
+            {"predictions": predictions, "provenance": provenance},
+            indent=2,
+            sort_keys=True,
+        ),
+        encoding="utf-8",
+    )
+
+
+def load_prediction_bundle(
+    path: Path,
+    *,
+    expected_provenance: dict[str, Any],
+    records: list[dict[str, Any]],
+) -> dict[str, str]:
+    """Load saved predictions only when their full evaluation inputs match."""
+
+    bundle = load_json_object(path, label="saved predictions")
+    provenance = bundle.get("provenance")
+    if not isinstance(provenance, dict):
+        raise ValueError(
+            f"{path} is missing object field 'provenance'; regenerate it with "
+            "--save-predictions-json"
+        )
+    mismatched_fields = sorted(
+        field
+        for field in set(expected_provenance) | set(provenance)
+        if field not in provenance
+        or field not in expected_provenance
+        or provenance[field] != expected_provenance[field]
+    )
+    if mismatched_fields:
+        raise ValueError(
+            f"{path} prediction provenance does not match the selected model, "
+            "dataset, split, and prompt context; mismatched fields: "
+            f"{', '.join(mismatched_fields)}"
+        )
+
+    raw_predictions = bundle.get("predictions")
+    if not isinstance(raw_predictions, dict) or not all(
+        isinstance(record_id, str) and isinstance(prediction, str)
+        for record_id, prediction in raw_predictions.items()
+    ):
+        raise ValueError(
+            f"{path} field 'predictions' must map string record IDs to strings"
+        )
+    if any(
+        not isinstance(record.get("id"), str) or not str(record["id"]).strip()
+        for record in records
+    ):
+        raise ValueError("evaluation records must have unique non-empty string IDs")
+    expected_ids = [str(record["id"]) for record in records]
+    if len(expected_ids) != len(set(expected_ids)):
+        raise ValueError("evaluation records must have unique non-empty string IDs")
+    expected_id_set = set(expected_ids)
+    actual_id_set = set(raw_predictions)
+    if actual_id_set != expected_id_set:
+        missing = sorted(expected_id_set - actual_id_set)
+        unexpected = sorted(actual_id_set - expected_id_set)
+        details = []
+        if missing:
+            details.append(f"missing: {', '.join(missing)}")
+        if unexpected:
+            details.append(f"unexpected: {', '.join(unexpected)}")
+        raise ValueError(
+            f"{path} predictions do not match evaluated record IDs "
+            f"({'; '.join(details)})"
+        )
+    return dict(raw_predictions)
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--dataset", default=str(DEFAULT_DATASET_PATH))
@@ -273,27 +365,46 @@ def main() -> int:
         required=True,
         help="base model, adapter checkpoint, or merged model represented by the report",
     )
-    parser.add_argument("--predictions-json")
+    predictions_group = parser.add_mutually_exclusive_group()
+    predictions_group.add_argument(
+        "--predictions-json",
+        help="reuse a provenance-bound bundle written by --save-predictions-json",
+    )
+    predictions_group.add_argument(
+        "--save-predictions-json",
+        help="save generated predictions and their provenance for later scoring",
+    )
     parser.add_argument("--split", default="test")
     parser.add_argument("--output", default=str(DEFAULT_EVAL_REPORT_PATH))
     args = parser.parse_args()
 
     dataset_path = Path(args.dataset)
-    dataset_sha256 = file_sha256(dataset_path)
-    records = [
-        record for record in read_jsonl(dataset_path) if record.get("split") == args.split
-    ]
-    if args.predictions_json:
-        predictions = json.loads(Path(args.predictions_json).read_text(encoding="utf-8"))
-    else:
-        predictions = generate_predictions(args.model_id, records)
-
-    report = score_predictions(records, predictions)
-    report["provenance"] = evaluation_provenance(
+    dataset_records = read_jsonl(dataset_path)
+    dataset_sha256 = canonical_jsonl_sha256(dataset_records)
+    records = [record for record in dataset_records if record.get("split") == args.split]
+    provenance = evaluation_provenance(
         args.model_id,
         args.split,
         dataset_sha256,
+        evaluation_prompt_sha256(records),
     )
+    if args.predictions_json:
+        predictions = load_prediction_bundle(
+            Path(args.predictions_json),
+            expected_provenance=provenance,
+            records=records,
+        )
+    else:
+        predictions = generate_predictions(args.model_id, records)
+        if args.save_predictions_json:
+            write_prediction_bundle(
+                Path(args.save_predictions_json),
+                predictions=predictions,
+                provenance=provenance,
+            )
+
+    report = score_predictions(records, predictions)
+    report["provenance"] = provenance
     output_path = Path(args.output)
     output_path.parent.mkdir(parents=True, exist_ok=True)
     output_path.write_text(json.dumps(report, indent=2, sort_keys=True), encoding="utf-8")

--- a/ml/profile-qa/profile_qa/evaluate.py
+++ b/ml/profile-qa/profile_qa/evaluate.py
@@ -13,6 +13,14 @@ from .config import (
     DEFAULT_EVAL_REPORT_PATH,
     MODEL_CONTEXT_LIMIT,
     PRIMARY_BASE_MODEL_ID,
+    PRIMARY_BASE_MODEL_REVISION,
+)
+from .export_onnx import ensure_teapot_export_model
+from .provenance import (
+    ADAPTER_DIGEST_FIELD,
+    LINEAGE_FILENAME,
+    MERGED_DIGEST_FIELD,
+    directory_sha256,
 )
 from .train_lora import (
     ensure_primary_base_model_id,
@@ -102,6 +110,73 @@ def _adapter_base_model_id(model_id: str) -> str | None:
     return str(base_model_id) if isinstance(base_model_id, str) else None
 
 
+def evaluation_provenance(model_id: str, split: str) -> dict[str, Any]:
+    """Describe the immutable model lineage used to create an eval report."""
+
+    normalized_split = split.strip()
+    if not normalized_split:
+        raise RuntimeError("evaluation split must not be empty")
+    if model_id.rstrip("/") == PRIMARY_BASE_MODEL_ID:
+        return {
+            "model_kind": "baseline",
+            "model_id": PRIMARY_BASE_MODEL_ID,
+            "model_revision": PRIMARY_BASE_MODEL_REVISION,
+            "base_model": PRIMARY_BASE_MODEL_ID,
+            "split": normalized_split,
+        }
+
+    model_path = require_local_model_path(
+        model_id,
+        source="evaluation model",
+    ).resolve()
+    canonical_model_id = str(model_path)
+    model_reference = Path(model_id).as_posix()
+    adapter_base_model_id = _adapter_base_model_id(canonical_model_id)
+    if adapter_base_model_id:
+        ensure_primary_base_model_id(
+            adapter_base_model_id,
+            source=f"{canonical_model_id} adapter base",
+        )
+        adapter_digest = directory_sha256(model_path)
+        return {
+            "model_kind": "adapter",
+            "model_id": model_reference,
+            "model_sha256": adapter_digest,
+            "adapter_model_id": model_reference,
+            ADAPTER_DIGEST_FIELD: adapter_digest,
+            "base_model": PRIMARY_BASE_MODEL_ID,
+            "split": normalized_split,
+        }
+
+    if (model_path / LINEAGE_FILENAME).exists():
+        lineage = ensure_teapot_export_model(canonical_model_id).data
+        adapter_model_id = lineage.get("adapter_model_id")
+        adapter_digest = lineage.get(ADAPTER_DIGEST_FIELD)
+        if not isinstance(adapter_model_id, str) or not adapter_model_id.strip():
+            raise RuntimeError(
+                f"{model_path / LINEAGE_FILENAME} does not record an adapter_model_id"
+            )
+        if not isinstance(adapter_digest, str):
+            raise RuntimeError(
+                f"{model_path / LINEAGE_FILENAME} does not record "
+                f"{ADAPTER_DIGEST_FIELD}"
+            )
+        return {
+            "model_kind": "merged",
+            "model_id": model_reference,
+            "model_sha256": lineage[MERGED_DIGEST_FIELD],
+            "adapter_model_id": Path(adapter_model_id).as_posix(),
+            ADAPTER_DIGEST_FIELD: adapter_digest,
+            "base_model": PRIMARY_BASE_MODEL_ID,
+            "split": normalized_split,
+        }
+
+    raise RuntimeError(
+        "local evaluation models must be an adapter checkpoint or a merged model "
+        f"containing {LINEAGE_FILENAME}: {model_path}"
+    )
+
+
 def _ensure_generation_lineage(model_id: str, adapter_base_model_id: str | None, config: Any) -> None:
     if adapter_base_model_id:
         ensure_primary_base_model_id(adapter_base_model_id, source=f"{model_id} adapter base")
@@ -171,7 +246,11 @@ def generate_predictions(model_id: str, records: list[dict[str, Any]]) -> dict[s
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--dataset", default=str(DEFAULT_DATASET_PATH))
-    parser.add_argument("--model-id")
+    parser.add_argument(
+        "--model-id",
+        required=True,
+        help="base model, adapter checkpoint, or merged model represented by the report",
+    )
     parser.add_argument("--predictions-json")
     parser.add_argument("--split", default="test")
     parser.add_argument("--output", default=str(DEFAULT_EVAL_REPORT_PATH))
@@ -182,12 +261,11 @@ def main() -> int:
     ]
     if args.predictions_json:
         predictions = json.loads(Path(args.predictions_json).read_text(encoding="utf-8"))
-    elif args.model_id:
-        predictions = generate_predictions(args.model_id, records)
     else:
-        raise RuntimeError("provide --model-id or --predictions-json")
+        predictions = generate_predictions(args.model_id, records)
 
     report = score_predictions(records, predictions)
+    report["provenance"] = evaluation_provenance(args.model_id, args.split)
     output_path = Path(args.output)
     output_path.parent.mkdir(parents=True, exist_ok=True)
     output_path.write_text(json.dumps(report, indent=2, sort_keys=True), encoding="utf-8")

--- a/ml/profile-qa/profile_qa/evaluate.py
+++ b/ml/profile-qa/profile_qa/evaluate.py
@@ -3,7 +3,11 @@
 from __future__ import annotations
 
 import argparse
+import inspect
+import io
 import json
+import textwrap
+import tokenize
 from collections import defaultdict
 from pathlib import Path
 from typing import Any
@@ -24,6 +28,7 @@ from .provenance import (
     LINEAGE_FILENAME,
     MERGED_DIGEST_FIELD,
     PROMPT_DIGEST_FIELD,
+    canonical_json_sha256,
     directory_sha256,
     load_json_object,
     require_checkpoint_label,
@@ -38,6 +43,16 @@ from .train_lora import (
     trusted_model_load_kwargs,
 )
 from .validation import canonical_jsonl_sha256, read_jsonl
+
+SCORING_SCHEMA_VERSION = 1
+SCORING_SCHEMA_FIELD = "scoring_schema_version"
+SCORING_DIGEST_FIELD = "scoring_implementation_sha256"
+GENERATION_SCHEMA_VERSION = 1
+GENERATION_SCHEMA_FIELD = "generation_schema_version"
+GENERATION_DIGEST_FIELD = "generation_implementation_sha256"
+GENERATION_CONFIG_FIELD = "generation_config"
+GENERATION_MAX_NEW_TOKENS = 160
+GENERATION_DO_SAMPLE = False
 
 
 def score_answer(record: dict[str, Any], prediction: str) -> dict[str, float]:
@@ -87,6 +102,53 @@ def score_predictions(records: list[dict[str, Any]], predictions: dict[str, str]
 
 def _mean(values: list[float]) -> float:
     return sum(values) / len(values) if values else 0.0
+
+
+def _implementation_sha256(
+    functions: tuple[Any, ...],
+    *,
+    schema_version: int,
+) -> str:
+    """Hash semantic Python tokens without Python-minor-specific AST layouts."""
+
+    function_tokens = []
+    ignored_token_types = {
+        tokenize.COMMENT,
+        tokenize.ENCODING,
+        tokenize.ENDMARKER,
+        tokenize.NL,
+    }
+    structural_token_types = {
+        tokenize.DEDENT,
+        tokenize.INDENT,
+        tokenize.NEWLINE,
+    }
+    for function in functions:
+        source = textwrap.dedent(inspect.getsource(function))
+        tokens = []
+        for token in tokenize.generate_tokens(io.StringIO(source).readline):
+            if token.type in ignored_token_types:
+                continue
+            token_value = (
+                "" if token.type in structural_token_types else token.string
+            )
+            tokens.append((tokenize.tok_name[token.type], token_value))
+        function_tokens.append(tokens)
+    return canonical_json_sha256(
+        {
+            "schema_version": schema_version,
+            "function_tokens": function_tokens,
+        }
+    )
+
+
+def scoring_implementation_sha256() -> str:
+    """Hash every function that defines report scores."""
+
+    return _implementation_sha256(
+        (score_answer, score_predictions, _mean),
+        schema_version=SCORING_SCHEMA_VERSION,
+    )
 
 
 def _load_generation_stack() -> dict[str, Any]:
@@ -139,6 +201,11 @@ def evaluation_provenance(
         field=PROMPT_DIGEST_FIELD,
         source=Path("evaluation prompts"),
     )
+    evaluation_contract_provenance = {
+        SCORING_SCHEMA_FIELD: SCORING_SCHEMA_VERSION,
+        SCORING_DIGEST_FIELD: scoring_implementation_sha256(),
+        **generation_provenance_fields(),
+    }
     if model_id.rstrip("/") == PRIMARY_BASE_MODEL_ID:
         return {
             "model_kind": "baseline",
@@ -147,6 +214,7 @@ def evaluation_provenance(
             "base_model": PRIMARY_BASE_MODEL_ID,
             DATASET_DIGEST_FIELD: normalized_dataset_sha256,
             PROMPT_DIGEST_FIELD: normalized_prompt_sha256,
+            **evaluation_contract_provenance,
             "split": normalized_split,
         }
 
@@ -176,6 +244,7 @@ def evaluation_provenance(
             BASE_MODEL_REVISION_FIELD: PRIMARY_BASE_MODEL_REVISION,
             DATASET_DIGEST_FIELD: normalized_dataset_sha256,
             PROMPT_DIGEST_FIELD: normalized_prompt_sha256,
+            **evaluation_contract_provenance,
             "split": normalized_split,
         }
 
@@ -201,6 +270,7 @@ def evaluation_provenance(
             BASE_MODEL_REVISION_FIELD: lineage[BASE_MODEL_REVISION_FIELD],
             DATASET_DIGEST_FIELD: normalized_dataset_sha256,
             PROMPT_DIGEST_FIELD: normalized_prompt_sha256,
+            **evaluation_contract_provenance,
             "split": normalized_split,
         }
 
@@ -267,13 +337,48 @@ def generate_predictions(model_id: str, records: list[dict[str, Any]]) -> dict[s
         with stack["torch"].no_grad():
             output_ids = model.generate(
                 **inputs,
-                max_new_tokens=160,
-                do_sample=False,
+                max_new_tokens=GENERATION_MAX_NEW_TOKENS,
+                do_sample=GENERATION_DO_SAMPLE,
             )
         generated_ids = output_ids[0]
         generated = tokenizer.decode(generated_ids, skip_special_tokens=True)
         predictions[str(record["id"])] = str(generated).strip()
     return predictions
+
+
+def generation_config() -> dict[str, Any]:
+    """Return generation settings that materially affect saved predictions."""
+
+    return {
+        "decode_skip_special_tokens": True,
+        "do_sample": GENERATION_DO_SAMPLE,
+        "input_truncation": True,
+        "max_input_tokens": MODEL_CONTEXT_LIMIT,
+        "max_new_tokens": GENERATION_MAX_NEW_TOKENS,
+    }
+
+
+def generation_implementation_sha256() -> str:
+    """Hash the local generation path independently of scoring semantics."""
+
+    return _implementation_sha256(
+        (
+            _adapter_base_model_id,
+            _ensure_generation_lineage,
+            generate_predictions,
+        ),
+        schema_version=GENERATION_SCHEMA_VERSION,
+    )
+
+
+def generation_provenance_fields() -> dict[str, Any]:
+    """Describe the exact generation contract for reports and saved bundles."""
+
+    return {
+        GENERATION_SCHEMA_FIELD: GENERATION_SCHEMA_VERSION,
+        GENERATION_DIGEST_FIELD: generation_implementation_sha256(),
+        GENERATION_CONFIG_FIELD: generation_config(),
+    }
 
 
 def write_prediction_bundle(

--- a/ml/profile-qa/profile_qa/export_onnx.py
+++ b/ml/profile-qa/profile_qa/export_onnx.py
@@ -21,8 +21,8 @@ from .provenance import (
     LINEAGE_SCHEMA_VERSION,
     MERGED_DIGEST_FIELD,
     directory_sha256,
-    file_sha256,
     load_json_object,
+    public_lineage_sha256,
     require_checkpoint_label,
     require_sha256,
     validate_artifact_lineage,
@@ -118,7 +118,10 @@ def ensure_teapot_export_model(model: str) -> ValidatedMergeLineage:
             f"{lineage_path} merged model digest does not match {model_path}: "
             f"expected {recorded_merged_digest}, got {actual_merged_digest}"
         )
-    return ValidatedMergeLineage(data=lineage, sha256=file_sha256(lineage_path))
+    return ValidatedMergeLineage(
+        data=lineage,
+        sha256=public_lineage_sha256(lineage),
+    )
 
 
 def export_onnx(model: str, output_dir: Path) -> ValidatedMergeLineage:
@@ -161,7 +164,6 @@ def export_onnx(model: str, output_dir: Path) -> ValidatedMergeLineage:
     write_artifact_lineage(
         output_dir,
         source_lineage=lineage.data,
-        source_lineage_sha256=lineage.sha256,
         stage="onnx-fp",
     )
     return lineage
@@ -175,7 +177,7 @@ def quantize_onnx(
 ) -> None:
     fp_lineage = validate_artifact_lineage(
         input_dir,
-        source_lineage_sha256=lineage.sha256,
+        source_lineage=lineage.data,
         stage="onnx-fp",
     )
     fp_artifact_sha256 = require_sha256(
@@ -213,7 +215,6 @@ def quantize_onnx(
     write_artifact_lineage(
         output_dir,
         source_lineage=lineage.data,
-        source_lineage_sha256=lineage.sha256,
         stage=f"onnx-{dtype}",
         parent_artifact_sha256s={"onnx-fp": fp_artifact_sha256},
     )
@@ -247,7 +248,7 @@ def assemble_browser_artifact(
 
     fp_lineage = validate_artifact_lineage(
         fp_dir,
-        source_lineage_sha256=lineage.sha256,
+        source_lineage=lineage.data,
         stage="onnx-fp",
     )
     fp_artifact_sha256 = require_sha256(
@@ -259,7 +260,7 @@ def assemble_browser_artifact(
     for dtype, quantized_dir in quantized_dirs.items():
         quantized_lineage = validate_artifact_lineage(
             quantized_dir,
-            source_lineage_sha256=lineage.sha256,
+            source_lineage=lineage.data,
             stage=f"onnx-{dtype}",
             parent_artifact_sha256s={"onnx-fp": fp_artifact_sha256},
         )
@@ -293,7 +294,6 @@ def assemble_browser_artifact(
     write_artifact_lineage(
         output_dir,
         source_lineage=lineage.data,
-        source_lineage_sha256=lineage.sha256,
         stage="browser",
         parent_artifact_sha256s=browser_parent_digests,
     )
@@ -314,7 +314,7 @@ def main() -> int:
         reject_external_data_files(fp_dir)
         validate_artifact_lineage(
             fp_dir,
-            source_lineage_sha256=lineage.sha256,
+            source_lineage=lineage.data,
             stage="onnx-fp",
         )
     else:

--- a/ml/profile-qa/profile_qa/export_onnx.py
+++ b/ml/profile-qa/profile_qa/export_onnx.py
@@ -3,17 +3,36 @@
 from __future__ import annotations
 
 import argparse
-import json
 import shutil
 import subprocess
 import sys
+from dataclasses import dataclass
 from pathlib import Path
+from typing import Any
 
 from .config import MERGED_DIR, ONNX_DIR
-from .merge_adapter import LINEAGE_FILENAME
+from .provenance import (
+    ADAPTER_DIGEST_FIELD,
+    EXPECTED_LINEAGE_PIPELINE,
+    LINEAGE_FILENAME,
+    LINEAGE_SCHEMA_VERSION,
+    MERGED_DIGEST_FIELD,
+    directory_sha256,
+    file_sha256,
+    load_json_object,
+    require_sha256,
+    validate_artifact_lineage,
+    write_artifact_lineage,
+)
 from .train_lora import ensure_primary_base_model_id
 
 TEAPOT_EXPORT_TASK = "text2text-generation-with-past"
+
+
+@dataclass(frozen=True)
+class ValidatedMergeLineage:
+    data: dict[str, Any]
+    sha256: str
 
 
 def reject_external_data_files(output_dir: Path) -> None:
@@ -36,25 +55,62 @@ def venv_tool(name: str) -> str:
     return str(tool_path) if tool_path.exists() else name
 
 
-def ensure_teapot_export_model(model: str) -> None:
+def ensure_teapot_export_model(model: str) -> ValidatedMergeLineage:
     """Require a merged model directory produced by the Teapot adapter merge step."""
 
-    lineage_path = Path(model) / LINEAGE_FILENAME
+    model_path = Path(model)
+    lineage_path = model_path / LINEAGE_FILENAME
     if not lineage_path.exists():
         raise RuntimeError(
             "ONNX export is TeapotLLM-only; pass a merged model directory produced by "
             f"profile_qa.merge_adapter with {LINEAGE_FILENAME}"
         )
-    lineage = json.loads(lineage_path.read_text(encoding="utf-8"))
+    try:
+        lineage = load_json_object(lineage_path, label="model lineage")
+    except ValueError as exc:
+        raise RuntimeError(str(exc)) from exc
+    if lineage.get("schema_version") != LINEAGE_SCHEMA_VERSION:
+        raise RuntimeError(
+            f"{lineage_path} field 'schema_version' must be "
+            f"{LINEAGE_SCHEMA_VERSION}"
+        )
     base_model = lineage.get("base_model")
     if not isinstance(base_model, str):
         raise RuntimeError(f"{lineage_path} does not record a base_model")
     ensure_primary_base_model_id(base_model, source=f"{lineage_path} base_model")
+    if lineage.get("pipeline") != EXPECTED_LINEAGE_PIPELINE:
+        raise RuntimeError(
+            f"{lineage_path} does not record pipeline "
+            f"{EXPECTED_LINEAGE_PIPELINE!r}"
+        )
+    try:
+        require_sha256(
+            lineage.get(ADAPTER_DIGEST_FIELD),
+            field=ADAPTER_DIGEST_FIELD,
+            source=lineage_path,
+        )
+        recorded_merged_digest = require_sha256(
+            lineage.get(MERGED_DIGEST_FIELD),
+            field=MERGED_DIGEST_FIELD,
+            source=lineage_path,
+        )
+        actual_merged_digest = directory_sha256(
+            model_path,
+            excluded_relative_paths=frozenset({LINEAGE_FILENAME}),
+        )
+    except ValueError as exc:
+        raise RuntimeError(str(exc)) from exc
+    if recorded_merged_digest != actual_merged_digest:
+        raise RuntimeError(
+            f"{lineage_path} merged model digest does not match {model_path}: "
+            f"expected {recorded_merged_digest}, got {actual_merged_digest}"
+        )
+    return ValidatedMergeLineage(data=lineage, sha256=file_sha256(lineage_path))
 
 
-def export_onnx(model: str, output_dir: Path) -> None:
+def export_onnx(model: str, output_dir: Path) -> ValidatedMergeLineage:
     output_dir.mkdir(parents=True, exist_ok=True)
-    ensure_teapot_export_model(model)
+    lineage = ensure_teapot_export_model(model)
     run_command(
         [
             venv_tool("optimum-cli"),
@@ -68,9 +124,21 @@ def export_onnx(model: str, output_dir: Path) -> None:
         ]
     )
     reject_external_data_files(output_dir)
+    write_artifact_lineage(
+        output_dir,
+        source_lineage=lineage.data,
+        source_lineage_sha256=lineage.sha256,
+        stage="onnx-fp",
+    )
+    return lineage
 
 
-def quantize_onnx(input_dir: Path, output_dir: Path, dtype: str) -> None:
+def quantize_onnx(
+    input_dir: Path,
+    output_dir: Path,
+    dtype: str,
+    lineage: ValidatedMergeLineage,
+) -> None:
     if output_dir.exists():
         shutil.rmtree(output_dir)
     output_dir.mkdir(parents=True, exist_ok=True)
@@ -85,6 +153,8 @@ def quantize_onnx(input_dir: Path, output_dir: Path, dtype: str) -> None:
 
     weight_type = QuantType.QInt8 if dtype == "int8" else QuantType.QUInt8
     for source_path in sorted(input_dir.iterdir()):
+        if source_path.name == LINEAGE_FILENAME:
+            continue
         target_path = output_dir / source_path.name
         if source_path.suffix == ".onnx":
             quantize_dynamic(
@@ -96,6 +166,12 @@ def quantize_onnx(input_dir: Path, output_dir: Path, dtype: str) -> None:
         elif source_path.is_file():
             shutil.copy2(source_path, target_path)
     reject_external_data_files(output_dir)
+    write_artifact_lineage(
+        output_dir,
+        source_lineage=lineage.data,
+        source_lineage_sha256=lineage.sha256,
+        stage=f"onnx-{dtype}",
+    )
 
 
 def get_browser_model_paths(quantized_dir: Path) -> list[Path]:
@@ -116,8 +192,25 @@ def get_browser_model_paths(quantized_dir: Path) -> list[Path]:
     )
 
 
-def assemble_browser_artifact(fp_dir: Path, quantized_dirs: dict[str, Path], output_dir: Path) -> None:
+def assemble_browser_artifact(
+    fp_dir: Path,
+    quantized_dirs: dict[str, Path],
+    output_dir: Path,
+    lineage: ValidatedMergeLineage,
+) -> None:
     """Create a Transformers.js-compatible upload directory."""
+
+    validate_artifact_lineage(
+        fp_dir,
+        source_lineage_sha256=lineage.sha256,
+        stage="onnx-fp",
+    )
+    for dtype, quantized_dir in quantized_dirs.items():
+        validate_artifact_lineage(
+            quantized_dir,
+            source_lineage_sha256=lineage.sha256,
+            stage=f"onnx-{dtype}",
+        )
 
     if output_dir.exists():
         shutil.rmtree(output_dir)
@@ -126,7 +219,11 @@ def assemble_browser_artifact(fp_dir: Path, quantized_dirs: dict[str, Path], out
     onnx_dir.mkdir(parents=True, exist_ok=True)
 
     for source_path in sorted(fp_dir.iterdir()):
-        if source_path.is_file() and source_path.suffix != ".onnx":
+        if (
+            source_path.is_file()
+            and source_path.suffix != ".onnx"
+            and source_path.name != LINEAGE_FILENAME
+        ):
             shutil.copy2(source_path, output_dir / source_path.name)
 
     for dtype, quantized_dir in quantized_dirs.items():
@@ -136,6 +233,12 @@ def assemble_browser_artifact(fp_dir: Path, quantized_dirs: dict[str, Path], out
             shutil.copy2(model_path, onnx_dir / f"{model_path.stem}{suffix}.onnx")
 
     reject_external_data_files(output_dir)
+    write_artifact_lineage(
+        output_dir,
+        source_lineage=lineage.data,
+        source_lineage_sha256=lineage.sha256,
+        stage="browser",
+    )
 
 
 def main() -> int:
@@ -149,9 +252,15 @@ def main() -> int:
     output_dir = Path(args.output_dir)
     fp_dir = output_dir / "onnx"
     if args.skip_export:
+        lineage = ensure_teapot_export_model(args.model)
         reject_external_data_files(fp_dir)
+        validate_artifact_lineage(
+            fp_dir,
+            source_lineage_sha256=lineage.sha256,
+            stage="onnx-fp",
+        )
     else:
-        export_onnx(args.model, fp_dir)
+        lineage = export_onnx(args.model, fp_dir)
 
     quantized_dirs = {
         "int8": output_dir / "int8",
@@ -159,8 +268,13 @@ def main() -> int:
     }
     if not args.skip_quantize:
         for dtype, quantized_dir in quantized_dirs.items():
-            quantize_onnx(fp_dir, quantized_dir, dtype)
-    assemble_browser_artifact(fp_dir, quantized_dirs, output_dir / "browser")
+            quantize_onnx(fp_dir, quantized_dir, dtype, lineage)
+    assemble_browser_artifact(
+        fp_dir,
+        quantized_dirs,
+        output_dir / "browser",
+        lineage,
+    )
 
     print(f"validated browser-safe ONNX artifacts under {output_dir / 'browser'}")
     return 0

--- a/ml/profile-qa/profile_qa/export_onnx.py
+++ b/ml/profile-qa/profile_qa/export_onnx.py
@@ -14,6 +14,7 @@ from .config import MERGED_DIR, ONNX_DIR, PRIMARY_BASE_MODEL_REVISION
 from .provenance import (
     ADAPTER_CHECKPOINT_FIELD,
     ADAPTER_DIGEST_FIELD,
+    ARTIFACT_DIGEST_FIELD,
     BASE_MODEL_REVISION_FIELD,
     EXPECTED_LINEAGE_PIPELINE,
     LINEAGE_FILENAME,
@@ -121,8 +122,29 @@ def ensure_teapot_export_model(model: str) -> ValidatedMergeLineage:
 
 
 def export_onnx(model: str, output_dir: Path) -> ValidatedMergeLineage:
-    output_dir.mkdir(parents=True, exist_ok=True)
     lineage = ensure_teapot_export_model(model)
+    model_path = Path(model).resolve()
+    resolved_output_dir = output_dir.resolve()
+    if (
+        model_path == resolved_output_dir
+        or model_path in resolved_output_dir.parents
+        or resolved_output_dir in model_path.parents
+    ):
+        raise RuntimeError(
+            "full-precision export directory must not overlap the selected "
+            f"merged model directory: {resolved_output_dir} and {model_path}"
+        )
+    if output_dir.is_symlink():
+        raise RuntimeError(
+            f"full-precision export directory must not be a symlink: {output_dir}"
+        )
+    if output_dir.exists():
+        if not output_dir.is_dir():
+            raise RuntimeError(
+                f"full-precision export path is not a directory: {output_dir}"
+            )
+        shutil.rmtree(output_dir)
+    output_dir.mkdir(parents=True)
     run_command(
         [
             venv_tool("optimum-cli"),
@@ -151,6 +173,16 @@ def quantize_onnx(
     dtype: str,
     lineage: ValidatedMergeLineage,
 ) -> None:
+    fp_lineage = validate_artifact_lineage(
+        input_dir,
+        source_lineage_sha256=lineage.sha256,
+        stage="onnx-fp",
+    )
+    fp_artifact_sha256 = require_sha256(
+        fp_lineage.get(ARTIFACT_DIGEST_FIELD),
+        field=ARTIFACT_DIGEST_FIELD,
+        source=input_dir / LINEAGE_FILENAME,
+    )
     if output_dir.exists():
         shutil.rmtree(output_dir)
     output_dir.mkdir(parents=True, exist_ok=True)
@@ -183,6 +215,7 @@ def quantize_onnx(
         source_lineage=lineage.data,
         source_lineage_sha256=lineage.sha256,
         stage=f"onnx-{dtype}",
+        parent_artifact_sha256s={"onnx-fp": fp_artifact_sha256},
     )
 
 
@@ -212,16 +245,28 @@ def assemble_browser_artifact(
 ) -> None:
     """Create a Transformers.js-compatible upload directory."""
 
-    validate_artifact_lineage(
+    fp_lineage = validate_artifact_lineage(
         fp_dir,
         source_lineage_sha256=lineage.sha256,
         stage="onnx-fp",
     )
+    fp_artifact_sha256 = require_sha256(
+        fp_lineage.get(ARTIFACT_DIGEST_FIELD),
+        field=ARTIFACT_DIGEST_FIELD,
+        source=fp_dir / LINEAGE_FILENAME,
+    )
+    browser_parent_digests = {"onnx-fp": fp_artifact_sha256}
     for dtype, quantized_dir in quantized_dirs.items():
-        validate_artifact_lineage(
+        quantized_lineage = validate_artifact_lineage(
             quantized_dir,
             source_lineage_sha256=lineage.sha256,
             stage=f"onnx-{dtype}",
+            parent_artifact_sha256s={"onnx-fp": fp_artifact_sha256},
+        )
+        browser_parent_digests[f"onnx-{dtype}"] = require_sha256(
+            quantized_lineage.get(ARTIFACT_DIGEST_FIELD),
+            field=ARTIFACT_DIGEST_FIELD,
+            source=quantized_dir / LINEAGE_FILENAME,
         )
 
     if output_dir.exists():
@@ -250,6 +295,7 @@ def assemble_browser_artifact(
         source_lineage=lineage.data,
         source_lineage_sha256=lineage.sha256,
         stage="browser",
+        parent_artifact_sha256s=browser_parent_digests,
     )
 
 

--- a/ml/profile-qa/profile_qa/export_onnx.py
+++ b/ml/profile-qa/profile_qa/export_onnx.py
@@ -10,9 +10,11 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
-from .config import MERGED_DIR, ONNX_DIR
+from .config import MERGED_DIR, ONNX_DIR, PRIMARY_BASE_MODEL_REVISION
 from .provenance import (
+    ADAPTER_CHECKPOINT_FIELD,
     ADAPTER_DIGEST_FIELD,
+    BASE_MODEL_REVISION_FIELD,
     EXPECTED_LINEAGE_PIPELINE,
     LINEAGE_FILENAME,
     LINEAGE_SCHEMA_VERSION,
@@ -20,6 +22,7 @@ from .provenance import (
     directory_sha256,
     file_sha256,
     load_json_object,
+    require_checkpoint_label,
     require_sha256,
     validate_artifact_lineage,
     write_artifact_lineage,
@@ -84,6 +87,10 @@ def ensure_teapot_export_model(model: str) -> ValidatedMergeLineage:
             f"{EXPECTED_LINEAGE_PIPELINE!r}"
         )
     try:
+        require_checkpoint_label(
+            lineage.get(ADAPTER_CHECKPOINT_FIELD),
+            source=lineage_path,
+        )
         require_sha256(
             lineage.get(ADAPTER_DIGEST_FIELD),
             field=ADAPTER_DIGEST_FIELD,
@@ -94,12 +101,17 @@ def ensure_teapot_export_model(model: str) -> ValidatedMergeLineage:
             field=MERGED_DIGEST_FIELD,
             source=lineage_path,
         )
-        actual_merged_digest = directory_sha256(
-            model_path,
-            excluded_relative_paths=frozenset({LINEAGE_FILENAME}),
-        )
     except ValueError as exc:
         raise RuntimeError(str(exc)) from exc
+    if lineage.get(BASE_MODEL_REVISION_FIELD) != PRIMARY_BASE_MODEL_REVISION:
+        raise RuntimeError(
+            f"{lineage_path} field {BASE_MODEL_REVISION_FIELD!r} must be "
+            f"{PRIMARY_BASE_MODEL_REVISION!r}"
+        )
+    actual_merged_digest = directory_sha256(
+        model_path,
+        excluded_relative_paths=frozenset({LINEAGE_FILENAME}),
+    )
     if recorded_merged_digest != actual_merged_digest:
         raise RuntimeError(
             f"{lineage_path} merged model digest does not match {model_path}: "

--- a/ml/profile-qa/profile_qa/merge_adapter.py
+++ b/ml/profile-qa/profile_qa/merge_adapter.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import shutil
 from pathlib import Path
 
 from .config import (
@@ -29,6 +30,29 @@ from .train_lora import (
 )
 
 
+def prepare_merge_output_directory(adapter_path: Path, output_dir: Path) -> None:
+    """Replace a merge output tree only when it is disjoint from the adapter."""
+
+    resolved_adapter_path = adapter_path.resolve()
+    resolved_output_dir = output_dir.resolve()
+    if (
+        resolved_adapter_path == resolved_output_dir
+        or resolved_adapter_path in resolved_output_dir.parents
+        or resolved_output_dir in resolved_adapter_path.parents
+    ):
+        raise RuntimeError(
+            "merge output directory must not overlap the adapter checkpoint: "
+            f"{resolved_output_dir} and {resolved_adapter_path}"
+        )
+    if output_dir.is_symlink():
+        raise RuntimeError(f"merge output directory must not be a symlink: {output_dir}")
+    if output_dir.exists():
+        if not output_dir.is_dir():
+            raise RuntimeError(f"merge output path is not a directory: {output_dir}")
+        shutil.rmtree(output_dir)
+    output_dir.mkdir(parents=True)
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--adapter-model-id", required=True)
@@ -41,9 +65,6 @@ def main() -> int:
         from transformers import AutoModelForSeq2SeqLM, AutoTokenizer
     except ImportError as exc:
         raise RuntimeError("Install merge dependencies with pip install -r ml/profile-qa/requirements.txt") from exc
-
-    output_dir = Path(args.output_dir)
-    output_dir.mkdir(parents=True, exist_ok=True)
 
     adapter_path = require_local_model_path(
         args.adapter_model_id,
@@ -74,6 +95,8 @@ def main() -> int:
     model = PeftModel.from_pretrained(base_model, args.adapter_model_id)
     merged_model = model.merge_and_unload()
 
+    output_dir = Path(args.output_dir)
+    prepare_merge_output_directory(adapter_path, output_dir)
     merged_model.save_pretrained(output_dir, safe_serialization=True)
     tokenizer.save_pretrained(output_dir)
     (output_dir / LINEAGE_FILENAME).write_text(

--- a/ml/profile-qa/profile_qa/merge_adapter.py
+++ b/ml/profile-qa/profile_qa/merge_adapter.py
@@ -24,7 +24,7 @@ from .provenance import (
     require_checkpoint_label,
 )
 from .train_lora import (
-    ensure_primary_base_model_id,
+    ensure_adapter_base_lineage,
     require_local_model_path,
     trusted_model_load_kwargs,
 )
@@ -75,10 +75,9 @@ def main() -> int:
         source=adapter_path,
     )
     adapter_config = PeftConfig.from_pretrained(args.adapter_model_id)
-    adapter_base_model_id = str(getattr(adapter_config, "base_model_name_or_path", ""))
-    ensure_primary_base_model_id(
-        adapter_base_model_id,
-        source=f"{args.adapter_model_id} adapter base",
+    ensure_adapter_base_lineage(
+        adapter_config,
+        source=f"{args.adapter_model_id} adapter",
     )
 
     tokenizer = AutoTokenizer.from_pretrained(

--- a/ml/profile-qa/profile_qa/merge_adapter.py
+++ b/ml/profile-qa/profile_qa/merge_adapter.py
@@ -7,13 +7,19 @@ import json
 from pathlib import Path
 
 from .config import MERGED_DIR, PRIMARY_BASE_MODEL_ID
+from .provenance import (
+    ADAPTER_DIGEST_FIELD,
+    EXPECTED_LINEAGE_PIPELINE,
+    LINEAGE_FILENAME,
+    LINEAGE_SCHEMA_VERSION,
+    MERGED_DIGEST_FIELD,
+    directory_sha256,
+)
 from .train_lora import (
     ensure_primary_base_model_id,
     require_local_model_path,
     trusted_model_load_kwargs,
 )
-
-LINEAGE_FILENAME = "teapot_profile_qa_lineage.json"
 
 
 def main() -> int:
@@ -32,7 +38,10 @@ def main() -> int:
     output_dir = Path(args.output_dir)
     output_dir.mkdir(parents=True, exist_ok=True)
 
-    require_local_model_path(args.adapter_model_id, source="adapter model")
+    adapter_path = require_local_model_path(
+        args.adapter_model_id,
+        source="adapter model",
+    ).resolve()
     adapter_config = PeftConfig.from_pretrained(args.adapter_model_id)
     adapter_base_model_id = str(getattr(adapter_config, "base_model_name_or_path", ""))
     ensure_primary_base_model_id(
@@ -59,9 +68,15 @@ def main() -> int:
     (output_dir / LINEAGE_FILENAME).write_text(
         json.dumps(
             {
-                "adapter_model_id": args.adapter_model_id,
+                "schema_version": LINEAGE_SCHEMA_VERSION,
+                "adapter_model_id": Path(args.adapter_model_id).as_posix(),
+                ADAPTER_DIGEST_FIELD: directory_sha256(adapter_path),
                 "base_model": PRIMARY_BASE_MODEL_ID,
-                "pipeline": "profile-qa-teapot-lora",
+                "pipeline": EXPECTED_LINEAGE_PIPELINE,
+                MERGED_DIGEST_FIELD: directory_sha256(
+                    output_dir,
+                    excluded_relative_paths=frozenset({LINEAGE_FILENAME}),
+                ),
             },
             indent=2,
             sort_keys=True,

--- a/ml/profile-qa/profile_qa/merge_adapter.py
+++ b/ml/profile-qa/profile_qa/merge_adapter.py
@@ -6,14 +6,21 @@ import argparse
 import json
 from pathlib import Path
 
-from .config import MERGED_DIR, PRIMARY_BASE_MODEL_ID
+from .config import (
+    MERGED_DIR,
+    PRIMARY_BASE_MODEL_ID,
+    PRIMARY_BASE_MODEL_REVISION,
+)
 from .provenance import (
+    ADAPTER_CHECKPOINT_FIELD,
     ADAPTER_DIGEST_FIELD,
+    BASE_MODEL_REVISION_FIELD,
     EXPECTED_LINEAGE_PIPELINE,
     LINEAGE_FILENAME,
     LINEAGE_SCHEMA_VERSION,
     MERGED_DIGEST_FIELD,
     directory_sha256,
+    require_checkpoint_label,
 )
 from .train_lora import (
     ensure_primary_base_model_id,
@@ -42,6 +49,10 @@ def main() -> int:
         args.adapter_model_id,
         source="adapter model",
     ).resolve()
+    adapter_checkpoint = require_checkpoint_label(
+        adapter_path.name,
+        source=adapter_path,
+    )
     adapter_config = PeftConfig.from_pretrained(args.adapter_model_id)
     adapter_base_model_id = str(getattr(adapter_config, "base_model_name_or_path", ""))
     ensure_primary_base_model_id(
@@ -69,9 +80,13 @@ def main() -> int:
         json.dumps(
             {
                 "schema_version": LINEAGE_SCHEMA_VERSION,
-                "adapter_model_id": Path(args.adapter_model_id).as_posix(),
+                # This canonical path is private build metadata. Exported artifact
+                # markers retain only the portable checkpoint label and digest.
+                "adapter_model_id": str(adapter_path),
+                ADAPTER_CHECKPOINT_FIELD: adapter_checkpoint,
                 ADAPTER_DIGEST_FIELD: directory_sha256(adapter_path),
                 "base_model": PRIMARY_BASE_MODEL_ID,
+                BASE_MODEL_REVISION_FIELD: PRIMARY_BASE_MODEL_REVISION,
                 "pipeline": EXPECTED_LINEAGE_PIPELINE,
                 MERGED_DIGEST_FIELD: directory_sha256(
                     output_dir,

--- a/ml/profile-qa/profile_qa/prepare_hf_artifacts.py
+++ b/ml/profile-qa/profile_qa/prepare_hf_artifacts.py
@@ -17,20 +17,38 @@ from .config import (
     ONNX_DIR,
     PACKAGE_ROOT,
     PRIMARY_BASE_MODEL_ID,
+    PRIMARY_BASE_MODEL_REVISION,
     REPORT_DIR,
 )
 from .export_onnx import reject_external_data_files
+from .provenance import (
+    ADAPTER_DIGEST_FIELD,
+    ARTIFACT_DIGEST_FIELD,
+    EXPECTED_LINEAGE_PIPELINE,
+    LINEAGE_FILENAME,
+    LINEAGE_SCHEMA_VERSION,
+    MERGED_DIGEST_FIELD,
+    SOURCE_LINEAGE_DIGEST_FIELD,
+    directory_sha256,
+    file_sha256,
+    load_json_object,
+    require_sha256,
+    validate_artifact_lineage,
+)
 from .public_profile import PROFILE_SECTIONS
 from .validation import read_jsonl, write_jsonl
 
 DEFAULT_MODEL_REPO_ID = "justinthelaw/teapot-profile-qa-browser-1024"
 DEFAULT_DATASET_REPO_ID = "justinthelaw/profile-qa-synthetic-public-v1"
-EXPECTED_LINEAGE_PIPELINE = "profile-qa-teapot-lora"
 TRAINER_STATE_FILENAME = "trainer_state.json"
 
 
 @dataclass(frozen=True)
 class ModelProvenance:
+    adapter_model_id: str
+    adapter_model_sha256: str
+    merged_model_sha256: str
+    browser_artifact_sha256: str
     promoted_checkpoint: str
     latest_train_loss: float
     latest_train_step: int
@@ -38,14 +56,15 @@ class ModelProvenance:
     release_date: str
 
 
+@dataclass(frozen=True)
+class EvaluationReports:
+    baseline_test: dict[str, Any]
+    promoted_validation: dict[str, Any]
+    promoted_test: dict[str, Any]
+
+
 def _load_json_object(path: Path, *, label: str) -> dict[str, Any]:
-    try:
-        value = json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError) as exc:
-        raise ValueError(f"could not load required {label} {path}: {exc}") from exc
-    if not isinstance(value, dict):
-        raise ValueError(f"required {label} {path} must contain a JSON object")
-    return value
+    return load_json_object(path, label=label)
 
 
 def _required_text(value: Any, *, field: str, source: Path) -> str:
@@ -113,6 +132,7 @@ def _training_losses(
 
 def load_model_provenance(
     lineage_path: Path,
+    browser_dir: Path,
     release_date: str | None,
 ) -> ModelProvenance:
     """Load and validate model-card provenance from release inputs."""
@@ -130,6 +150,11 @@ def load_model_provenance(
         raise ValueError("release date must use YYYY-MM-DD format")
 
     lineage = _load_json_object(lineage_path, label="model lineage")
+    if lineage.get("schema_version") != LINEAGE_SCHEMA_VERSION:
+        raise ValueError(
+            f"{lineage_path} field 'schema_version' must be "
+            f"{LINEAGE_SCHEMA_VERSION}"
+        )
     adapter_model_id = _required_text(
         lineage.get("adapter_model_id"),
         field="adapter_model_id",
@@ -156,7 +181,40 @@ def load_model_provenance(
             f"{EXPECTED_LINEAGE_PIPELINE!r}, got {pipeline_name!r}"
         )
 
-    checkpoint_path = Path(adapter_model_id)
+    adapter_model_sha256 = require_sha256(
+        lineage.get(ADAPTER_DIGEST_FIELD),
+        field=ADAPTER_DIGEST_FIELD,
+        source=lineage_path,
+    )
+    merged_model_sha256 = require_sha256(
+        lineage.get(MERGED_DIGEST_FIELD),
+        field=MERGED_DIGEST_FIELD,
+        source=lineage_path,
+    )
+    source_lineage_sha256 = file_sha256(lineage_path)
+    browser_lineage = validate_artifact_lineage(
+        browser_dir,
+        source_lineage_sha256=source_lineage_sha256,
+        stage="browser",
+    )
+    for field, expected_value in lineage.items():
+        if browser_lineage.get(field) != expected_value:
+            raise ValueError(
+                f"{browser_dir / LINEAGE_FILENAME} field {field!r} does not "
+                f"match the selected merge lineage {lineage_path}"
+            )
+    if browser_lineage.get(SOURCE_LINEAGE_DIGEST_FIELD) != source_lineage_sha256:
+        raise ValueError(
+            f"{browser_dir / LINEAGE_FILENAME} does not preserve selected "
+            f"merge lineage {lineage_path}"
+        )
+    browser_artifact_sha256 = require_sha256(
+        browser_lineage.get(ARTIFACT_DIGEST_FIELD),
+        field=ARTIFACT_DIGEST_FIELD,
+        source=browser_dir / LINEAGE_FILENAME,
+    )
+
+    checkpoint_path = Path(adapter_model_id).resolve()
     if not checkpoint_path.is_dir():
         raise ValueError(
             f"adapter checkpoint from {lineage_path} does not exist: "
@@ -166,6 +224,12 @@ def load_model_provenance(
     if not checkpoint_label:
         raise ValueError(
             f"adapter checkpoint from {lineage_path} has no publishable name"
+        )
+    actual_adapter_digest = directory_sha256(checkpoint_path)
+    if actual_adapter_digest != adapter_model_sha256:
+        raise ValueError(
+            f"{lineage_path} adapter digest does not match {checkpoint_path}: "
+            f"expected {adapter_model_sha256}, got {actual_adapter_digest}"
         )
     trainer_state_path = checkpoint_path / TRAINER_STATE_FILENAME
     trainer_state = _load_json_object(
@@ -177,6 +241,10 @@ def load_model_provenance(
     )
 
     return ModelProvenance(
+        adapter_model_id=str(checkpoint_path),
+        adapter_model_sha256=adapter_model_sha256,
+        merged_model_sha256=merged_model_sha256,
+        browser_artifact_sha256=browser_artifact_sha256,
         promoted_checkpoint=checkpoint_label,
         latest_train_loss=latest_train_loss,
         latest_train_step=latest_train_step,
@@ -186,7 +254,143 @@ def load_model_provenance(
 
 
 def _load_report(path: Path) -> dict[str, Any]:
-    return json.loads(path.read_text(encoding="utf-8"))
+    return _load_json_object(path, label="evaluation report")
+
+
+def _validate_report_provenance(
+    report: dict[str, Any],
+    *,
+    report_path: Path,
+    expected_split: str,
+    model_provenance: ModelProvenance,
+    baseline: bool,
+) -> None:
+    report_provenance = report.get("provenance")
+    if not isinstance(report_provenance, dict):
+        raise ValueError(
+            f"evaluation report {report_path} is missing object field 'provenance'; "
+            "regenerate it with profile_qa.evaluate"
+        )
+    base_model = _required_text(
+        report_provenance.get("base_model"),
+        field="provenance.base_model",
+        source=report_path,
+    )
+    if base_model != PRIMARY_BASE_MODEL_ID:
+        raise ValueError(
+            f"evaluation report {report_path} must use base model "
+            f"{PRIMARY_BASE_MODEL_ID!r}, got {base_model!r}"
+        )
+    report_split = _required_text(
+        report_provenance.get("split"),
+        field="provenance.split",
+        source=report_path,
+    )
+    if report_split != expected_split:
+        raise ValueError(
+            f"evaluation report {report_path} must describe split "
+            f"{expected_split!r}, got {report_split!r}"
+        )
+
+    model_kind = _required_text(
+        report_provenance.get("model_kind"),
+        field="provenance.model_kind",
+        source=report_path,
+    )
+    if baseline:
+        if model_kind != "baseline":
+            raise ValueError(
+                f"evaluation report {report_path} must describe the baseline model"
+            )
+        if report_provenance.get("model_id") != PRIMARY_BASE_MODEL_ID:
+            raise ValueError(
+                f"evaluation report {report_path} baseline model_id must be "
+                f"{PRIMARY_BASE_MODEL_ID!r}"
+            )
+        if report_provenance.get("model_revision") != PRIMARY_BASE_MODEL_REVISION:
+            raise ValueError(
+                f"evaluation report {report_path} baseline revision must be "
+                f"{PRIMARY_BASE_MODEL_REVISION!r}"
+            )
+        return
+
+    if model_kind not in {"adapter", "merged"}:
+        raise ValueError(
+            f"evaluation report {report_path} must describe an adapter or merged model"
+        )
+    report_adapter_model_id = _required_text(
+        report_provenance.get("adapter_model_id"),
+        field="provenance.adapter_model_id",
+        source=report_path,
+    )
+    if str(Path(report_adapter_model_id).resolve()) != model_provenance.adapter_model_id:
+        raise ValueError(
+            f"evaluation report {report_path} does not match selected adapter "
+            f"{model_provenance.adapter_model_id}"
+        )
+    report_adapter_digest = require_sha256(
+        report_provenance.get(ADAPTER_DIGEST_FIELD),
+        field=f"provenance.{ADAPTER_DIGEST_FIELD}",
+        source=report_path,
+    )
+    if report_adapter_digest != model_provenance.adapter_model_sha256:
+        raise ValueError(
+            f"evaluation report {report_path} adapter digest does not match the "
+            "selected merge lineage"
+        )
+    report_model_digest = require_sha256(
+        report_provenance.get("model_sha256"),
+        field="provenance.model_sha256",
+        source=report_path,
+    )
+    expected_model_digest = (
+        model_provenance.adapter_model_sha256
+        if model_kind == "adapter"
+        else model_provenance.merged_model_sha256
+    )
+    if report_model_digest != expected_model_digest:
+        raise ValueError(
+            f"evaluation report {report_path} evaluated model digest does not "
+            "match the selected merge lineage"
+        )
+
+
+def _load_evaluation_reports(
+    args: argparse.Namespace,
+    model_provenance: ModelProvenance,
+) -> EvaluationReports:
+    baseline_path = Path(args.baseline_report)
+    validation_path = Path(args.validation_report)
+    test_path = Path(args.test_report)
+    baseline_test = _load_report(baseline_path)
+    promoted_validation = _load_report(validation_path)
+    promoted_test = _load_report(test_path)
+    _validate_report_provenance(
+        baseline_test,
+        report_path=baseline_path,
+        expected_split="test",
+        model_provenance=model_provenance,
+        baseline=True,
+    )
+    _validate_report_provenance(
+        promoted_validation,
+        report_path=validation_path,
+        expected_split="validation",
+        model_provenance=model_provenance,
+        baseline=False,
+    )
+    _validate_report_provenance(
+        promoted_test,
+        report_path=test_path,
+        expected_split="test",
+        model_provenance=model_provenance,
+        baseline=False,
+    )
+    return EvaluationReports(
+        baseline_test=baseline_test,
+        promoted_validation=promoted_validation,
+        promoted_test=promoted_test,
+    )
 
 
 def _metric(value: float) -> str:
@@ -274,6 +478,7 @@ def _write_model_card(
     latest_train_step = provenance.latest_train_step
     best_validation_eval_loss = _metric(provenance.best_validation_eval_loss)
     release_date = provenance.release_date
+    browser_artifact_sha256 = provenance.browser_artifact_sha256
     output_path.write_text(
         f"""---
 license: mit
@@ -320,9 +525,12 @@ Transformers.js ONNX files under `onnx/`:
 - `decoder_model_merged_int8.onnx`
 - `encoder_model_uint8.onnx`
 - `decoder_model_merged_uint8.onnx`
+- `{LINEAGE_FILENAME}`
 
 The export gate rejects external `.onnx.data` files so the model can be loaded
-as self-contained browser assets.
+as self-contained browser assets. The lineage marker records the selected merge
+lineage and an artifact SHA-256 of `{browser_artifact_sha256}` over the browser
+model/config payload, excluding the lineage marker and generated model card.
 
 ## How to Use
 
@@ -529,28 +737,27 @@ def prepare_model_payload(args: argparse.Namespace) -> Path:
     lineage_file = getattr(args, "lineage_file", None)
     if not isinstance(lineage_file, str) or not lineage_file.strip():
         raise ValueError("model lineage is required; pass --lineage-file")
-    provenance = load_model_provenance(
-        Path(lineage_file),
-        getattr(args, "release_date", None),
-    )
     browser_dir = Path(args.model_browser_dir)
     if not browser_dir.exists():
         raise RuntimeError(f"model browser directory does not exist: {browser_dir}")
     reject_external_data_files(browser_dir)
+    provenance = load_model_provenance(
+        Path(lineage_file),
+        browser_dir,
+        getattr(args, "release_date", None),
+    )
+    reports = _load_evaluation_reports(args, provenance)
 
     model_output_dir = Path(args.output_dir) / "model"
     _copy_tree_contents(browser_dir, model_output_dir)
 
-    baseline_test = _load_report(Path(args.baseline_report))
-    promoted_validation = _load_report(Path(args.validation_report))
-    promoted_test = _load_report(Path(args.test_report))
     _write_model_card(
         model_output_dir / "README.md",
         model_repo_id=args.model_repo_id,
         dataset_repo_id=args.dataset_repo_id,
-        baseline_test=baseline_test,
-        promoted_validation=promoted_validation,
-        promoted_test=promoted_test,
+        baseline_test=reports.baseline_test,
+        promoted_validation=reports.promoted_validation,
+        promoted_test=reports.promoted_test,
         provenance=provenance,
     )
     reject_external_data_files(model_output_dir)
@@ -618,11 +825,11 @@ def main() -> int:
     )
     parser.add_argument(
         "--validation-report",
-        default=str(REPORT_DIR / "profile_qa_eval_v5_validation.json"),
+        default=str(REPORT_DIR / "profile_qa_eval_candidate_validation.json"),
     )
     parser.add_argument(
         "--test-report",
-        default=str(REPORT_DIR / "profile_qa_eval_v5_test.json"),
+        default=str(REPORT_DIR / "profile_qa_eval_candidate_test.json"),
     )
     args = parser.parse_args()
 

--- a/ml/profile-qa/profile_qa/prepare_hf_artifacts.py
+++ b/ml/profile-qa/profile_qa/prepare_hf_artifacts.py
@@ -22,8 +22,11 @@ from .config import (
 )
 from .export_onnx import reject_external_data_files
 from .provenance import (
+    ADAPTER_CHECKPOINT_FIELD,
     ADAPTER_DIGEST_FIELD,
     ARTIFACT_DIGEST_FIELD,
+    BASE_MODEL_REVISION_FIELD,
+    DATASET_DIGEST_FIELD,
     EXPECTED_LINEAGE_PIPELINE,
     LINEAGE_FILENAME,
     LINEAGE_SCHEMA_VERSION,
@@ -32,6 +35,8 @@ from .provenance import (
     directory_sha256,
     file_sha256,
     load_json_object,
+    public_lineage_fields,
+    require_checkpoint_label,
     require_sha256,
     validate_artifact_lineage,
 )
@@ -45,8 +50,9 @@ TRAINER_STATE_FILENAME = "trainer_state.json"
 
 @dataclass(frozen=True)
 class ModelProvenance:
-    adapter_model_id: str
+    adapter_checkpoint: str
     adapter_model_sha256: str
+    base_model_revision: str
     merged_model_sha256: str
     browser_artifact_sha256: str
     promoted_checkpoint: str
@@ -160,6 +166,10 @@ def load_model_provenance(
         field="adapter_model_id",
         source=lineage_path,
     )
+    adapter_checkpoint = require_checkpoint_label(
+        lineage.get(ADAPTER_CHECKPOINT_FIELD),
+        source=lineage_path,
+    )
     base_model = _required_text(
         lineage.get("base_model"),
         field="base_model",
@@ -169,6 +179,16 @@ def load_model_provenance(
         raise ValueError(
             f"{lineage_path} field 'base_model' must be {PRIMARY_BASE_MODEL_ID!r}, "
             f"got {base_model!r}"
+        )
+    base_model_revision = _required_text(
+        lineage.get(BASE_MODEL_REVISION_FIELD),
+        field=BASE_MODEL_REVISION_FIELD,
+        source=lineage_path,
+    )
+    if base_model_revision != PRIMARY_BASE_MODEL_REVISION:
+        raise ValueError(
+            f"{lineage_path} field {BASE_MODEL_REVISION_FIELD!r} must be "
+            f"{PRIMARY_BASE_MODEL_REVISION!r}, got {base_model_revision!r}"
         )
     pipeline_name = _required_text(
         lineage.get("pipeline"),
@@ -197,7 +217,7 @@ def load_model_provenance(
         source_lineage_sha256=source_lineage_sha256,
         stage="browser",
     )
-    for field, expected_value in lineage.items():
+    for field, expected_value in public_lineage_fields(lineage).items():
         if browser_lineage.get(field) != expected_value:
             raise ValueError(
                 f"{browser_dir / LINEAGE_FILENAME} field {field!r} does not "
@@ -225,6 +245,11 @@ def load_model_provenance(
         raise ValueError(
             f"adapter checkpoint from {lineage_path} has no publishable name"
         )
+    if checkpoint_label != adapter_checkpoint:
+        raise ValueError(
+            f"{lineage_path} field {ADAPTER_CHECKPOINT_FIELD!r} must match "
+            f"adapter checkpoint directory {checkpoint_label!r}"
+        )
     actual_adapter_digest = directory_sha256(checkpoint_path)
     if actual_adapter_digest != adapter_model_sha256:
         raise ValueError(
@@ -241,8 +266,9 @@ def load_model_provenance(
     )
 
     return ModelProvenance(
-        adapter_model_id=str(checkpoint_path),
+        adapter_checkpoint=adapter_checkpoint,
         adapter_model_sha256=adapter_model_sha256,
+        base_model_revision=base_model_revision,
         merged_model_sha256=merged_model_sha256,
         browser_artifact_sha256=browser_artifact_sha256,
         promoted_checkpoint=checkpoint_label,
@@ -262,6 +288,7 @@ def _validate_report_provenance(
     *,
     report_path: Path,
     expected_split: str,
+    expected_dataset_sha256: str,
     model_provenance: ModelProvenance,
     baseline: bool,
 ) -> None:
@@ -280,6 +307,26 @@ def _validate_report_provenance(
         raise ValueError(
             f"evaluation report {report_path} must use base model "
             f"{PRIMARY_BASE_MODEL_ID!r}, got {base_model!r}"
+        )
+    report_base_revision = _required_text(
+        report_provenance.get(BASE_MODEL_REVISION_FIELD),
+        field=f"provenance.{BASE_MODEL_REVISION_FIELD}",
+        source=report_path,
+    )
+    if report_base_revision != model_provenance.base_model_revision:
+        raise ValueError(
+            f"evaluation report {report_path} base revision does not match the "
+            "selected merge lineage"
+        )
+    report_dataset_sha256 = require_sha256(
+        report_provenance.get(DATASET_DIGEST_FIELD),
+        field=f"provenance.{DATASET_DIGEST_FIELD}",
+        source=report_path,
+    )
+    if report_dataset_sha256 != expected_dataset_sha256:
+        raise ValueError(
+            f"evaluation report {report_path} dataset digest does not match "
+            "the selected dataset"
         )
     report_split = _required_text(
         report_provenance.get("split"),
@@ -307,26 +354,20 @@ def _validate_report_provenance(
                 f"evaluation report {report_path} baseline model_id must be "
                 f"{PRIMARY_BASE_MODEL_ID!r}"
             )
-        if report_provenance.get("model_revision") != PRIMARY_BASE_MODEL_REVISION:
-            raise ValueError(
-                f"evaluation report {report_path} baseline revision must be "
-                f"{PRIMARY_BASE_MODEL_REVISION!r}"
-            )
         return
 
     if model_kind not in {"adapter", "merged"}:
         raise ValueError(
             f"evaluation report {report_path} must describe an adapter or merged model"
         )
-    report_adapter_model_id = _required_text(
-        report_provenance.get("adapter_model_id"),
-        field="provenance.adapter_model_id",
+    report_adapter_checkpoint = require_checkpoint_label(
+        report_provenance.get(ADAPTER_CHECKPOINT_FIELD),
         source=report_path,
     )
-    if str(Path(report_adapter_model_id).resolve()) != model_provenance.adapter_model_id:
+    if report_adapter_checkpoint != model_provenance.adapter_checkpoint:
         raise ValueError(
-            f"evaluation report {report_path} does not match selected adapter "
-            f"{model_provenance.adapter_model_id}"
+            f"evaluation report {report_path} does not match selected checkpoint "
+            f"{model_provenance.adapter_checkpoint}"
         )
     report_adapter_digest = require_sha256(
         report_provenance.get(ADAPTER_DIGEST_FIELD),
@@ -359,6 +400,7 @@ def _load_evaluation_reports(
     args: argparse.Namespace,
     model_provenance: ModelProvenance,
 ) -> EvaluationReports:
+    dataset_sha256 = file_sha256(Path(args.dataset))
     baseline_path = Path(args.baseline_report)
     validation_path = Path(args.validation_report)
     test_path = Path(args.test_report)
@@ -369,6 +411,7 @@ def _load_evaluation_reports(
         baseline_test,
         report_path=baseline_path,
         expected_split="test",
+        expected_dataset_sha256=dataset_sha256,
         model_provenance=model_provenance,
         baseline=True,
     )
@@ -376,6 +419,7 @@ def _load_evaluation_reports(
         promoted_validation,
         report_path=validation_path,
         expected_split="validation",
+        expected_dataset_sha256=dataset_sha256,
         model_provenance=model_provenance,
         baseline=False,
     )
@@ -383,6 +427,7 @@ def _load_evaluation_reports(
         promoted_test,
         report_path=test_path,
         expected_split="test",
+        expected_dataset_sha256=dataset_sha256,
         model_provenance=model_provenance,
         baseline=False,
     )
@@ -474,6 +519,7 @@ def _write_model_card(
     provenance: ModelProvenance,
 ) -> None:
     promoted_checkpoint = provenance.promoted_checkpoint
+    base_model_revision = provenance.base_model_revision
     latest_train_loss = _metric(provenance.latest_train_loss)
     latest_train_step = provenance.latest_train_step
     best_validation_eval_loss = _metric(provenance.best_validation_eval_loss)
@@ -552,6 +598,7 @@ with signed int8 ONNX weights.
 ## Training
 
 - Base model: `teapotai/teapotllm`
+- Base model revision: `{base_model_revision}`
 - Method: local LoRA/QLoRA continuation, no full fine-tune and no cloud training
 - Promoted checkpoint: `{promoted_checkpoint}`
 - LoRA: rank 16, alpha 32, dropout 0.03, target modules `q` and `v`

--- a/ml/profile-qa/profile_qa/prepare_hf_artifacts.py
+++ b/ml/profile-qa/profile_qa/prepare_hf_artifacts.py
@@ -20,8 +20,8 @@ from .config import (
     PRIMARY_BASE_MODEL_REVISION,
     REPORT_DIR,
 )
-from .export_onnx import reject_external_data_files
 from .evaluate import (
+    EVALUATION_REPORT_FIELDS,
     GENERATION_CONFIG_FIELD,
     GENERATION_DIGEST_FIELD,
     GENERATION_SCHEMA_FIELD,
@@ -29,11 +29,13 @@ from .evaluate import (
     SCORING_DIGEST_FIELD,
     SCORING_SCHEMA_FIELD,
     SCORING_SCHEMA_VERSION,
+    evaluation_provenance_fields,
     generation_config,
     generation_implementation_sha256,
     score_predictions,
     scoring_implementation_sha256,
 )
+from .export_onnx import reject_external_data_files
 from .provenance import (
     ADAPTER_CHECKPOINT_FIELD,
     ADAPTER_DIGEST_FIELD,
@@ -48,21 +50,24 @@ from .provenance import (
     PROMPT_DIGEST_FIELD,
     SOURCE_LINEAGE_DIGEST_FIELD,
     directory_sha256,
-    file_sha256,
     load_json_object,
     public_lineage_fields,
+    public_lineage_sha256,
     require_checkpoint_label,
     require_sha256,
     validate_artifact_lineage,
 )
 from .public_profile import PROFILE_SECTIONS
-from .train_lora import evaluation_prompt_sha256
+from .train_lora import (
+    ADAPTER_CONFIG_FILENAME,
+    ensure_adapter_base_lineage,
+    evaluation_prompt_sha256,
+)
 from .validation import canonical_jsonl_sha256, read_jsonl, write_jsonl
 
 DEFAULT_MODEL_REPO_ID = "justinthelaw/teapot-profile-qa-browser-1024"
 DEFAULT_DATASET_REPO_ID = "justinthelaw/profile-qa-synthetic-public-v1"
 TRAINER_STATE_FILENAME = "trainer_state.json"
-ADAPTER_CONFIG_FILENAME = "adapter_config.json"
 BROWSER_ONNX_FILENAMES = (
     "encoder_model_int8.onnx",
     "decoder_model_merged_int8.onnx",
@@ -311,10 +316,10 @@ def load_model_provenance(
         field=MERGED_DIGEST_FIELD,
         source=lineage_path,
     )
-    source_lineage_sha256 = file_sha256(lineage_path)
+    public_lineage_digest = public_lineage_sha256(lineage)
     browser_lineage = validate_artifact_lineage(
         browser_dir,
-        source_lineage_sha256=source_lineage_sha256,
+        source_lineage=lineage,
         stage="browser",
         required_parent_stages=BROWSER_PARENT_ARTIFACT_STAGES,
     )
@@ -324,10 +329,10 @@ def load_model_provenance(
                 f"{browser_dir / LINEAGE_FILENAME} field {field!r} does not "
                 f"match the selected merge lineage {lineage_path}"
             )
-    if browser_lineage.get(SOURCE_LINEAGE_DIGEST_FIELD) != source_lineage_sha256:
+    if browser_lineage.get(SOURCE_LINEAGE_DIGEST_FIELD) != public_lineage_digest:
         raise ValueError(
             f"{browser_dir / LINEAGE_FILENAME} does not preserve selected "
-            f"merge lineage {lineage_path}"
+            f"public merge lineage {lineage_path}"
         )
     browser_artifact_sha256 = require_sha256(
         browser_lineage.get(ARTIFACT_DIGEST_FIELD),
@@ -370,6 +375,10 @@ def load_model_provenance(
         adapter_config_path,
         label="adapter configuration",
     )
+    ensure_adapter_base_lineage(
+        adapter_config,
+        source=f"{adapter_config_path} adapter",
+    )
     lora_rank, lora_alpha, lora_dropout, lora_target_modules = (
         _lora_configuration(adapter_config, source=adapter_config_path)
     )
@@ -404,12 +413,81 @@ def _validate_report_evaluation_inputs(
     expected_dataset_sha256: str,
     expected_prompt_sha256: str,
 ) -> dict[str, Any]:
+    unexpected_report_fields = sorted(set(report) - EVALUATION_REPORT_FIELDS)
+    if unexpected_report_fields:
+        raise ValueError(
+            f"evaluation report {report_path} contains non-publishable fields: "
+            f"{', '.join(unexpected_report_fields)}"
+        )
+    missing_report_fields = sorted(EVALUATION_REPORT_FIELDS - set(report))
+    if missing_report_fields:
+        raise ValueError(
+            f"evaluation report {report_path} is missing required fields: "
+            f"{', '.join(missing_report_fields)}"
+        )
     report_provenance = report.get("provenance")
     if not isinstance(report_provenance, dict):
         raise ValueError(
             f"evaluation report {report_path} is missing object field 'provenance'; "
             "regenerate it with profile_qa.evaluate"
         )
+    report_model_kind = _required_text(
+        report_provenance.get("model_kind"),
+        field="provenance.model_kind",
+        source=report_path,
+    )
+    try:
+        allowed_provenance_fields = evaluation_provenance_fields(report_model_kind)
+    except ValueError as exc:
+        raise ValueError(f"evaluation report {report_path}: {exc}") from exc
+    unexpected_provenance_fields = sorted(
+        set(report_provenance) - allowed_provenance_fields
+    )
+    if unexpected_provenance_fields:
+        raise ValueError(
+            f"evaluation report {report_path} contains non-publishable "
+            "provenance fields: "
+            f"{', '.join(unexpected_provenance_fields)}"
+        )
+    missing_provenance_fields = sorted(
+        allowed_provenance_fields - set(report_provenance)
+    )
+    if missing_provenance_fields:
+        raise ValueError(
+            f"evaluation report {report_path} is missing required provenance "
+            f"fields: {', '.join(missing_provenance_fields)}"
+        )
+    report_base_model = _required_text(
+        report_provenance.get("base_model"),
+        field="provenance.base_model",
+        source=report_path,
+    )
+    if report_base_model != PRIMARY_BASE_MODEL_ID:
+        raise ValueError(
+            f"evaluation report {report_path} must use base model "
+            f"{PRIMARY_BASE_MODEL_ID!r}, got {report_base_model!r}"
+        )
+    report_base_revision = _required_text(
+        report_provenance.get(BASE_MODEL_REVISION_FIELD),
+        field=f"provenance.{BASE_MODEL_REVISION_FIELD}",
+        source=report_path,
+    )
+    if report_base_revision != PRIMARY_BASE_MODEL_REVISION:
+        raise ValueError(
+            f"evaluation report {report_path} base revision must be "
+            f"{PRIMARY_BASE_MODEL_REVISION!r}, got {report_base_revision!r}"
+        )
+    if report_model_kind == "baseline":
+        report_model_id = _required_text(
+            report_provenance.get("model_id"),
+            field="provenance.model_id",
+            source=report_path,
+        )
+        if report_model_id != PRIMARY_BASE_MODEL_ID:
+            raise ValueError(
+                f"evaluation report {report_path} baseline model_id must be "
+                f"{PRIMARY_BASE_MODEL_ID!r}"
+            )
     report_dataset_sha256 = require_sha256(
         report_provenance.get(DATASET_DIGEST_FIELD),
         field=f"provenance.{DATASET_DIGEST_FIELD}",
@@ -569,7 +647,7 @@ def _validate_report_provenance(
     expected_prompt_sha256: str,
     model_provenance: ModelProvenance,
     baseline: bool,
-) -> None:
+) -> tuple[str, str, str] | None:
     report_provenance = _validate_report_evaluation_inputs(
         report,
         report_path=report_path,
@@ -613,12 +691,13 @@ def _validate_report_provenance(
                 f"evaluation report {report_path} baseline model_id must be "
                 f"{PRIMARY_BASE_MODEL_ID!r}"
             )
-        return
+        return None
 
-    if model_kind not in {"adapter", "merged"}:
-        raise ValueError(
-            f"evaluation report {report_path} must describe an adapter or merged model"
-        )
+    promoted_identity = _promoted_report_identity(
+        report,
+        report_path=report_path,
+    )
+    model_kind, _, report_model_digest = promoted_identity
     report_adapter_checkpoint = require_checkpoint_label(
         report_provenance.get(ADAPTER_CHECKPOINT_FIELD),
         source=report_path,
@@ -638,11 +717,6 @@ def _validate_report_provenance(
             f"evaluation report {report_path} adapter digest does not match the "
             "selected merge lineage"
         )
-    report_model_digest = require_sha256(
-        report_provenance.get("model_sha256"),
-        field="provenance.model_sha256",
-        source=report_path,
-    )
     expected_model_digest = (
         model_provenance.adapter_model_sha256
         if model_kind == "adapter"
@@ -652,6 +726,102 @@ def _validate_report_provenance(
         raise ValueError(
             f"evaluation report {report_path} evaluated model digest does not "
             "match the selected merge lineage"
+        )
+    return promoted_identity
+
+
+def _promoted_report_identity(
+    report: dict[str, Any],
+    *,
+    report_path: Path,
+) -> tuple[str, str, str]:
+    """Return one strict promoted-model representation from report provenance."""
+
+    provenance = report.get("provenance")
+    if not isinstance(provenance, dict):
+        raise ValueError(
+            f"evaluation report {report_path} is missing object field 'provenance'"
+        )
+    model_kind = _required_text(
+        provenance.get("model_kind"),
+        field="provenance.model_kind",
+        source=report_path,
+    )
+    if model_kind not in {"adapter", "merged"}:
+        raise ValueError(
+            f"evaluation report {report_path} must describe an adapter or merged model"
+        )
+    model_id = _required_text(
+        provenance.get("model_id"),
+        field="provenance.model_id",
+        source=report_path,
+    )
+    model_sha256 = require_sha256(
+        provenance.get("model_sha256"),
+        field="provenance.model_sha256",
+        source=report_path,
+    )
+    adapter_checkpoint = require_checkpoint_label(
+        provenance.get(ADAPTER_CHECKPOINT_FIELD),
+        source=report_path,
+    )
+    adapter_sha256 = require_sha256(
+        provenance.get(ADAPTER_DIGEST_FIELD),
+        field=f"provenance.{ADAPTER_DIGEST_FIELD}",
+        source=report_path,
+    )
+    expected_model_id = (
+        adapter_checkpoint if model_kind == "adapter" else "merged-model"
+    )
+    if model_id != expected_model_id:
+        raise ValueError(
+            f"evaluation report {report_path} model_id must be "
+            f"{expected_model_id!r} for model kind {model_kind!r}"
+        )
+    if model_kind == "adapter" and model_sha256 != adapter_sha256:
+        raise ValueError(
+            f"evaluation report {report_path} adapter model_sha256 must match "
+            f"provenance.{ADAPTER_DIGEST_FIELD}"
+        )
+    return model_kind, model_id, model_sha256
+
+
+def _require_baseline_report_identity(
+    report: dict[str, Any],
+    *,
+    report_path: Path,
+) -> None:
+    """Require the canonical pinned base model in the baseline report slot."""
+
+    provenance = report.get("provenance")
+    if not isinstance(provenance, dict):
+        raise ValueError(
+            f"evaluation report {report_path} is missing object field 'provenance'"
+        )
+    model_kind = _required_text(
+        provenance.get("model_kind"),
+        field="provenance.model_kind",
+        source=report_path,
+    )
+    if model_kind != "baseline":
+        raise ValueError(
+            f"evaluation report {report_path} must describe the baseline model"
+        )
+
+
+def _require_matching_promoted_report_identity(
+    validation_identity: tuple[str, str, str],
+    *,
+    validation_path: Path,
+    test_identity: tuple[str, str, str],
+    test_path: Path,
+) -> None:
+    if validation_identity != test_identity:
+        raise ValueError(
+            "promoted validation and test reports must use the same model "
+            "representation (model_kind, model_id, and model_sha256); got "
+            f"{validation_identity!r} from {validation_path} and "
+            f"{test_identity!r} from {test_path}"
         )
 
 
@@ -685,7 +855,7 @@ def _load_evaluation_reports(
         report_path=baseline_path,
         records=_split_records(dataset_records, "test"),
     )
-    _validate_report_provenance(
+    validation_identity = _validate_report_provenance(
         promoted_validation,
         report_path=validation_path,
         expected_split="validation",
@@ -699,7 +869,7 @@ def _load_evaluation_reports(
         report_path=validation_path,
         records=_split_records(dataset_records, "validation"),
     )
-    _validate_report_provenance(
+    test_identity = _validate_report_provenance(
         promoted_test,
         report_path=test_path,
         expected_split="test",
@@ -712,6 +882,14 @@ def _load_evaluation_reports(
         promoted_test,
         report_path=test_path,
         records=_split_records(dataset_records, "test"),
+    )
+    if validation_identity is None or test_identity is None:
+        raise AssertionError("promoted report validation did not return an identity")
+    _require_matching_promoted_report_identity(
+        validation_identity,
+        validation_path=validation_path,
+        test_identity=test_identity,
+        test_path=test_path,
     )
     return EvaluationReports(
         baseline_test=baseline_test,
@@ -863,10 +1041,11 @@ Transformers.js ONNX files under `onnx/`:
 - `{LINEAGE_FILENAME}`
 
 The export gate rejects external `.onnx.data` files so the model can be loaded
-as self-contained browser assets. The lineage marker records the selected merge
-lineage; the exact full-precision, int8, and uint8 parent-stage digests; and an
-artifact SHA-256 of `{browser_artifact_sha256}` over the browser model/config
-payload, excluding the lineage marker and generated model card.
+as self-contained browser assets. The lineage marker records the sanitized
+public merge lineage and its path-independent digest; the exact full-precision,
+int8, and uint8 parent-stage digests; and an artifact SHA-256 of
+`{browser_artifact_sha256}` over the browser model/config payload, excluding the
+lineage marker and generated model card.
 
 ## How to Use
 
@@ -1136,6 +1315,25 @@ def prepare_dataset_payload(args: argparse.Namespace) -> Path:
             records=split_records,
         )
         loaded_reports.append(report)
+
+    _require_baseline_report_identity(
+        loaded_reports[0],
+        report_path=report_inputs[0][0],
+    )
+    validation_identity = _promoted_report_identity(
+        loaded_reports[1],
+        report_path=report_inputs[1][0],
+    )
+    test_identity = _promoted_report_identity(
+        loaded_reports[2],
+        report_path=report_inputs[2][0],
+    )
+    _require_matching_promoted_report_identity(
+        validation_identity,
+        validation_path=report_inputs[1][0],
+        test_identity=test_identity,
+        test_path=report_inputs[2][0],
+    )
 
     dataset_output_dir = Path(args.output_dir) / "dataset"
     if dataset_output_dir.exists():

--- a/ml/profile-qa/profile_qa/prepare_hf_artifacts.py
+++ b/ml/profile-qa/profile_qa/prepare_hf_artifacts.py
@@ -31,6 +31,7 @@ from .provenance import (
     LINEAGE_FILENAME,
     LINEAGE_SCHEMA_VERSION,
     MERGED_DIGEST_FIELD,
+    PROMPT_DIGEST_FIELD,
     SOURCE_LINEAGE_DIGEST_FIELD,
     directory_sha256,
     file_sha256,
@@ -41,7 +42,8 @@ from .provenance import (
     validate_artifact_lineage,
 )
 from .public_profile import PROFILE_SECTIONS
-from .validation import read_jsonl, write_jsonl
+from .train_lora import evaluation_prompt_sha256
+from .validation import canonical_jsonl_sha256, read_jsonl, write_jsonl
 
 DEFAULT_MODEL_REPO_ID = "justinthelaw/teapot-profile-qa-browser-1024"
 DEFAULT_DATASET_REPO_ID = "justinthelaw/profile-qa-synthetic-public-v1"
@@ -283,21 +285,70 @@ def _load_report(path: Path) -> dict[str, Any]:
     return _load_json_object(path, label="evaluation report")
 
 
-def _validate_report_provenance(
+def _validate_report_evaluation_inputs(
     report: dict[str, Any],
     *,
     report_path: Path,
     expected_split: str,
     expected_dataset_sha256: str,
-    model_provenance: ModelProvenance,
-    baseline: bool,
-) -> None:
+    expected_prompt_sha256: str,
+) -> dict[str, Any]:
     report_provenance = report.get("provenance")
     if not isinstance(report_provenance, dict):
         raise ValueError(
             f"evaluation report {report_path} is missing object field 'provenance'; "
             "regenerate it with profile_qa.evaluate"
         )
+    report_dataset_sha256 = require_sha256(
+        report_provenance.get(DATASET_DIGEST_FIELD),
+        field=f"provenance.{DATASET_DIGEST_FIELD}",
+        source=report_path,
+    )
+    if report_dataset_sha256 != expected_dataset_sha256:
+        raise ValueError(
+            f"evaluation report {report_path} dataset digest does not match "
+            "the selected dataset"
+        )
+    report_prompt_sha256 = require_sha256(
+        report_provenance.get(PROMPT_DIGEST_FIELD),
+        field=f"provenance.{PROMPT_DIGEST_FIELD}",
+        source=report_path,
+    )
+    if report_prompt_sha256 != expected_prompt_sha256:
+        raise ValueError(
+            f"evaluation report {report_path} prompt digest does not match "
+            "the selected formatted prompt context"
+        )
+    report_split = _required_text(
+        report_provenance.get("split"),
+        field="provenance.split",
+        source=report_path,
+    )
+    if report_split != expected_split:
+        raise ValueError(
+            f"evaluation report {report_path} must describe split "
+            f"{expected_split!r}, got {report_split!r}"
+        )
+    return report_provenance
+
+
+def _validate_report_provenance(
+    report: dict[str, Any],
+    *,
+    report_path: Path,
+    expected_split: str,
+    expected_dataset_sha256: str,
+    expected_prompt_sha256: str,
+    model_provenance: ModelProvenance,
+    baseline: bool,
+) -> None:
+    report_provenance = _validate_report_evaluation_inputs(
+        report,
+        report_path=report_path,
+        expected_split=expected_split,
+        expected_dataset_sha256=expected_dataset_sha256,
+        expected_prompt_sha256=expected_prompt_sha256,
+    )
     base_model = _required_text(
         report_provenance.get("base_model"),
         field="provenance.base_model",
@@ -317,26 +368,6 @@ def _validate_report_provenance(
         raise ValueError(
             f"evaluation report {report_path} base revision does not match the "
             "selected merge lineage"
-        )
-    report_dataset_sha256 = require_sha256(
-        report_provenance.get(DATASET_DIGEST_FIELD),
-        field=f"provenance.{DATASET_DIGEST_FIELD}",
-        source=report_path,
-    )
-    if report_dataset_sha256 != expected_dataset_sha256:
-        raise ValueError(
-            f"evaluation report {report_path} dataset digest does not match "
-            "the selected dataset"
-        )
-    report_split = _required_text(
-        report_provenance.get("split"),
-        field="provenance.split",
-        source=report_path,
-    )
-    if report_split != expected_split:
-        raise ValueError(
-            f"evaluation report {report_path} must describe split "
-            f"{expected_split!r}, got {report_split!r}"
         )
 
     model_kind = _required_text(
@@ -400,7 +431,12 @@ def _load_evaluation_reports(
     args: argparse.Namespace,
     model_provenance: ModelProvenance,
 ) -> EvaluationReports:
-    dataset_sha256 = file_sha256(Path(args.dataset))
+    dataset_records = read_jsonl(Path(args.dataset))
+    dataset_sha256 = canonical_jsonl_sha256(dataset_records)
+    prompt_sha256_by_split = {
+        split: evaluation_prompt_sha256(_split_records(dataset_records, split))
+        for split in ("validation", "test")
+    }
     baseline_path = Path(args.baseline_report)
     validation_path = Path(args.validation_report)
     test_path = Path(args.test_report)
@@ -412,6 +448,7 @@ def _load_evaluation_reports(
         report_path=baseline_path,
         expected_split="test",
         expected_dataset_sha256=dataset_sha256,
+        expected_prompt_sha256=prompt_sha256_by_split["test"],
         model_provenance=model_provenance,
         baseline=True,
     )
@@ -420,6 +457,7 @@ def _load_evaluation_reports(
         report_path=validation_path,
         expected_split="validation",
         expected_dataset_sha256=dataset_sha256,
+        expected_prompt_sha256=prompt_sha256_by_split["validation"],
         model_provenance=model_provenance,
         baseline=False,
     )
@@ -428,6 +466,7 @@ def _load_evaluation_reports(
         report_path=test_path,
         expected_split="test",
         expected_dataset_sha256=dataset_sha256,
+        expected_prompt_sha256=prompt_sha256_by_split["test"],
         model_provenance=model_provenance,
         baseline=False,
     )
@@ -813,6 +852,26 @@ def prepare_model_payload(args: argparse.Namespace) -> Path:
 
 def prepare_dataset_payload(args: argparse.Namespace) -> Path:
     records = read_jsonl(Path(args.dataset))
+    dataset_sha256 = canonical_jsonl_sha256(records)
+    report_inputs = [
+        (Path(args.baseline_report), "test"),
+        (Path(args.validation_report), "validation"),
+        (Path(args.test_report), "test"),
+    ]
+    loaded_reports: list[dict[str, Any]] = []
+    for report_path, split in report_inputs:
+        report = _load_report(report_path)
+        _validate_report_evaluation_inputs(
+            report,
+            report_path=report_path,
+            expected_split=split,
+            expected_dataset_sha256=dataset_sha256,
+            expected_prompt_sha256=evaluation_prompt_sha256(
+                _split_records(records, split)
+            ),
+        )
+        loaded_reports.append(report)
+
     dataset_output_dir = Path(args.output_dir) / "dataset"
     if dataset_output_dir.exists():
         shutil.rmtree(dataset_output_dir)
@@ -825,16 +884,14 @@ def prepare_dataset_payload(args: argparse.Namespace) -> Path:
 
     reports_dir = dataset_output_dir / "eval_reports"
     reports_dir.mkdir(parents=True, exist_ok=True)
-    for report_path in [
-        Path(args.baseline_report),
-        Path(args.validation_report),
-        Path(args.test_report),
-    ]:
-        shutil.copy2(report_path, reports_dir / report_path.name)
+    for (report_path, _), report in zip(
+        report_inputs,
+        loaded_reports,
+        strict=True,
+    ):
+        _write_json(reports_dir / report_path.name, report)
 
-    baseline_test = _load_report(Path(args.baseline_report))
-    promoted_validation = _load_report(Path(args.validation_report))
-    promoted_test = _load_report(Path(args.test_report))
+    baseline_test, promoted_validation, promoted_test = loaded_reports
     _write_dataset_card(
         dataset_output_dir / "README.md",
         records=records,

--- a/ml/profile-qa/profile_qa/prepare_hf_artifacts.py
+++ b/ml/profile-qa/profile_qa/prepare_hf_artifacts.py
@@ -4,18 +4,185 @@ from __future__ import annotations
 
 import argparse
 import json
+import math
 import shutil
 from collections import Counter
+from dataclasses import dataclass
+from datetime import date
 from pathlib import Path
 from typing import Any
 
-from .config import DEFAULT_DATASET_PATH, ONNX_DIR, PACKAGE_ROOT, REPORT_DIR
+from .config import (
+    DEFAULT_DATASET_PATH,
+    ONNX_DIR,
+    PACKAGE_ROOT,
+    PRIMARY_BASE_MODEL_ID,
+    REPORT_DIR,
+)
 from .export_onnx import reject_external_data_files
 from .public_profile import PROFILE_SECTIONS
 from .validation import read_jsonl, write_jsonl
 
 DEFAULT_MODEL_REPO_ID = "justinthelaw/teapot-profile-qa-browser-1024"
 DEFAULT_DATASET_REPO_ID = "justinthelaw/profile-qa-synthetic-public-v1"
+EXPECTED_LINEAGE_PIPELINE = "profile-qa-teapot-lora"
+TRAINER_STATE_FILENAME = "trainer_state.json"
+
+
+@dataclass(frozen=True)
+class ModelProvenance:
+    promoted_checkpoint: str
+    latest_train_loss: float
+    latest_train_step: int
+    best_validation_eval_loss: float
+    release_date: str
+
+
+def _load_json_object(path: Path, *, label: str) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ValueError(f"could not load required {label} {path}: {exc}") from exc
+    if not isinstance(value, dict):
+        raise ValueError(f"required {label} {path} must contain a JSON object")
+    return value
+
+
+def _required_text(value: Any, *, field: str, source: Path) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{source} is missing non-empty string field {field!r}")
+    return value.strip()
+
+
+def _loss_value(value: Any, *, field: str, source: Path) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise ValueError(f"{source} field {field!r} must be a number, got {value!r}")
+    loss = float(value)
+    if not math.isfinite(loss) or loss < 0:
+        raise ValueError(
+            f"{source} field {field!r} must be a finite non-negative number, "
+            f"got {value!r}"
+        )
+    return loss
+
+
+def _training_losses(
+    trainer_state: dict[str, Any],
+    *,
+    source: Path,
+) -> tuple[float, int, float]:
+    log_history = trainer_state.get("log_history")
+    if not isinstance(log_history, list):
+        raise ValueError(f"{source} is missing list field 'log_history'")
+
+    training_entries: list[tuple[int, int, float]] = []
+    validation_losses: list[float] = []
+    for index, entry in enumerate(log_history):
+        if not isinstance(entry, dict):
+            continue
+        if "loss" in entry:
+            step = entry.get("step")
+            if isinstance(step, bool) or not isinstance(step, int) or step < 0:
+                raise ValueError(
+                    f"{source} training loss entry has invalid step {step!r}"
+                )
+            training_entries.append(
+                (
+                    step,
+                    index,
+                    _loss_value(entry["loss"], field="loss", source=source),
+                )
+            )
+        if "eval_loss" in entry:
+            validation_losses.append(
+                _loss_value(
+                    entry["eval_loss"],
+                    field="eval_loss",
+                    source=source,
+                )
+            )
+
+    if not training_entries:
+        raise ValueError(f"{source} does not contain a recorded training loss")
+    if not validation_losses:
+        raise ValueError(f"{source} does not contain a recorded validation eval loss")
+
+    latest_step, _, latest_train_loss = max(training_entries)
+    return latest_train_loss, latest_step, min(validation_losses)
+
+
+def load_model_provenance(
+    lineage_path: Path,
+    release_date: str | None,
+) -> ModelProvenance:
+    """Load and validate model-card provenance from release inputs."""
+
+    if not isinstance(release_date, str) or not release_date.strip():
+        raise ValueError(
+            "release date is required; pass --release-date in YYYY-MM-DD format"
+        )
+    normalized_release_date = release_date.strip()
+    try:
+        parsed_release_date = date.fromisoformat(normalized_release_date)
+    except ValueError as exc:
+        raise ValueError("release date must use YYYY-MM-DD format") from exc
+    if parsed_release_date.isoformat() != normalized_release_date:
+        raise ValueError("release date must use YYYY-MM-DD format")
+
+    lineage = _load_json_object(lineage_path, label="model lineage")
+    adapter_model_id = _required_text(
+        lineage.get("adapter_model_id"),
+        field="adapter_model_id",
+        source=lineage_path,
+    )
+    base_model = _required_text(
+        lineage.get("base_model"),
+        field="base_model",
+        source=lineage_path,
+    )
+    if base_model != PRIMARY_BASE_MODEL_ID:
+        raise ValueError(
+            f"{lineage_path} field 'base_model' must be {PRIMARY_BASE_MODEL_ID!r}, "
+            f"got {base_model!r}"
+        )
+    pipeline_name = _required_text(
+        lineage.get("pipeline"),
+        field="pipeline",
+        source=lineage_path,
+    )
+    if pipeline_name != EXPECTED_LINEAGE_PIPELINE:
+        raise ValueError(
+            f"{lineage_path} field 'pipeline' must be "
+            f"{EXPECTED_LINEAGE_PIPELINE!r}, got {pipeline_name!r}"
+        )
+
+    checkpoint_path = Path(adapter_model_id)
+    if not checkpoint_path.is_dir():
+        raise ValueError(
+            f"adapter checkpoint from {lineage_path} does not exist: "
+            f"{checkpoint_path}"
+        )
+    checkpoint_label = checkpoint_path.name
+    if not checkpoint_label:
+        raise ValueError(
+            f"adapter checkpoint from {lineage_path} has no publishable name"
+        )
+    trainer_state_path = checkpoint_path / TRAINER_STATE_FILENAME
+    trainer_state = _load_json_object(
+        trainer_state_path,
+        label="trainer state",
+    )
+    latest_train_loss, latest_train_step, best_validation_eval_loss = (
+        _training_losses(trainer_state, source=trainer_state_path)
+    )
+
+    return ModelProvenance(
+        promoted_checkpoint=checkpoint_label,
+        latest_train_loss=latest_train_loss,
+        latest_train_step=latest_train_step,
+        best_validation_eval_loss=best_validation_eval_loss,
+        release_date=parsed_release_date.isoformat(),
+    )
 
 
 def _load_report(path: Path) -> dict[str, Any]:
@@ -100,7 +267,13 @@ def _write_model_card(
     baseline_test: dict[str, Any],
     promoted_validation: dict[str, Any],
     promoted_test: dict[str, Any],
+    provenance: ModelProvenance,
 ) -> None:
+    promoted_checkpoint = provenance.promoted_checkpoint
+    latest_train_loss = _metric(provenance.latest_train_loss)
+    latest_train_step = provenance.latest_train_step
+    best_validation_eval_loss = _metric(provenance.best_validation_eval_loss)
+    release_date = provenance.release_date
     output_path.write_text(
         f"""---
 license: mit
@@ -172,12 +345,12 @@ with signed int8 ONNX weights.
 
 - Base model: `teapotai/teapotllm`
 - Method: local LoRA/QLoRA continuation, no full fine-tune and no cloud training
-- Promoted checkpoint: `teapot-profile-qa-lora-v5/checkpoint-40`
+- Promoted checkpoint: `{promoted_checkpoint}`
 - LoRA: rank 16, alpha 32, dropout 0.03, target modules `q` and `v`
 - 8GB-safe settings: 4-bit base loading, batch size 1, gradient accumulation 8,
   gradient checkpointing, short eval batches
-- Final continuation window: train loss 0.0330 at step 40
-- Best validation eval loss: 0.0287
+- Latest recorded train loss: {latest_train_loss} at step {latest_train_step}
+- Best recorded validation eval loss: {best_validation_eval_loss}
 
 ## Software
 
@@ -227,8 +400,8 @@ identity verification.
 
 ## Release Notes
 
-- 2026-06-19: Initial local browser profile-QA export with `int8` and `uint8`
-  ONNX variants.
+- {release_date}: Browser profile-QA export from `{promoted_checkpoint}` with
+  `int8` and `uint8` ONNX variants.
 
 ## License
 
@@ -353,6 +526,13 @@ MIT.
 
 
 def prepare_model_payload(args: argparse.Namespace) -> Path:
+    lineage_file = getattr(args, "lineage_file", None)
+    if not isinstance(lineage_file, str) or not lineage_file.strip():
+        raise ValueError("model lineage is required; pass --lineage-file")
+    provenance = load_model_provenance(
+        Path(lineage_file),
+        getattr(args, "release_date", None),
+    )
     browser_dir = Path(args.model_browser_dir)
     if not browser_dir.exists():
         raise RuntimeError(f"model browser directory does not exist: {browser_dir}")
@@ -371,6 +551,7 @@ def prepare_model_payload(args: argparse.Namespace) -> Path:
         baseline_test=baseline_test,
         promoted_validation=promoted_validation,
         promoted_test=promoted_test,
+        provenance=provenance,
     )
     reject_external_data_files(model_output_dir)
     return model_output_dir
@@ -421,6 +602,16 @@ def main() -> int:
     parser.add_argument("--output-dir", default=str(PACKAGE_ROOT / "hf"))
     parser.add_argument("--model-repo-id", default=DEFAULT_MODEL_REPO_ID)
     parser.add_argument("--dataset-repo-id", default=DEFAULT_DATASET_REPO_ID)
+    parser.add_argument(
+        "--lineage-file",
+        required=True,
+        help="lineage JSON produced by profile_qa.merge_adapter",
+    )
+    parser.add_argument(
+        "--release-date",
+        required=True,
+        help="model-card release date in YYYY-MM-DD format",
+    )
     parser.add_argument(
         "--baseline-report",
         default=str(REPORT_DIR / "profile_qa_eval_baseline_test.json"),

--- a/ml/profile-qa/profile_qa/prepare_hf_artifacts.py
+++ b/ml/profile-qa/profile_qa/prepare_hf_artifacts.py
@@ -21,11 +21,25 @@ from .config import (
     REPORT_DIR,
 )
 from .export_onnx import reject_external_data_files
+from .evaluate import (
+    GENERATION_CONFIG_FIELD,
+    GENERATION_DIGEST_FIELD,
+    GENERATION_SCHEMA_FIELD,
+    GENERATION_SCHEMA_VERSION,
+    SCORING_DIGEST_FIELD,
+    SCORING_SCHEMA_FIELD,
+    SCORING_SCHEMA_VERSION,
+    generation_config,
+    generation_implementation_sha256,
+    score_predictions,
+    scoring_implementation_sha256,
+)
 from .provenance import (
     ADAPTER_CHECKPOINT_FIELD,
     ADAPTER_DIGEST_FIELD,
     ARTIFACT_DIGEST_FIELD,
     BASE_MODEL_REVISION_FIELD,
+    BROWSER_PARENT_ARTIFACT_STAGES,
     DATASET_DIGEST_FIELD,
     EXPECTED_LINEAGE_PIPELINE,
     LINEAGE_FILENAME,
@@ -48,6 +62,13 @@ from .validation import canonical_jsonl_sha256, read_jsonl, write_jsonl
 DEFAULT_MODEL_REPO_ID = "justinthelaw/teapot-profile-qa-browser-1024"
 DEFAULT_DATASET_REPO_ID = "justinthelaw/profile-qa-synthetic-public-v1"
 TRAINER_STATE_FILENAME = "trainer_state.json"
+ADAPTER_CONFIG_FILENAME = "adapter_config.json"
+BROWSER_ONNX_FILENAMES = (
+    "encoder_model_int8.onnx",
+    "decoder_model_merged_int8.onnx",
+    "encoder_model_uint8.onnx",
+    "decoder_model_merged_uint8.onnx",
+)
 
 
 @dataclass(frozen=True)
@@ -61,6 +82,10 @@ class ModelProvenance:
     latest_train_loss: float
     latest_train_step: int
     best_validation_eval_loss: float
+    lora_rank: int
+    lora_alpha: float
+    lora_dropout: float
+    lora_target_modules: tuple[str, ...]
     release_date: str
 
 
@@ -136,6 +161,79 @@ def _training_losses(
 
     latest_step, _, latest_train_loss = max(training_entries)
     return latest_train_loss, latest_step, min(validation_losses)
+
+
+def _lora_configuration(
+    adapter_config: dict[str, Any],
+    *,
+    source: Path,
+) -> tuple[int, float, float, tuple[str, ...]]:
+    """Validate model-card LoRA claims from the digest-bound PEFT config."""
+
+    if adapter_config.get("peft_type") != "LORA":
+        raise ValueError(f"{source} field 'peft_type' must be 'LORA'")
+    if adapter_config.get("task_type") != "SEQ_2_SEQ_LM":
+        raise ValueError(f"{source} field 'task_type' must be 'SEQ_2_SEQ_LM'")
+    simple_lora_fields: dict[str, Any] = {
+        "alpha_pattern": {},
+        "bias": "none",
+        "modules_to_save": None,
+        "rank_pattern": {},
+        "use_dora": False,
+        "use_rslora": False,
+    }
+    unsupported_fields = [
+        field
+        for field, expected_value in simple_lora_fields.items()
+        if field not in adapter_config or adapter_config[field] != expected_value
+    ]
+    if unsupported_fields:
+        raise ValueError(
+            f"{source} does not describe the simple LoRA shape supported by the "
+            "generated model card; unsupported or missing fields: "
+            f"{', '.join(unsupported_fields)}"
+        )
+
+    rank = adapter_config.get("r")
+    if isinstance(rank, bool) or not isinstance(rank, int) or rank <= 0:
+        raise ValueError(f"{source} field 'r' must be a positive integer")
+
+    alpha_value = adapter_config.get("lora_alpha")
+    if isinstance(alpha_value, bool) or not isinstance(alpha_value, (int, float)):
+        raise ValueError(f"{source} field 'lora_alpha' must be a positive number")
+    alpha = float(alpha_value)
+    if not math.isfinite(alpha) or alpha <= 0:
+        raise ValueError(f"{source} field 'lora_alpha' must be a positive number")
+
+    dropout_value = adapter_config.get("lora_dropout")
+    if isinstance(dropout_value, bool) or not isinstance(dropout_value, (int, float)):
+        raise ValueError(
+            f"{source} field 'lora_dropout' must be a number from 0 through 1"
+        )
+    dropout = float(dropout_value)
+    if not math.isfinite(dropout) or not 0 <= dropout <= 1:
+        raise ValueError(
+            f"{source} field 'lora_dropout' must be a number from 0 through 1"
+        )
+
+    raw_target_modules = adapter_config.get("target_modules")
+    if (
+        not isinstance(raw_target_modules, list)
+        or not raw_target_modules
+        or any(
+            not isinstance(module, str) or not module.strip()
+            for module in raw_target_modules
+        )
+    ):
+        raise ValueError(
+            f"{source} field 'target_modules' must be a non-empty list of strings"
+        )
+    target_modules = tuple(sorted(raw_target_modules))
+    if len(set(target_modules)) != len(target_modules):
+        raise ValueError(
+            f"{source} field 'target_modules' must contain unique non-empty strings"
+        )
+    return rank, alpha, dropout, target_modules
 
 
 def load_model_provenance(
@@ -218,6 +316,7 @@ def load_model_provenance(
         browser_dir,
         source_lineage_sha256=source_lineage_sha256,
         stage="browser",
+        required_parent_stages=BROWSER_PARENT_ARTIFACT_STAGES,
     )
     for field, expected_value in public_lineage_fields(lineage).items():
         if browser_lineage.get(field) != expected_value:
@@ -266,6 +365,14 @@ def load_model_provenance(
     latest_train_loss, latest_train_step, best_validation_eval_loss = (
         _training_losses(trainer_state, source=trainer_state_path)
     )
+    adapter_config_path = checkpoint_path / ADAPTER_CONFIG_FILENAME
+    adapter_config = _load_json_object(
+        adapter_config_path,
+        label="adapter configuration",
+    )
+    lora_rank, lora_alpha, lora_dropout, lora_target_modules = (
+        _lora_configuration(adapter_config, source=adapter_config_path)
+    )
 
     return ModelProvenance(
         adapter_checkpoint=adapter_checkpoint,
@@ -277,6 +384,10 @@ def load_model_provenance(
         latest_train_loss=latest_train_loss,
         latest_train_step=latest_train_step,
         best_validation_eval_loss=best_validation_eval_loss,
+        lora_rank=lora_rank,
+        lora_alpha=lora_alpha,
+        lora_dropout=lora_dropout,
+        lora_target_modules=lora_target_modules,
         release_date=parsed_release_date.isoformat(),
     )
 
@@ -329,7 +440,124 @@ def _validate_report_evaluation_inputs(
             f"evaluation report {report_path} must describe split "
             f"{expected_split!r}, got {report_split!r}"
         )
+    report_scoring_schema = report_provenance.get(SCORING_SCHEMA_FIELD)
+    if (
+        isinstance(report_scoring_schema, bool)
+        or not isinstance(report_scoring_schema, int)
+        or report_scoring_schema != SCORING_SCHEMA_VERSION
+    ):
+        raise ValueError(
+            f"evaluation report {report_path} field "
+            f"provenance.{SCORING_SCHEMA_FIELD} must be "
+            f"{SCORING_SCHEMA_VERSION}; regenerate it with profile_qa.evaluate"
+        )
+    report_scoring_digest = require_sha256(
+        report_provenance.get(SCORING_DIGEST_FIELD),
+        field=f"provenance.{SCORING_DIGEST_FIELD}",
+        source=report_path,
+    )
+    expected_scoring_digest = scoring_implementation_sha256()
+    if report_scoring_digest != expected_scoring_digest:
+        raise ValueError(
+            f"evaluation report {report_path} scoring implementation does not "
+            "match the current evaluator; regenerate it with profile_qa.evaluate"
+        )
+    report_generation_schema = report_provenance.get(GENERATION_SCHEMA_FIELD)
+    if (
+        isinstance(report_generation_schema, bool)
+        or not isinstance(report_generation_schema, int)
+        or report_generation_schema != GENERATION_SCHEMA_VERSION
+    ):
+        raise ValueError(
+            f"evaluation report {report_path} field "
+            f"provenance.{GENERATION_SCHEMA_FIELD} must be "
+            f"{GENERATION_SCHEMA_VERSION}; regenerate it with profile_qa.evaluate"
+        )
+    report_generation_digest = require_sha256(
+        report_provenance.get(GENERATION_DIGEST_FIELD),
+        field=f"provenance.{GENERATION_DIGEST_FIELD}",
+        source=report_path,
+    )
+    if report_generation_digest != generation_implementation_sha256():
+        raise ValueError(
+            f"evaluation report {report_path} generation implementation does "
+            "not match the current evaluator; regenerate its predictions"
+        )
+    report_generation_config = report_provenance.get(GENERATION_CONFIG_FIELD)
+    if (
+        not isinstance(report_generation_config, dict)
+        or report_generation_config != generation_config()
+    ):
+        raise ValueError(
+            f"evaluation report {report_path} generation configuration does "
+            "not match the current evaluator; regenerate its predictions"
+        )
     return report_provenance
+
+
+def _validate_report_scores(
+    report: dict[str, Any],
+    *,
+    report_path: Path,
+    records: list[dict[str, Any]],
+) -> None:
+    """Recompute a report from its saved predictions using the current scorer."""
+
+    raw_report_records = report.get("records")
+    if not isinstance(raw_report_records, list):
+        raise ValueError(
+            f"evaluation report {report_path} is missing list field 'records'; "
+            "regenerate it with profile_qa.evaluate"
+        )
+    predictions: dict[str, str] = {}
+    for entry in raw_report_records:
+        if not isinstance(entry, dict):
+            raise ValueError(
+                f"evaluation report {report_path} field 'records' must contain "
+                "objects"
+            )
+        record_id = entry.get("id")
+        prediction = entry.get("prediction")
+        if (
+            not isinstance(record_id, str)
+            or not record_id.strip()
+            or not isinstance(prediction, str)
+            or record_id in predictions
+        ):
+            raise ValueError(
+                f"evaluation report {report_path} must contain one string "
+                "prediction for every unique record ID"
+            )
+        predictions[record_id] = prediction
+
+    expected_ids = [str(record.get("id", "")) for record in records]
+    if (
+        any(not record_id for record_id in expected_ids)
+        or len(expected_ids) != len(set(expected_ids))
+        or set(predictions) != set(expected_ids)
+    ):
+        raise ValueError(
+            f"evaluation report {report_path} predictions do not match the "
+            "selected dataset split"
+        )
+
+    recomputed = score_predictions(records, predictions)
+    score_fields = (
+        "macro",
+        "by_task",
+        "refusal_accuracy",
+        "multi_turn_accuracy",
+        "records",
+    )
+    mismatched_fields = [
+        field for field in score_fields if report.get(field) != recomputed[field]
+    ]
+    if mismatched_fields:
+        raise ValueError(
+            f"evaluation report {report_path} scores do not match its saved "
+            "predictions under the current scoring implementation; mismatched "
+            f"fields: {', '.join(mismatched_fields)}"
+        )
 
 
 def _validate_report_provenance(
@@ -452,6 +680,11 @@ def _load_evaluation_reports(
         model_provenance=model_provenance,
         baseline=True,
     )
+    _validate_report_scores(
+        baseline_test,
+        report_path=baseline_path,
+        records=_split_records(dataset_records, "test"),
+    )
     _validate_report_provenance(
         promoted_validation,
         report_path=validation_path,
@@ -460,6 +693,11 @@ def _load_evaluation_reports(
         expected_prompt_sha256=prompt_sha256_by_split["validation"],
         model_provenance=model_provenance,
         baseline=False,
+    )
+    _validate_report_scores(
+        promoted_validation,
+        report_path=validation_path,
+        records=_split_records(dataset_records, "validation"),
     )
     _validate_report_provenance(
         promoted_test,
@@ -470,6 +708,11 @@ def _load_evaluation_reports(
         model_provenance=model_provenance,
         baseline=False,
     )
+    _validate_report_scores(
+        promoted_test,
+        report_path=test_path,
+        records=_split_records(dataset_records, "test"),
+    )
     return EvaluationReports(
         baseline_test=baseline_test,
         promoted_validation=promoted_validation,
@@ -479,6 +722,10 @@ def _load_evaluation_reports(
 
 def _metric(value: float) -> str:
     return f"{value:.4f}"
+
+
+def _plain_number(value: float) -> str:
+    return f"{value:g}"
 
 
 def _copy_tree_contents(source_dir: Path, target_dir: Path) -> None:
@@ -564,6 +811,9 @@ def _write_model_card(
     best_validation_eval_loss = _metric(provenance.best_validation_eval_loss)
     release_date = provenance.release_date
     browser_artifact_sha256 = provenance.browser_artifact_sha256
+    lora_target_modules = ", ".join(
+        f"`{module}`" for module in provenance.lora_target_modules
+    )
     output_path.write_text(
         f"""---
 license: mit
@@ -587,7 +837,7 @@ metrics:
 
 ## Description
 
-This model is a browser-oriented ONNX export of a local LoRA continuation from
+This model is a browser-oriented ONNX export of a PEFT LoRA adapter merged into
 `teapotai/teapotllm`. It is tuned for public resume/profile Q&A prompts that fit
 within a 1024-token browser context budget.
 
@@ -597,8 +847,8 @@ the browser runtime still loads this T5-style export with the Transformers.js
 
 The target use case is a static portfolio or resume site that runs inference in
 the browser with Transformers.js, without API routes, hosted inference, server
-actions, or cloud training. The profile schema is intentionally generic for repo
-reuse: `identity`, `current_role`, `experience`, `projects`, `education`,
+actions, or runtime model services. The profile schema is intentionally generic
+for repo reuse: `identity`, `current_role`, `experience`, `projects`, `education`,
 `recommendations`, `skills`, and `interests`.
 
 ## Browser Artifacts
@@ -614,8 +864,9 @@ Transformers.js ONNX files under `onnx/`:
 
 The export gate rejects external `.onnx.data` files so the model can be loaded
 as self-contained browser assets. The lineage marker records the selected merge
-lineage and an artifact SHA-256 of `{browser_artifact_sha256}` over the browser
-model/config payload, excluding the lineage marker and generated model card.
+lineage; the exact full-precision, int8, and uint8 parent-stage digests; and an
+artifact SHA-256 of `{browser_artifact_sha256}` over the browser model/config
+payload, excluding the lineage marker and generated model card.
 
 ## How to Use
 
@@ -638,11 +889,11 @@ with signed int8 ONNX weights.
 
 - Base model: `teapotai/teapotllm`
 - Base model revision: `{base_model_revision}`
-- Method: local LoRA/QLoRA continuation, no full fine-tune and no cloud training
+- Method represented by the selected adapter: PEFT LoRA
 - Promoted checkpoint: `{promoted_checkpoint}`
-- LoRA: rank 16, alpha 32, dropout 0.03, target modules `q` and `v`
-- 8GB-safe settings: 4-bit base loading, batch size 1, gradient accumulation 8,
-  gradient checkpointing, short eval batches
+- LoRA: rank {provenance.lora_rank}, alpha {_plain_number(provenance.lora_alpha)},
+  dropout {_plain_number(provenance.lora_dropout)}, target modules
+  {lora_target_modules}
 - Latest recorded train loss: {latest_train_loss} at step {latest_train_step}
 - Best recorded validation eval loss: {best_validation_eval_loss}
 
@@ -656,10 +907,10 @@ with signed int8 ONNX weights.
 
 ## Hardware
 
-Training was designed for a local 8GB NVIDIA laptop GPU profile, with GPU
-health checks for `nvidia-smi`, `/dev/nvidia*`, CUDA-enabled PyTorch, and
-`torch.cuda.is_available()`. Export and card preparation can run on CPU after
-training completes.
+The selected checkpoint does not preserve trustworthy hardware, optimizer,
+quantization, or effective-batch-size provenance. Those run-specific claims are
+therefore omitted from this generated card. Export and card preparation can run
+on CPU after training completes.
 
 ## Evaluation
 
@@ -832,6 +1083,16 @@ def prepare_model_payload(args: argparse.Namespace) -> Path:
         browser_dir,
         getattr(args, "release_date", None),
     )
+    missing_browser_artifacts = [
+        filename
+        for filename in BROWSER_ONNX_FILENAMES
+        if not (browser_dir / "onnx" / filename).is_file()
+    ]
+    if missing_browser_artifacts:
+        raise ValueError(
+            f"model browser directory {browser_dir} is missing published ONNX "
+            f"artifacts: {', '.join(missing_browser_artifacts)}"
+        )
     reports = _load_evaluation_reports(args, provenance)
 
     model_output_dir = Path(args.output_dir) / "model"
@@ -861,14 +1122,18 @@ def prepare_dataset_payload(args: argparse.Namespace) -> Path:
     loaded_reports: list[dict[str, Any]] = []
     for report_path, split in report_inputs:
         report = _load_report(report_path)
+        split_records = _split_records(records, split)
         _validate_report_evaluation_inputs(
             report,
             report_path=report_path,
             expected_split=split,
             expected_dataset_sha256=dataset_sha256,
-            expected_prompt_sha256=evaluation_prompt_sha256(
-                _split_records(records, split)
-            ),
+            expected_prompt_sha256=evaluation_prompt_sha256(split_records),
+        )
+        _validate_report_scores(
+            report,
+            report_path=report_path,
+            records=split_records,
         )
         loaded_reports.append(report)
 

--- a/ml/profile-qa/profile_qa/provenance.py
+++ b/ml/profile-qa/profile_qa/provenance.py
@@ -4,17 +4,37 @@ from __future__ import annotations
 
 import hashlib
 import json
+import re
 from pathlib import Path
 from typing import Any
 
 LINEAGE_FILENAME = "teapot_profile_qa_lineage.json"
 LINEAGE_SCHEMA_VERSION = 1
 EXPECTED_LINEAGE_PIPELINE = "profile-qa-teapot-lora"
+ADAPTER_CHECKPOINT_FIELD = "adapter_checkpoint"
 ADAPTER_DIGEST_FIELD = "adapter_model_sha256"
+BASE_MODEL_REVISION_FIELD = "base_model_revision"
 MERGED_DIGEST_FIELD = "merged_model_sha256"
+DATASET_DIGEST_FIELD = "dataset_sha256"
 SOURCE_LINEAGE_DIGEST_FIELD = "source_lineage_sha256"
 ARTIFACT_STAGE_FIELD = "artifact_stage"
 ARTIFACT_DIGEST_FIELD = "artifact_sha256"
+PUBLIC_LINEAGE_FIELDS = frozenset(
+    {
+        "schema_version",
+        ADAPTER_CHECKPOINT_FIELD,
+        ADAPTER_DIGEST_FIELD,
+        "base_model",
+        BASE_MODEL_REVISION_FIELD,
+        "pipeline",
+        MERGED_DIGEST_FIELD,
+    }
+)
+ARTIFACT_LINEAGE_FIELDS = PUBLIC_LINEAGE_FIELDS | {
+    SOURCE_LINEAGE_DIGEST_FIELD,
+    ARTIFACT_STAGE_FIELD,
+    ARTIFACT_DIGEST_FIELD,
+}
 
 
 def _artifact_digest_exclusions(stage: str) -> frozenset[str]:
@@ -93,6 +113,32 @@ def require_sha256(value: Any, *, field: str, source: Path) -> str:
     return normalized
 
 
+def require_checkpoint_label(value: Any, *, source: Path) -> str:
+    """Require a portable checkpoint label rather than a workstation path."""
+
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(
+            f"{source} is missing non-empty string field {ADAPTER_CHECKPOINT_FIELD!r}"
+        )
+    label = value.strip()
+    if re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9._-]{0,127}", label) is None:
+        raise ValueError(
+            f"{source} field {ADAPTER_CHECKPOINT_FIELD!r} must be a portable "
+            "ASCII label"
+        )
+    return label
+
+
+def public_lineage_fields(source_lineage: dict[str, Any]) -> dict[str, Any]:
+    """Remove host-local locators before lineage enters publishable artifacts."""
+
+    return {
+        key: value
+        for key, value in source_lineage.items()
+        if key in PUBLIC_LINEAGE_FIELDS
+    }
+
+
 def write_artifact_lineage(
     artifact_dir: Path,
     *,
@@ -103,7 +149,7 @@ def write_artifact_lineage(
     """Write lineage metadata bound to an artifact directory's exact contents."""
 
     lineage_path = artifact_dir / LINEAGE_FILENAME
-    payload = dict(source_lineage)
+    payload = public_lineage_fields(source_lineage)
     payload[SOURCE_LINEAGE_DIGEST_FIELD] = source_lineage_sha256
     payload[ARTIFACT_STAGE_FIELD] = stage
     payload[ARTIFACT_DIGEST_FIELD] = directory_sha256(
@@ -127,6 +173,12 @@ def validate_artifact_lineage(
 
     lineage_path = artifact_dir / LINEAGE_FILENAME
     lineage = load_json_object(lineage_path, label=f"{stage} artifact lineage")
+    unexpected_fields = sorted(set(lineage) - ARTIFACT_LINEAGE_FIELDS)
+    if unexpected_fields:
+        raise ValueError(
+            f"{lineage_path} contains non-publishable fields: "
+            f"{', '.join(unexpected_fields)}"
+        )
     recorded_source_digest = require_sha256(
         lineage.get(SOURCE_LINEAGE_DIGEST_FIELD),
         field=SOURCE_LINEAGE_DIGEST_FIELD,

--- a/ml/profile-qa/profile_qa/provenance.py
+++ b/ml/profile-qa/profile_qa/provenance.py
@@ -16,6 +16,7 @@ ADAPTER_DIGEST_FIELD = "adapter_model_sha256"
 BASE_MODEL_REVISION_FIELD = "base_model_revision"
 MERGED_DIGEST_FIELD = "merged_model_sha256"
 DATASET_DIGEST_FIELD = "dataset_sha256"
+PROMPT_DIGEST_FIELD = "evaluation_prompt_sha256"
 SOURCE_LINEAGE_DIGEST_FIELD = "source_lineage_sha256"
 ARTIFACT_STAGE_FIELD = "artifact_stage"
 ARTIFACT_DIGEST_FIELD = "artifact_sha256"
@@ -68,6 +69,18 @@ def file_sha256(path: Path) -> str:
     except OSError as exc:
         raise ValueError(f"could not hash required file {path}: {exc}") from exc
     return digest.hexdigest()
+
+
+def canonical_json_sha256(value: Any) -> str:
+    """Hash a JSON value with deterministic encoding and no layout variance."""
+
+    encoded = json.dumps(
+        value,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
 
 
 def directory_sha256(

--- a/ml/profile-qa/profile_qa/provenance.py
+++ b/ml/profile-qa/profile_qa/provenance.py
@@ -184,19 +184,43 @@ def public_lineage_fields(source_lineage: dict[str, Any]) -> dict[str, Any]:
     }
 
 
+def public_lineage_sha256(source_lineage: dict[str, Any]) -> str:
+    """Hash only publishable lineage so private paths cannot affect markers."""
+
+    return canonical_json_sha256(public_lineage_fields(source_lineage))
+
+
+def _required_public_lineage_fields(
+    lineage: dict[str, Any],
+    *,
+    source: Path,
+) -> dict[str, Any]:
+    """Return a complete public projection or reject an incomplete lineage."""
+
+    missing_fields = sorted(PUBLIC_LINEAGE_FIELDS - set(lineage))
+    if missing_fields:
+        raise ValueError(
+            f"{source} is missing required public lineage fields: "
+            f"{', '.join(missing_fields)}"
+        )
+    return public_lineage_fields(lineage)
+
+
 def write_artifact_lineage(
     artifact_dir: Path,
     *,
     source_lineage: dict[str, Any],
-    source_lineage_sha256: str,
     stage: str,
     parent_artifact_sha256s: dict[str, str] | None = None,
 ) -> Path:
-    """Write lineage metadata bound to an artifact directory's exact contents."""
+    """Write artifact metadata bound to sanitized lineage and exact contents."""
 
     lineage_path = artifact_dir / LINEAGE_FILENAME
-    payload = public_lineage_fields(source_lineage)
-    payload[SOURCE_LINEAGE_DIGEST_FIELD] = source_lineage_sha256
+    payload = _required_public_lineage_fields(
+        source_lineage,
+        source=lineage_path,
+    )
+    payload[SOURCE_LINEAGE_DIGEST_FIELD] = canonical_json_sha256(payload)
     payload[ARTIFACT_STAGE_FIELD] = stage
     if parent_artifact_sha256s is not None:
         payload[PARENT_ARTIFACT_DIGESTS_FIELD] = require_artifact_digest_map(
@@ -218,12 +242,12 @@ def write_artifact_lineage(
 def validate_artifact_lineage(
     artifact_dir: Path,
     *,
-    source_lineage_sha256: str,
+    source_lineage: dict[str, Any],
     stage: str,
     parent_artifact_sha256s: dict[str, str] | None = None,
     required_parent_stages: frozenset[str] = frozenset(),
 ) -> dict[str, Any]:
-    """Verify that an artifact marker matches its source lineage and files."""
+    """Verify a marker against sanitized source lineage and artifact files."""
 
     lineage_path = artifact_dir / LINEAGE_FILENAME
     lineage = load_json_object(lineage_path, label=f"{stage} artifact lineage")
@@ -233,15 +257,28 @@ def validate_artifact_lineage(
             f"{lineage_path} contains non-publishable fields: "
             f"{', '.join(unexpected_fields)}"
         )
-    recorded_source_digest = require_sha256(
+    expected_public_lineage = _required_public_lineage_fields(
+        source_lineage,
+        source=lineage_path,
+    )
+    recorded_public_lineage = _required_public_lineage_fields(
+        lineage,
+        source=lineage_path,
+    )
+    if recorded_public_lineage != expected_public_lineage:
+        raise ValueError(
+            f"{lineage_path} public fields do not match the selected merge lineage"
+        )
+    recorded_public_digest = require_sha256(
         lineage.get(SOURCE_LINEAGE_DIGEST_FIELD),
         field=SOURCE_LINEAGE_DIGEST_FIELD,
         source=lineage_path,
     )
-    if recorded_source_digest != source_lineage_sha256:
+    expected_public_digest = canonical_json_sha256(expected_public_lineage)
+    if recorded_public_digest != expected_public_digest:
         raise ValueError(
-            f"{lineage_path} does not match the selected merge lineage: "
-            f"expected {source_lineage_sha256}, got {recorded_source_digest}"
+            f"{lineage_path} does not match the selected public merge lineage: "
+            f"expected {expected_public_digest}, got {recorded_public_digest}"
         )
     recorded_stage = lineage.get(ARTIFACT_STAGE_FIELD)
     if recorded_stage != stage:

--- a/ml/profile-qa/profile_qa/provenance.py
+++ b/ml/profile-qa/profile_qa/provenance.py
@@ -20,6 +20,10 @@ PROMPT_DIGEST_FIELD = "evaluation_prompt_sha256"
 SOURCE_LINEAGE_DIGEST_FIELD = "source_lineage_sha256"
 ARTIFACT_STAGE_FIELD = "artifact_stage"
 ARTIFACT_DIGEST_FIELD = "artifact_sha256"
+PARENT_ARTIFACT_DIGESTS_FIELD = "parent_artifact_sha256s"
+BROWSER_PARENT_ARTIFACT_STAGES = frozenset(
+    {"onnx-fp", "onnx-int8", "onnx-uint8"}
+)
 PUBLIC_LINEAGE_FIELDS = frozenset(
     {
         "schema_version",
@@ -35,6 +39,7 @@ ARTIFACT_LINEAGE_FIELDS = PUBLIC_LINEAGE_FIELDS | {
     SOURCE_LINEAGE_DIGEST_FIELD,
     ARTIFACT_STAGE_FIELD,
     ARTIFACT_DIGEST_FIELD,
+    PARENT_ARTIFACT_DIGESTS_FIELD,
 }
 
 
@@ -142,6 +147,33 @@ def require_checkpoint_label(value: Any, *, source: Path) -> str:
     return label
 
 
+def require_artifact_digest_map(
+    value: Any,
+    *,
+    field: str,
+    source: Path,
+) -> dict[str, str]:
+    """Validate a non-empty mapping from portable stage labels to digests."""
+
+    if not isinstance(value, dict) or not value:
+        raise ValueError(f"{source} field {field!r} must be a non-empty object")
+    normalized: dict[str, str] = {}
+    for stage, digest in value.items():
+        if (
+            not isinstance(stage, str)
+            or re.fullmatch(r"[a-z0-9][a-z0-9-]{0,63}", stage) is None
+        ):
+            raise ValueError(
+                f"{source} field {field!r} contains invalid stage label {stage!r}"
+            )
+        normalized[stage] = require_sha256(
+            digest,
+            field=f"{field}.{stage}",
+            source=source,
+        )
+    return normalized
+
+
 def public_lineage_fields(source_lineage: dict[str, Any]) -> dict[str, Any]:
     """Remove host-local locators before lineage enters publishable artifacts."""
 
@@ -158,6 +190,7 @@ def write_artifact_lineage(
     source_lineage: dict[str, Any],
     source_lineage_sha256: str,
     stage: str,
+    parent_artifact_sha256s: dict[str, str] | None = None,
 ) -> Path:
     """Write lineage metadata bound to an artifact directory's exact contents."""
 
@@ -165,6 +198,12 @@ def write_artifact_lineage(
     payload = public_lineage_fields(source_lineage)
     payload[SOURCE_LINEAGE_DIGEST_FIELD] = source_lineage_sha256
     payload[ARTIFACT_STAGE_FIELD] = stage
+    if parent_artifact_sha256s is not None:
+        payload[PARENT_ARTIFACT_DIGESTS_FIELD] = require_artifact_digest_map(
+            parent_artifact_sha256s,
+            field=PARENT_ARTIFACT_DIGESTS_FIELD,
+            source=lineage_path,
+        )
     payload[ARTIFACT_DIGEST_FIELD] = directory_sha256(
         artifact_dir,
         excluded_relative_paths=_artifact_digest_exclusions(stage),
@@ -181,6 +220,8 @@ def validate_artifact_lineage(
     *,
     source_lineage_sha256: str,
     stage: str,
+    parent_artifact_sha256s: dict[str, str] | None = None,
+    required_parent_stages: frozenset[str] = frozenset(),
 ) -> dict[str, Any]:
     """Verify that an artifact marker matches its source lineage and files."""
 
@@ -208,6 +249,46 @@ def validate_artifact_lineage(
             f"{lineage_path} field {ARTIFACT_STAGE_FIELD!r} must be {stage!r}, "
             f"got {recorded_stage!r}"
         )
+    recorded_parent_digests = lineage.get(PARENT_ARTIFACT_DIGESTS_FIELD)
+    if parent_artifact_sha256s is None and not required_parent_stages:
+        if recorded_parent_digests is not None:
+            raise ValueError(
+                f"{lineage_path} unexpectedly records "
+                f"{PARENT_ARTIFACT_DIGESTS_FIELD!r} for stage {stage!r}"
+            )
+    else:
+        normalized_parent_digests = require_artifact_digest_map(
+            recorded_parent_digests,
+            field=PARENT_ARTIFACT_DIGESTS_FIELD,
+            source=lineage_path,
+        )
+        if parent_artifact_sha256s is not None:
+            expected_parent_digests = require_artifact_digest_map(
+                parent_artifact_sha256s,
+                field=PARENT_ARTIFACT_DIGESTS_FIELD,
+                source=lineage_path,
+            )
+        else:
+            expected_parent_digests = normalized_parent_digests
+        expected_parent_stages = (
+            set(expected_parent_digests)
+            if not required_parent_stages
+            else set(required_parent_stages)
+        )
+        if set(normalized_parent_digests) != expected_parent_stages:
+            raise ValueError(
+                f"{lineage_path} parent artifact stages do not match stage "
+                f"{stage!r}: expected {sorted(expected_parent_stages)}, got "
+                f"{sorted(normalized_parent_digests)}"
+            )
+        if (
+            parent_artifact_sha256s is not None
+            and normalized_parent_digests != expected_parent_digests
+        ):
+            raise ValueError(
+                f"{lineage_path} parent artifact digests do not match the "
+                "selected export stages"
+            )
     recorded_artifact_digest = require_sha256(
         lineage.get(ARTIFACT_DIGEST_FIELD),
         field=ARTIFACT_DIGEST_FIELD,

--- a/ml/profile-qa/profile_qa/provenance.py
+++ b/ml/profile-qa/profile_qa/provenance.py
@@ -1,0 +1,160 @@
+"""Deterministic lineage and artifact-digest helpers for profile-QA releases."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+LINEAGE_FILENAME = "teapot_profile_qa_lineage.json"
+LINEAGE_SCHEMA_VERSION = 1
+EXPECTED_LINEAGE_PIPELINE = "profile-qa-teapot-lora"
+ADAPTER_DIGEST_FIELD = "adapter_model_sha256"
+MERGED_DIGEST_FIELD = "merged_model_sha256"
+SOURCE_LINEAGE_DIGEST_FIELD = "source_lineage_sha256"
+ARTIFACT_STAGE_FIELD = "artifact_stage"
+ARTIFACT_DIGEST_FIELD = "artifact_sha256"
+
+
+def _artifact_digest_exclusions(stage: str) -> frozenset[str]:
+    excluded = {LINEAGE_FILENAME}
+    if stage == "browser":
+        # Preparation generates the release-specific model card after export.
+        excluded.add("README.md")
+    return frozenset(excluded)
+
+
+def load_json_object(path: Path, *, label: str) -> dict[str, Any]:
+    """Read a required JSON object with a release-oriented error message."""
+
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ValueError(f"could not load required {label} {path}: {exc}") from exc
+    if not isinstance(value, dict):
+        raise ValueError(f"required {label} {path} must contain a JSON object")
+    return value
+
+
+def file_sha256(path: Path) -> str:
+    """Return the SHA-256 digest of one file."""
+
+    digest = hashlib.sha256()
+    try:
+        with path.open("rb") as handle:
+            for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+                digest.update(chunk)
+    except OSError as exc:
+        raise ValueError(f"could not hash required file {path}: {exc}") from exc
+    return digest.hexdigest()
+
+
+def directory_sha256(
+    directory: Path,
+    *,
+    excluded_relative_paths: frozenset[str] = frozenset(),
+) -> str:
+    """Hash relative paths, sizes, and contents for every regular file."""
+
+    if not directory.is_dir():
+        raise ValueError(f"artifact directory does not exist: {directory}")
+
+    digest = hashlib.sha256()
+    entries = sorted(directory.rglob("*"))
+    for file_path in entries:
+        if file_path.is_symlink():
+            raise ValueError(f"artifact directories may not contain symlinks: {file_path}")
+        if not file_path.is_file():
+            continue
+        relative_path = file_path.relative_to(directory).as_posix()
+        if relative_path in excluded_relative_paths:
+            continue
+
+        relative_bytes = relative_path.encode("utf-8")
+        file_size = file_path.stat().st_size
+        digest.update(len(relative_bytes).to_bytes(8, "big"))
+        digest.update(relative_bytes)
+        digest.update(file_size.to_bytes(8, "big"))
+        with file_path.open("rb") as handle:
+            for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+                digest.update(chunk)
+    return digest.hexdigest()
+
+
+def require_sha256(value: Any, *, field: str, source: Path) -> str:
+    """Validate and normalize a lowercase SHA-256 value."""
+
+    if not isinstance(value, str):
+        raise ValueError(f"{source} is missing SHA-256 field {field!r}")
+    normalized = value.strip().lower()
+    if len(normalized) != 64 or any(character not in "0123456789abcdef" for character in normalized):
+        raise ValueError(f"{source} field {field!r} must be a 64-character SHA-256")
+    return normalized
+
+
+def write_artifact_lineage(
+    artifact_dir: Path,
+    *,
+    source_lineage: dict[str, Any],
+    source_lineage_sha256: str,
+    stage: str,
+) -> Path:
+    """Write lineage metadata bound to an artifact directory's exact contents."""
+
+    lineage_path = artifact_dir / LINEAGE_FILENAME
+    payload = dict(source_lineage)
+    payload[SOURCE_LINEAGE_DIGEST_FIELD] = source_lineage_sha256
+    payload[ARTIFACT_STAGE_FIELD] = stage
+    payload[ARTIFACT_DIGEST_FIELD] = directory_sha256(
+        artifact_dir,
+        excluded_relative_paths=_artifact_digest_exclusions(stage),
+    )
+    lineage_path.write_text(
+        json.dumps(payload, indent=2, sort_keys=True),
+        encoding="utf-8",
+    )
+    return lineage_path
+
+
+def validate_artifact_lineage(
+    artifact_dir: Path,
+    *,
+    source_lineage_sha256: str,
+    stage: str,
+) -> dict[str, Any]:
+    """Verify that an artifact marker matches its source lineage and files."""
+
+    lineage_path = artifact_dir / LINEAGE_FILENAME
+    lineage = load_json_object(lineage_path, label=f"{stage} artifact lineage")
+    recorded_source_digest = require_sha256(
+        lineage.get(SOURCE_LINEAGE_DIGEST_FIELD),
+        field=SOURCE_LINEAGE_DIGEST_FIELD,
+        source=lineage_path,
+    )
+    if recorded_source_digest != source_lineage_sha256:
+        raise ValueError(
+            f"{lineage_path} does not match the selected merge lineage: "
+            f"expected {source_lineage_sha256}, got {recorded_source_digest}"
+        )
+    recorded_stage = lineage.get(ARTIFACT_STAGE_FIELD)
+    if recorded_stage != stage:
+        raise ValueError(
+            f"{lineage_path} field {ARTIFACT_STAGE_FIELD!r} must be {stage!r}, "
+            f"got {recorded_stage!r}"
+        )
+    recorded_artifact_digest = require_sha256(
+        lineage.get(ARTIFACT_DIGEST_FIELD),
+        field=ARTIFACT_DIGEST_FIELD,
+        source=lineage_path,
+    )
+    actual_artifact_digest = directory_sha256(
+        artifact_dir,
+        excluded_relative_paths=_artifact_digest_exclusions(stage),
+    )
+    if recorded_artifact_digest != actual_artifact_digest:
+        raise ValueError(
+            f"{lineage_path} artifact digest does not match {artifact_dir}: "
+            f"expected {recorded_artifact_digest}, got {actual_artifact_digest}"
+        )
+    return lineage

--- a/ml/profile-qa/profile_qa/train_lora.py
+++ b/ml/profile-qa/profile_qa/train_lora.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import re
 from pathlib import Path
 from typing import Any
 
@@ -26,12 +27,13 @@ from .config import (
     WEIGHT_DECAY,
 )
 from .gpu_health import assert_gpu_ready
-from .provenance import canonical_json_sha256
+from .provenance import canonical_json_sha256, load_json_object
 from .synthetic_data import profile_context_text
 from .validation import read_jsonl
 
 TEAPOT_MODEL_TYPE = "t5"
 TEAPOT_LORA_TARGET_MODULES = ["q", "v"]
+ADAPTER_CONFIG_FILENAME = "adapter_config.json"
 
 
 def ensure_primary_base_model_id(model_id: str, *, source: str) -> None:
@@ -45,6 +47,49 @@ def ensure_primary_base_model_id(model_id: str, *, source: str) -> None:
         f"profile-QA is TeapotLLM-only; {source} must use {PRIMARY_BASE_MODEL_ID}, "
         f"got {model_id}"
     )
+
+
+def ensure_adapter_base_lineage(adapter_config: Any, *, source: str) -> None:
+    """Require an adapter trained from the pinned Teapot base revision."""
+
+    if isinstance(adapter_config, dict):
+        base_model_id = adapter_config.get("base_model_name_or_path")
+        base_model_revision = adapter_config.get("revision")
+    else:
+        base_model_id = getattr(adapter_config, "base_model_name_or_path", None)
+        base_model_revision = getattr(adapter_config, "revision", None)
+    ensure_primary_base_model_id(str(base_model_id or ""), source=f"{source} base")
+    if base_model_revision != PRIMARY_BASE_MODEL_REVISION:
+        raise RuntimeError(
+            f"{source} revision must be {PRIMARY_BASE_MODEL_REVISION!r}, "
+            f"got {base_model_revision!r}; retrain the adapter from the pinned base"
+        )
+
+
+def resolve_resume_checkpoint(output_dir: Path) -> Path:
+    """Resolve and validate the exact latest Trainer checkpoint for resume."""
+
+    if not output_dir.is_dir():
+        raise RuntimeError(f"resume output directory does not exist: {output_dir}")
+    checkpoints: list[tuple[int, Path]] = []
+    for candidate in output_dir.iterdir():
+        match = re.fullmatch(r"checkpoint-(\d+)", candidate.name)
+        if match is None or not candidate.is_dir() or candidate.is_symlink():
+            continue
+        checkpoints.append((int(match.group(1)), candidate))
+    if not checkpoints:
+        raise RuntimeError(f"no Trainer checkpoints found under {output_dir}")
+    _, checkpoint_path = max(checkpoints, key=lambda checkpoint: checkpoint[0])
+    adapter_config_path = checkpoint_path / ADAPTER_CONFIG_FILENAME
+    adapter_config = load_json_object(
+        adapter_config_path,
+        label="resume adapter configuration",
+    )
+    ensure_adapter_base_lineage(
+        adapter_config,
+        source=f"{checkpoint_path} adapter",
+    )
+    return checkpoint_path
 
 
 def require_local_model_path(model_id: str, *, source: str) -> Path:
@@ -180,6 +225,14 @@ def ensure_teapot_seq2seq_config(config: Any, model_id: str) -> None:
 
 
 def run_training(args: argparse.Namespace) -> None:
+    if args.resume and args.adapter_model_id:
+        raise RuntimeError(
+            "--resume and --adapter-model-id select different adapter sources; "
+            "use exactly one"
+        )
+    resume_checkpoint = (
+        resolve_resume_checkpoint(Path(args.output_dir)) if args.resume else None
+    )
     assert_gpu_ready(min_vram_gb=args.min_vram_gb)
     stack = _load_training_stack()
     torch = stack["torch"]
@@ -220,10 +273,9 @@ def run_training(args: argparse.Namespace) -> None:
     if args.adapter_model_id:
         require_local_model_path(args.adapter_model_id, source="adapter model")
         adapter_config = stack["PeftConfig"].from_pretrained(args.adapter_model_id)
-        adapter_base_model_id = str(getattr(adapter_config, "base_model_name_or_path", ""))
-        ensure_primary_base_model_id(
-            adapter_base_model_id,
-            source=f"{args.adapter_model_id} adapter base",
+        ensure_adapter_base_lineage(
+            adapter_config,
+            source=f"{args.adapter_model_id} adapter",
         )
         model = stack["PeftModel"].from_pretrained(
             model,
@@ -239,7 +291,11 @@ def run_training(args: argparse.Namespace) -> None:
             task_type="SEQ_2_SEQ_LM",
             target_modules=TEAPOT_LORA_TARGET_MODULES,
         )
-        model = stack["get_peft_model"](model, lora_config)
+        model = stack["get_peft_model"](
+            model,
+            lora_config,
+            revision=PRIMARY_BASE_MODEL_REVISION,
+        )
 
     dataset_cls = stack["Dataset"]
     train_dataset = dataset_cls.from_list(train_records)
@@ -312,7 +368,11 @@ def run_training(args: argparse.Namespace) -> None:
         callbacks=callbacks,
     )
 
-    trainer.train(resume_from_checkpoint=args.resume)
+    trainer.train(
+        resume_from_checkpoint=(
+            str(resume_checkpoint) if resume_checkpoint is not None else None
+        )
+    )
     trainer.save_model(args.output_dir)
     tokenizer.save_pretrained(args.output_dir)
 

--- a/ml/profile-qa/profile_qa/train_lora.py
+++ b/ml/profile-qa/profile_qa/train_lora.py
@@ -9,8 +9,8 @@ from typing import Any
 from .config import (
     DEFAULT_DATASET_PATH,
     DEFAULT_TRAIN_OUTPUT_DIR,
-    EVAL_STEPS,
     EVAL_BATCH_SIZE,
+    EVAL_STEPS,
     GRADIENT_ACCUMULATION_STEPS,
     LEARNING_RATE,
     LORA_ALPHA,
@@ -26,6 +26,7 @@ from .config import (
     WEIGHT_DECAY,
 )
 from .gpu_health import assert_gpu_ready
+from .provenance import canonical_json_sha256
 from .synthetic_data import profile_context_text
 from .validation import read_jsonl
 
@@ -96,6 +97,20 @@ def format_instruction(record: dict[str, Any]) -> str:
         f"{history_text}\n\n"
         f"Question: {record['question']}\n"
         "Answer:"
+    )
+
+
+def evaluation_prompt_sha256(records: list[dict[str, Any]]) -> str:
+    """Hash the exact ordered prompts presented during one evaluation split."""
+
+    return canonical_json_sha256(
+        [
+            {
+                "id": str(record.get("id", "")),
+                "prompt": format_instruction(record),
+            }
+            for record in records
+        ]
     )
 
 

--- a/ml/profile-qa/profile_qa/validation.py
+++ b/ml/profile-qa/profile_qa/validation.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
 from collections.abc import Iterable
 from pathlib import Path
@@ -43,14 +44,25 @@ def read_jsonl(path: Path) -> list[dict[str, Any]]:
     return records
 
 
+def canonical_jsonl_bytes(records: Iterable[dict[str, Any]]) -> bytes:
+    """Serialize records exactly as published, with stable keys and LF endings."""
+
+    return "".join(
+        f"{json.dumps(record, sort_keys=True)}\n" for record in records
+    ).encode("utf-8")
+
+
+def canonical_jsonl_sha256(records: Iterable[dict[str, Any]]) -> str:
+    """Hash the canonical JSONL bytes used for dataset publication."""
+
+    return hashlib.sha256(canonical_jsonl_bytes(records)).hexdigest()
+
+
 def write_jsonl(path: Path, records: Iterable[dict[str, Any]]) -> None:
-    """Write records to a JSONL file."""
+    """Write canonical JSONL bytes with platform-independent line endings."""
 
     path.parent.mkdir(parents=True, exist_ok=True)
-    with path.open("w", encoding="utf-8") as handle:
-        for record in records:
-            handle.write(json.dumps(record, sort_keys=True))
-            handle.write("\n")
+    path.write_bytes(canonical_jsonl_bytes(records))
 
 
 def validate_record(record: dict[str, Any]) -> list[str]:

--- a/ml/profile-qa/tests/test_model_card_provenance.py
+++ b/ml/profile-qa/tests/test_model_card_provenance.py
@@ -5,10 +5,12 @@ import json
 import tempfile
 import unittest
 from pathlib import Path
+from unittest.mock import patch
 
 from profile_qa.config import PRIMARY_BASE_MODEL_ID, PRIMARY_BASE_MODEL_REVISION
 from profile_qa.prepare_hf_artifacts import (
     load_model_provenance,
+    prepare_dataset_payload,
     prepare_model_payload,
 )
 from profile_qa.provenance import (
@@ -19,11 +21,14 @@ from profile_qa.provenance import (
     EXPECTED_LINEAGE_PIPELINE,
     LINEAGE_SCHEMA_VERSION,
     MERGED_DIGEST_FIELD,
+    PROMPT_DIGEST_FIELD,
     directory_sha256,
     file_sha256,
     validate_artifact_lineage,
     write_artifact_lineage,
 )
+from profile_qa.train_lora import evaluation_prompt_sha256
+from profile_qa.validation import canonical_jsonl_sha256, read_jsonl
 
 
 class ModelCardProvenanceTests(unittest.TestCase):
@@ -93,6 +98,11 @@ class ModelCardProvenanceTests(unittest.TestCase):
         dataset_path: Path,
         adapter_digest: str | None = None,
     ) -> Path:
+        dataset_records = read_jsonl(dataset_path)
+        dataset_sha256 = canonical_jsonl_sha256(dataset_records)
+        prompt_sha256 = evaluation_prompt_sha256(
+            [record for record in dataset_records if record.get("split") == split]
+        )
         report: dict[str, object] = {
             "macro": 1.0,
             "refusal_accuracy": 1.0,
@@ -105,7 +115,8 @@ class ModelCardProvenanceTests(unittest.TestCase):
                 "model_id": PRIMARY_BASE_MODEL_ID,
                 BASE_MODEL_REVISION_FIELD: PRIMARY_BASE_MODEL_REVISION,
                 "base_model": PRIMARY_BASE_MODEL_ID,
-                DATASET_DIGEST_FIELD: file_sha256(dataset_path),
+                DATASET_DIGEST_FIELD: dataset_sha256,
+                PROMPT_DIGEST_FIELD: prompt_sha256,
                 "split": split,
             }
         else:
@@ -118,7 +129,8 @@ class ModelCardProvenanceTests(unittest.TestCase):
                 ADAPTER_DIGEST_FIELD: digest,
                 "base_model": PRIMARY_BASE_MODEL_ID,
                 BASE_MODEL_REVISION_FIELD: PRIMARY_BASE_MODEL_REVISION,
-                DATASET_DIGEST_FIELD: file_sha256(dataset_path),
+                DATASET_DIGEST_FIELD: dataset_sha256,
+                PROMPT_DIGEST_FIELD: prompt_sha256,
                 "split": split,
             }
         path.write_text(json.dumps(report), encoding="utf-8")
@@ -132,7 +144,13 @@ class ModelCardProvenanceTests(unittest.TestCase):
         browser_dir: Path,
     ) -> argparse.Namespace:
         dataset_path = root / "profile_qa.jsonl"
-        dataset_path.write_text('{"id":"example"}\n', encoding="utf-8")
+        dataset_path.write_text(
+            '{ "question": "Validation question?", "task": "single_turn", '
+            '"split": "validation", "id": "validation-example" }\n'
+            '{"task":"single_turn", "question":"Test question?", '
+            '"id":"test-example", "split":"test"}\n',
+            encoding="utf-8",
+        )
         return argparse.Namespace(
             model_browser_dir=str(browser_dir),
             output_dir=str(root / "hf"),
@@ -345,6 +363,19 @@ class ModelCardProvenanceTests(unittest.TestCase):
 
             self.assertEqual(sentinel.read_text(encoding="utf-8"), "unchanged")
 
+            dataset_output_dir = root / "hf" / "dataset"
+            dataset_output_dir.mkdir(parents=True)
+            dataset_sentinel = dataset_output_dir / "keep.txt"
+            dataset_sentinel.write_text("unchanged", encoding="utf-8")
+
+            with self.assertRaisesRegex(ValueError, "dataset digest"):
+                prepare_dataset_payload(args)
+
+            self.assertEqual(
+                dataset_sentinel.read_text(encoding="utf-8"),
+                "unchanged",
+            )
+
     def test_report_for_another_base_revision_is_rejected(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
@@ -363,6 +394,51 @@ class ModelCardProvenanceTests(unittest.TestCase):
 
             with self.assertRaisesRegex(ValueError, "base revision"):
                 prepare_model_payload(args)
+
+    def test_report_for_another_prompt_context_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            lineage_path, checkpoint_dir = self._write_lineage(root)
+            browser_dir = self._write_browser_artifact(root, lineage_path)
+            args = self._release_args(
+                root,
+                lineage_path,
+                checkpoint_dir,
+                browser_dir,
+            )
+
+            with (
+                patch(
+                    "profile_qa.train_lora.profile_context_text",
+                    return_value="changed public profile context",
+                ),
+                self.assertRaisesRegex(ValueError, "prompt digest"),
+            ):
+                prepare_model_payload(args)
+
+    def test_report_digest_matches_canonical_published_dataset(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            lineage_path, checkpoint_dir = self._write_lineage(root)
+            browser_dir = self._write_browser_artifact(root, lineage_path)
+            args = self._release_args(
+                root,
+                lineage_path,
+                checkpoint_dir,
+                browser_dir,
+            )
+            source_bytes = Path(args.dataset).read_bytes()
+
+            prepare_model_payload(args)
+            dataset_dir = prepare_dataset_payload(args)
+            published_dataset = dataset_dir / "profile_qa.jsonl"
+            report = json.loads(Path(args.test_report).read_text(encoding="utf-8"))
+
+            self.assertNotEqual(source_bytes, published_dataset.read_bytes())
+            self.assertEqual(
+                report["provenance"][DATASET_DIGEST_FIELD],
+                file_sha256(published_dataset),
+            )
 
     def test_invalid_lineage_preserves_existing_model_payload(self) -> None:
         with tempfile.TemporaryDirectory() as directory:

--- a/ml/profile-qa/tests/test_model_card_provenance.py
+++ b/ml/profile-qa/tests/test_model_card_provenance.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+import argparse
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from profile_qa.prepare_hf_artifacts import (
+    load_model_provenance,
+    prepare_model_payload,
+)
+
+
+class ModelCardProvenanceTests(unittest.TestCase):
+    def _write_lineage(
+        self,
+        directory: Path,
+        *,
+        log_history: list[dict[str, object]] | None = None,
+    ) -> Path:
+        checkpoint_dir = directory / "teapot-profile-qa-lora-v6" / "checkpoint-80"
+        checkpoint_dir.mkdir(parents=True)
+        trainer_state = {
+            "log_history": log_history
+            if log_history is not None
+            else [
+                {"loss": 0.12, "step": 40},
+                {"eval_loss": 0.08, "step": 40},
+                {"loss": 0.03125, "step": 80},
+                {"eval_loss": 0.04, "step": 80},
+            ]
+        }
+        (checkpoint_dir / "trainer_state.json").write_text(
+            json.dumps(trainer_state),
+            encoding="utf-8",
+        )
+        lineage_path = directory / "teapot_profile_qa_lineage.json"
+        lineage_path.write_text(
+            json.dumps(
+                {
+                    "adapter_model_id": str(checkpoint_dir),
+                    "base_model": "teapotai/teapotllm",
+                    "pipeline": "profile-qa-teapot-lora",
+                }
+            ),
+            encoding="utf-8",
+        )
+        return lineage_path
+
+    def test_model_card_uses_validated_release_provenance(self) -> None:
+        report = {
+            "macro": 1.0,
+            "refusal_accuracy": 1.0,
+            "multi_turn_accuracy": 1.0,
+            "by_task": {"single_turn": 1.0},
+        }
+
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            lineage_path = self._write_lineage(root)
+            browser_dir = root / "browser"
+            browser_dir.mkdir()
+            (browser_dir / "config.json").write_text("{}", encoding="utf-8")
+            report_path = root / "report.json"
+            report_path.write_text(json.dumps(report), encoding="utf-8")
+            args = argparse.Namespace(
+                model_browser_dir=str(browser_dir),
+                output_dir=str(root / "hf"),
+                model_repo_id="owner/model",
+                dataset_repo_id="owner/dataset",
+                baseline_report=str(report_path),
+                validation_report=str(report_path),
+                test_report=str(report_path),
+                lineage_file=str(lineage_path),
+                release_date="2026-08-07",
+            )
+            model_dir = prepare_model_payload(args)
+            model_card = (model_dir / "README.md").read_text(encoding="utf-8")
+
+        self.assertIn("Promoted checkpoint: `checkpoint-80`", model_card)
+        self.assertIn("Latest recorded train loss: 0.0312 at step 80", model_card)
+        self.assertIn("Best recorded validation eval loss: 0.0400", model_card)
+        self.assertIn("2026-08-07: Browser profile-QA export", model_card)
+        self.assertNotIn("teapot-profile-qa-lora-v5/checkpoint-40", model_card)
+        self.assertNotIn("0.0330", model_card)
+        self.assertNotIn("0.0287", model_card)
+        self.assertNotIn("2026-06-19", model_card)
+
+    def test_missing_release_date_fails_clearly(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            lineage_path = self._write_lineage(Path(directory))
+
+            with self.assertRaisesRegex(ValueError, "release date is required"):
+                load_model_provenance(lineage_path, None)
+
+    def test_invalid_release_date_fails_clearly(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            lineage_path = self._write_lineage(Path(directory))
+
+            with self.assertRaisesRegex(ValueError, "must use YYYY-MM-DD"):
+                load_model_provenance(lineage_path, "August 7, 2026")
+
+    def test_missing_training_metrics_fail_clearly(self) -> None:
+        cases = [
+            ([{"eval_loss": 0.04, "step": 80}], "recorded training loss"),
+            ([{"loss": 0.03, "step": 80}], "recorded validation eval loss"),
+        ]
+        for log_history, expected_message in cases:
+            with self.subTest(expected_message=expected_message):
+                with tempfile.TemporaryDirectory() as directory:
+                    lineage_path = self._write_lineage(
+                        Path(directory),
+                        log_history=log_history,
+                    )
+
+                    with self.assertRaisesRegex(ValueError, expected_message):
+                        load_model_provenance(lineage_path, "2026-08-07")
+
+    def test_invalid_lineage_preserves_existing_model_payload(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            browser_dir = root / "browser"
+            browser_dir.mkdir()
+            lineage_path = root / "missing-lineage.json"
+            model_output_dir = root / "hf" / "model"
+            model_output_dir.mkdir(parents=True)
+            sentinel = model_output_dir / "keep.txt"
+            sentinel.write_text("unchanged", encoding="utf-8")
+            args = argparse.Namespace(
+                model_browser_dir=str(browser_dir),
+                output_dir=str(root / "hf"),
+                model_repo_id="owner/model",
+                dataset_repo_id="owner/dataset",
+                baseline_report=str(root / "unused-baseline.json"),
+                validation_report=str(root / "unused-validation.json"),
+                test_report=str(root / "unused-test.json"),
+                lineage_file=str(lineage_path),
+                release_date="2026-08-07",
+            )
+
+            with self.assertRaisesRegex(ValueError, "required model lineage"):
+                prepare_model_payload(args)
+
+            self.assertEqual(sentinel.read_text(encoding="utf-8"), "unchanged")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ml/profile-qa/tests/test_model_card_provenance.py
+++ b/ml/profile-qa/tests/test_model_card_provenance.py
@@ -8,6 +8,12 @@ from pathlib import Path
 from unittest.mock import patch
 
 from profile_qa.config import PRIMARY_BASE_MODEL_ID, PRIMARY_BASE_MODEL_REVISION
+from profile_qa.evaluate import (
+    GENERATION_CONFIG_FIELD,
+    SCORING_DIGEST_FIELD,
+    evaluation_provenance,
+    score_predictions,
+)
 from profile_qa.prepare_hf_artifacts import (
     load_model_provenance,
     prepare_dataset_payload,
@@ -17,11 +23,11 @@ from profile_qa.provenance import (
     ADAPTER_CHECKPOINT_FIELD,
     ADAPTER_DIGEST_FIELD,
     BASE_MODEL_REVISION_FIELD,
+    BROWSER_PARENT_ARTIFACT_STAGES,
     DATASET_DIGEST_FIELD,
     EXPECTED_LINEAGE_PIPELINE,
     LINEAGE_SCHEMA_VERSION,
     MERGED_DIGEST_FIELD,
-    PROMPT_DIGEST_FIELD,
     directory_sha256,
     file_sha256,
     validate_artifact_lineage,
@@ -37,6 +43,7 @@ class ModelCardProvenanceTests(unittest.TestCase):
         directory: Path,
         *,
         log_history: list[dict[str, object]] | None = None,
+        adapter_config: dict[str, object] | None = None,
     ) -> tuple[Path, Path]:
         checkpoint_dir = directory / "teapot-profile-qa-lora-v6" / "checkpoint-80"
         checkpoint_dir.mkdir(parents=True)
@@ -55,6 +62,27 @@ class ModelCardProvenanceTests(unittest.TestCase):
             encoding="utf-8",
         )
         (checkpoint_dir / "adapter_model.safetensors").write_bytes(b"adapter")
+        (checkpoint_dir / "adapter_config.json").write_text(
+            json.dumps(
+                adapter_config
+                or {
+                    "alpha_pattern": {},
+                    "base_model_name_or_path": PRIMARY_BASE_MODEL_ID,
+                    "bias": "none",
+                    "lora_alpha": 47,
+                    "lora_dropout": 0.17,
+                    "modules_to_save": None,
+                    "peft_type": "LORA",
+                    "r": 23,
+                    "rank_pattern": {},
+                    "target_modules": ["k", "o"],
+                    "task_type": "SEQ_2_SEQ_LM",
+                    "use_dora": False,
+                    "use_rslora": False,
+                }
+            ),
+            encoding="utf-8",
+        )
         lineage_path = directory / "teapot_profile_qa_lineage.json"
         lineage_path.write_text(
             json.dumps(
@@ -80,12 +108,23 @@ class ModelCardProvenanceTests(unittest.TestCase):
         browser_dir.mkdir()
         (browser_dir / "config.json").write_text("{}", encoding="utf-8")
         (browser_dir / "onnx").mkdir()
-        (browser_dir / "onnx" / "encoder_model_int8.onnx").write_bytes(b"onnx")
+        for filename in (
+            "encoder_model_int8.onnx",
+            "decoder_model_merged_int8.onnx",
+            "encoder_model_uint8.onnx",
+            "decoder_model_merged_uint8.onnx",
+        ):
+            (browser_dir / "onnx" / filename).write_bytes(filename.encode())
         write_artifact_lineage(
             browser_dir,
             source_lineage=json.loads(lineage_path.read_text(encoding="utf-8")),
             source_lineage_sha256=file_sha256(lineage_path),
             stage="browser",
+            parent_artifact_sha256s={
+                "onnx-fp": "1" * 64,
+                "onnx-int8": "2" * 64,
+                "onnx-uint8": "3" * 64,
+            },
         )
         return browser_dir
 
@@ -103,36 +142,25 @@ class ModelCardProvenanceTests(unittest.TestCase):
         prompt_sha256 = evaluation_prompt_sha256(
             [record for record in dataset_records if record.get("split") == split]
         )
-        report: dict[str, object] = {
-            "macro": 1.0,
-            "refusal_accuracy": 1.0,
-            "multi_turn_accuracy": 1.0,
-            "by_task": {"single_turn": 1.0},
+        split_records = [
+            record for record in dataset_records if record.get("split") == split
+        ]
+        predictions = {
+            str(record["id"]): "grounded answer" for record in split_records
         }
-        if checkpoint_dir is None:
-            report["provenance"] = {
-                "model_kind": "baseline",
-                "model_id": PRIMARY_BASE_MODEL_ID,
-                BASE_MODEL_REVISION_FIELD: PRIMARY_BASE_MODEL_REVISION,
-                "base_model": PRIMARY_BASE_MODEL_ID,
-                DATASET_DIGEST_FIELD: dataset_sha256,
-                PROMPT_DIGEST_FIELD: prompt_sha256,
-                "split": split,
-            }
-        else:
-            digest = adapter_digest or directory_sha256(checkpoint_dir)
-            report["provenance"] = {
-                "model_kind": "adapter",
-                "model_id": checkpoint_dir.name,
-                "model_sha256": digest,
-                ADAPTER_CHECKPOINT_FIELD: checkpoint_dir.name,
-                ADAPTER_DIGEST_FIELD: digest,
-                "base_model": PRIMARY_BASE_MODEL_ID,
-                BASE_MODEL_REVISION_FIELD: PRIMARY_BASE_MODEL_REVISION,
-                DATASET_DIGEST_FIELD: dataset_sha256,
-                PROMPT_DIGEST_FIELD: prompt_sha256,
-                "split": split,
-            }
+        report: dict[str, object] = score_predictions(split_records, predictions)
+        model_id = (
+            PRIMARY_BASE_MODEL_ID if checkpoint_dir is None else str(checkpoint_dir)
+        )
+        report["provenance"] = evaluation_provenance(
+            model_id,
+            split,
+            dataset_sha256,
+            prompt_sha256,
+        )
+        if checkpoint_dir is not None and adapter_digest is not None:
+            report["provenance"][ADAPTER_DIGEST_FIELD] = adapter_digest
+            report["provenance"]["model_sha256"] = adapter_digest
         path.write_text(json.dumps(report), encoding="utf-8")
         return path
 
@@ -207,11 +235,19 @@ class ModelCardProvenanceTests(unittest.TestCase):
                 model_dir,
                 source_lineage_sha256=file_sha256(lineage_path),
                 stage="browser",
+                required_parent_stages=BROWSER_PARENT_ARTIFACT_STAGES,
             )
 
         self.assertIn("Promoted checkpoint: `checkpoint-80`", model_card)
         self.assertIn("Latest recorded train loss: 0.0312 at step 80", model_card)
         self.assertIn("Best recorded validation eval loss: 0.0400", model_card)
+        self.assertIn("LoRA: rank 23, alpha 47,", model_card)
+        self.assertIn("dropout 0.17, target modules", model_card)
+        self.assertIn("`k`, `o`", model_card)
+        self.assertNotIn("rank 16, alpha 32, dropout 0.03", model_card)
+        self.assertNotIn("batch size 1", model_card)
+        self.assertNotIn("4-bit base loading", model_card)
+        self.assertNotIn("cloud training", model_card)
         self.assertIn("2026-08-07: Browser profile-QA export", model_card)
         self.assertIn(PRIMARY_BASE_MODEL_REVISION, model_card)
         self.assertIn(expected_browser_digest, model_card)
@@ -270,6 +306,61 @@ class ModelCardProvenanceTests(unittest.TestCase):
                             "2026-08-07",
                         )
 
+    def test_unverifiable_lora_configuration_fails_clearly(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            lineage_path, _ = self._write_lineage(
+                root,
+                adapter_config={
+                    "alpha_pattern": {},
+                    "base_model_name_or_path": PRIMARY_BASE_MODEL_ID,
+                    "bias": "none",
+                    "lora_alpha": 32,
+                    "lora_dropout": 0.03,
+                    "modules_to_save": None,
+                    "peft_type": "LORA",
+                    "r": 16,
+                    "rank_pattern": {},
+                    "target_modules": ["q", "v"],
+                    "use_dora": False,
+                    "use_rslora": False,
+                    # No task_type: the card must not guess this claim.
+                },
+            )
+            browser_dir = self._write_browser_artifact(root, lineage_path)
+
+            with self.assertRaisesRegex(ValueError, "task_type"):
+                load_model_provenance(
+                    lineage_path,
+                    browser_dir,
+                    "2026-08-07",
+                )
+
+    def test_per_module_lora_overrides_are_not_flattened_into_card_claims(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            lineage_path, checkpoint_dir = self._write_lineage(root)
+            adapter_config_path = checkpoint_dir / "adapter_config.json"
+            adapter_config = json.loads(
+                adapter_config_path.read_text(encoding="utf-8")
+            )
+            adapter_config["rank_pattern"] = {"encoder.block.0.q": 7}
+            adapter_config_path.write_text(
+                json.dumps(adapter_config),
+                encoding="utf-8",
+            )
+            lineage = json.loads(lineage_path.read_text(encoding="utf-8"))
+            lineage[ADAPTER_DIGEST_FIELD] = directory_sha256(checkpoint_dir)
+            lineage_path.write_text(json.dumps(lineage), encoding="utf-8")
+            browser_dir = self._write_browser_artifact(root, lineage_path)
+
+            with self.assertRaisesRegex(ValueError, "rank_pattern"):
+                load_model_provenance(
+                    lineage_path,
+                    browser_dir,
+                    "2026-08-07",
+                )
+
     def test_tampered_browser_artifact_preserves_existing_model_payload(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
@@ -288,6 +379,41 @@ class ModelCardProvenanceTests(unittest.TestCase):
             (browser_dir / "config.json").write_text('{"tampered": true}', encoding="utf-8")
 
             with self.assertRaisesRegex(ValueError, "artifact digest"):
+                prepare_model_payload(args)
+
+            self.assertEqual(sentinel.read_text(encoding="utf-8"), "unchanged")
+
+    def test_missing_advertised_browser_variant_preserves_existing_payload(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            lineage_path, checkpoint_dir = self._write_lineage(root)
+            browser_dir = self._write_browser_artifact(root, lineage_path)
+            args = self._release_args(
+                root,
+                lineage_path,
+                checkpoint_dir,
+                browser_dir,
+            )
+            (browser_dir / "onnx" / "encoder_model_uint8.onnx").unlink()
+            write_artifact_lineage(
+                browser_dir,
+                source_lineage=json.loads(
+                    lineage_path.read_text(encoding="utf-8")
+                ),
+                source_lineage_sha256=file_sha256(lineage_path),
+                stage="browser",
+                parent_artifact_sha256s={
+                    "onnx-fp": "1" * 64,
+                    "onnx-int8": "2" * 64,
+                    "onnx-uint8": "3" * 64,
+                },
+            )
+            model_output_dir = root / "hf" / "model"
+            model_output_dir.mkdir(parents=True)
+            sentinel = model_output_dir / "keep.txt"
+            sentinel.write_text("unchanged", encoding="utf-8")
+
+            with self.assertRaisesRegex(ValueError, "missing published ONNX"):
                 prepare_model_payload(args)
 
             self.assertEqual(sentinel.read_text(encoding="utf-8"), "unchanged")
@@ -393,6 +519,63 @@ class ModelCardProvenanceTests(unittest.TestCase):
             report_path.write_text(json.dumps(report), encoding="utf-8")
 
             with self.assertRaisesRegex(ValueError, "base revision"):
+                prepare_model_payload(args)
+
+    def test_report_from_stale_scoring_implementation_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            lineage_path, checkpoint_dir = self._write_lineage(root)
+            browser_dir = self._write_browser_artifact(root, lineage_path)
+            args = self._release_args(
+                root,
+                lineage_path,
+                checkpoint_dir,
+                browser_dir,
+            )
+            report_path = Path(args.test_report)
+            report = json.loads(report_path.read_text(encoding="utf-8"))
+            report["provenance"][SCORING_DIGEST_FIELD] = "f" * 64
+            report_path.write_text(json.dumps(report), encoding="utf-8")
+
+            with self.assertRaisesRegex(ValueError, "scoring implementation"):
+                prepare_model_payload(args)
+
+    def test_report_from_stale_generation_configuration_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            lineage_path, checkpoint_dir = self._write_lineage(root)
+            browser_dir = self._write_browser_artifact(root, lineage_path)
+            args = self._release_args(
+                root,
+                lineage_path,
+                checkpoint_dir,
+                browser_dir,
+            )
+            report_path = Path(args.test_report)
+            report = json.loads(report_path.read_text(encoding="utf-8"))
+            report["provenance"][GENERATION_CONFIG_FIELD]["max_new_tokens"] = 80
+            report_path.write_text(json.dumps(report), encoding="utf-8")
+
+            with self.assertRaisesRegex(ValueError, "generation configuration"):
+                prepare_model_payload(args)
+
+    def test_report_scores_are_recomputed_from_saved_predictions(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            lineage_path, checkpoint_dir = self._write_lineage(root)
+            browser_dir = self._write_browser_artifact(root, lineage_path)
+            args = self._release_args(
+                root,
+                lineage_path,
+                checkpoint_dir,
+                browser_dir,
+            )
+            report_path = Path(args.validation_report)
+            report = json.loads(report_path.read_text(encoding="utf-8"))
+            report["macro"] = 0.123
+            report_path.write_text(json.dumps(report), encoding="utf-8")
+
+            with self.assertRaisesRegex(ValueError, "saved predictions"):
                 prepare_model_payload(args)
 
     def test_report_for_another_prompt_context_is_rejected(self) -> None:

--- a/ml/profile-qa/tests/test_model_card_provenance.py
+++ b/ml/profile-qa/tests/test_model_card_provenance.py
@@ -12,7 +12,10 @@ from profile_qa.prepare_hf_artifacts import (
     prepare_model_payload,
 )
 from profile_qa.provenance import (
+    ADAPTER_CHECKPOINT_FIELD,
     ADAPTER_DIGEST_FIELD,
+    BASE_MODEL_REVISION_FIELD,
+    DATASET_DIGEST_FIELD,
     EXPECTED_LINEAGE_PIPELINE,
     LINEAGE_SCHEMA_VERSION,
     MERGED_DIGEST_FIELD,
@@ -53,8 +56,10 @@ class ModelCardProvenanceTests(unittest.TestCase):
                 {
                     "schema_version": LINEAGE_SCHEMA_VERSION,
                     "adapter_model_id": str(checkpoint_dir.resolve()),
+                    ADAPTER_CHECKPOINT_FIELD: checkpoint_dir.name,
                     ADAPTER_DIGEST_FIELD: directory_sha256(checkpoint_dir),
                     "base_model": PRIMARY_BASE_MODEL_ID,
+                    BASE_MODEL_REVISION_FIELD: PRIMARY_BASE_MODEL_REVISION,
                     "pipeline": EXPECTED_LINEAGE_PIPELINE,
                     MERGED_DIGEST_FIELD: "1" * 64,
                 },
@@ -85,6 +90,7 @@ class ModelCardProvenanceTests(unittest.TestCase):
         *,
         split: str,
         checkpoint_dir: Path | None,
+        dataset_path: Path,
         adapter_digest: str | None = None,
     ) -> Path:
         report: dict[str, object] = {
@@ -97,19 +103,22 @@ class ModelCardProvenanceTests(unittest.TestCase):
             report["provenance"] = {
                 "model_kind": "baseline",
                 "model_id": PRIMARY_BASE_MODEL_ID,
-                "model_revision": PRIMARY_BASE_MODEL_REVISION,
+                BASE_MODEL_REVISION_FIELD: PRIMARY_BASE_MODEL_REVISION,
                 "base_model": PRIMARY_BASE_MODEL_ID,
+                DATASET_DIGEST_FIELD: file_sha256(dataset_path),
                 "split": split,
             }
         else:
             digest = adapter_digest or directory_sha256(checkpoint_dir)
             report["provenance"] = {
                 "model_kind": "adapter",
-                "model_id": str(checkpoint_dir.resolve()),
+                "model_id": checkpoint_dir.name,
                 "model_sha256": digest,
-                "adapter_model_id": str(checkpoint_dir.resolve()),
+                ADAPTER_CHECKPOINT_FIELD: checkpoint_dir.name,
                 ADAPTER_DIGEST_FIELD: digest,
                 "base_model": PRIMARY_BASE_MODEL_ID,
+                BASE_MODEL_REVISION_FIELD: PRIMARY_BASE_MODEL_REVISION,
+                DATASET_DIGEST_FIELD: file_sha256(dataset_path),
                 "split": split,
             }
         path.write_text(json.dumps(report), encoding="utf-8")
@@ -122,6 +131,8 @@ class ModelCardProvenanceTests(unittest.TestCase):
         checkpoint_dir: Path,
         browser_dir: Path,
     ) -> argparse.Namespace:
+        dataset_path = root / "profile_qa.jsonl"
+        dataset_path.write_text('{"id":"example"}\n', encoding="utf-8")
         return argparse.Namespace(
             model_browser_dir=str(browser_dir),
             output_dir=str(root / "hf"),
@@ -132,6 +143,7 @@ class ModelCardProvenanceTests(unittest.TestCase):
                     root / "baseline.json",
                     split="test",
                     checkpoint_dir=None,
+                    dataset_path=dataset_path,
                 )
             ),
             validation_report=str(
@@ -139,6 +151,7 @@ class ModelCardProvenanceTests(unittest.TestCase):
                     root / "validation.json",
                     split="validation",
                     checkpoint_dir=checkpoint_dir,
+                    dataset_path=dataset_path,
                 )
             ),
             test_report=str(
@@ -146,9 +159,11 @@ class ModelCardProvenanceTests(unittest.TestCase):
                     root / "test.json",
                     split="test",
                     checkpoint_dir=checkpoint_dir,
+                    dataset_path=dataset_path,
                 )
             ),
             lineage_file=str(lineage_path),
+            dataset=str(dataset_path),
             release_date="2026-08-07",
         )
 
@@ -180,8 +195,14 @@ class ModelCardProvenanceTests(unittest.TestCase):
         self.assertIn("Latest recorded train loss: 0.0312 at step 80", model_card)
         self.assertIn("Best recorded validation eval loss: 0.0400", model_card)
         self.assertIn("2026-08-07: Browser profile-QA export", model_card)
+        self.assertIn(PRIMARY_BASE_MODEL_REVISION, model_card)
         self.assertIn(expected_browser_digest, model_card)
         self.assertEqual(published_lineage["artifact_sha256"], expected_browser_digest)
+        self.assertNotIn("adapter_model_id", published_lineage)
+        self.assertEqual(
+            published_lineage[ADAPTER_CHECKPOINT_FIELD],
+            "checkpoint-80",
+        )
         self.assertNotIn("teapot-profile-qa-lora-v5/checkpoint-40", model_card)
         self.assertNotIn("0.0330", model_card)
         self.assertNotIn("0.0287", model_card)
@@ -286,6 +307,7 @@ class ModelCardProvenanceTests(unittest.TestCase):
                 Path(args.test_report),
                 split="test",
                 checkpoint_dir=checkpoint_dir,
+                dataset_path=Path(args.dataset),
                 adapter_digest="f" * 64,
             )
             model_output_dir = root / "hf" / "model"
@@ -297,6 +319,50 @@ class ModelCardProvenanceTests(unittest.TestCase):
                 prepare_model_payload(args)
 
             self.assertEqual(sentinel.read_text(encoding="utf-8"), "unchanged")
+
+    def test_stale_report_for_another_dataset_preserves_existing_payload(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            lineage_path, checkpoint_dir = self._write_lineage(root)
+            browser_dir = self._write_browser_artifact(root, lineage_path)
+            args = self._release_args(
+                root,
+                lineage_path,
+                checkpoint_dir,
+                browser_dir,
+            )
+            Path(args.dataset).write_text(
+                '{"id":"regenerated-example"}\n',
+                encoding="utf-8",
+            )
+            model_output_dir = root / "hf" / "model"
+            model_output_dir.mkdir(parents=True)
+            sentinel = model_output_dir / "keep.txt"
+            sentinel.write_text("unchanged", encoding="utf-8")
+
+            with self.assertRaisesRegex(ValueError, "dataset digest"):
+                prepare_model_payload(args)
+
+            self.assertEqual(sentinel.read_text(encoding="utf-8"), "unchanged")
+
+    def test_report_for_another_base_revision_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            lineage_path, checkpoint_dir = self._write_lineage(root)
+            browser_dir = self._write_browser_artifact(root, lineage_path)
+            args = self._release_args(
+                root,
+                lineage_path,
+                checkpoint_dir,
+                browser_dir,
+            )
+            report_path = Path(args.validation_report)
+            report = json.loads(report_path.read_text(encoding="utf-8"))
+            report["provenance"][BASE_MODEL_REVISION_FIELD] = "0" * 40
+            report_path.write_text(json.dumps(report), encoding="utf-8")
+
+            with self.assertRaisesRegex(ValueError, "base revision"):
+                prepare_model_payload(args)
 
     def test_invalid_lineage_preserves_existing_model_payload(self) -> None:
         with tempfile.TemporaryDirectory() as directory:

--- a/ml/profile-qa/tests/test_model_card_provenance.py
+++ b/ml/profile-qa/tests/test_model_card_provenance.py
@@ -6,9 +6,20 @@ import tempfile
 import unittest
 from pathlib import Path
 
+from profile_qa.config import PRIMARY_BASE_MODEL_ID, PRIMARY_BASE_MODEL_REVISION
 from profile_qa.prepare_hf_artifacts import (
     load_model_provenance,
     prepare_model_payload,
+)
+from profile_qa.provenance import (
+    ADAPTER_DIGEST_FIELD,
+    EXPECTED_LINEAGE_PIPELINE,
+    LINEAGE_SCHEMA_VERSION,
+    MERGED_DIGEST_FIELD,
+    directory_sha256,
+    file_sha256,
+    validate_artifact_lineage,
+    write_artifact_lineage,
 )
 
 
@@ -18,7 +29,7 @@ class ModelCardProvenanceTests(unittest.TestCase):
         directory: Path,
         *,
         log_history: list[dict[str, object]] | None = None,
-    ) -> Path:
+    ) -> tuple[Path, Path]:
         checkpoint_dir = directory / "teapot-profile-qa-lora-v6" / "checkpoint-80"
         checkpoint_dir.mkdir(parents=True)
         trainer_state = {
@@ -35,53 +46,142 @@ class ModelCardProvenanceTests(unittest.TestCase):
             json.dumps(trainer_state),
             encoding="utf-8",
         )
+        (checkpoint_dir / "adapter_model.safetensors").write_bytes(b"adapter")
         lineage_path = directory / "teapot_profile_qa_lineage.json"
         lineage_path.write_text(
             json.dumps(
                 {
-                    "adapter_model_id": str(checkpoint_dir),
-                    "base_model": "teapotai/teapotllm",
-                    "pipeline": "profile-qa-teapot-lora",
-                }
+                    "schema_version": LINEAGE_SCHEMA_VERSION,
+                    "adapter_model_id": str(checkpoint_dir.resolve()),
+                    ADAPTER_DIGEST_FIELD: directory_sha256(checkpoint_dir),
+                    "base_model": PRIMARY_BASE_MODEL_ID,
+                    "pipeline": EXPECTED_LINEAGE_PIPELINE,
+                    MERGED_DIGEST_FIELD: "1" * 64,
+                },
+                indent=2,
+                sort_keys=True,
             ),
             encoding="utf-8",
         )
-        return lineage_path
+        return lineage_path, checkpoint_dir
 
-    def test_model_card_uses_validated_release_provenance(self) -> None:
-        report = {
+    def _write_browser_artifact(self, root: Path, lineage_path: Path) -> Path:
+        browser_dir = root / "browser"
+        browser_dir.mkdir()
+        (browser_dir / "config.json").write_text("{}", encoding="utf-8")
+        (browser_dir / "onnx").mkdir()
+        (browser_dir / "onnx" / "encoder_model_int8.onnx").write_bytes(b"onnx")
+        write_artifact_lineage(
+            browser_dir,
+            source_lineage=json.loads(lineage_path.read_text(encoding="utf-8")),
+            source_lineage_sha256=file_sha256(lineage_path),
+            stage="browser",
+        )
+        return browser_dir
+
+    def _write_report(
+        self,
+        path: Path,
+        *,
+        split: str,
+        checkpoint_dir: Path | None,
+        adapter_digest: str | None = None,
+    ) -> Path:
+        report: dict[str, object] = {
             "macro": 1.0,
             "refusal_accuracy": 1.0,
             "multi_turn_accuracy": 1.0,
             "by_task": {"single_turn": 1.0},
         }
+        if checkpoint_dir is None:
+            report["provenance"] = {
+                "model_kind": "baseline",
+                "model_id": PRIMARY_BASE_MODEL_ID,
+                "model_revision": PRIMARY_BASE_MODEL_REVISION,
+                "base_model": PRIMARY_BASE_MODEL_ID,
+                "split": split,
+            }
+        else:
+            digest = adapter_digest or directory_sha256(checkpoint_dir)
+            report["provenance"] = {
+                "model_kind": "adapter",
+                "model_id": str(checkpoint_dir.resolve()),
+                "model_sha256": digest,
+                "adapter_model_id": str(checkpoint_dir.resolve()),
+                ADAPTER_DIGEST_FIELD: digest,
+                "base_model": PRIMARY_BASE_MODEL_ID,
+                "split": split,
+            }
+        path.write_text(json.dumps(report), encoding="utf-8")
+        return path
 
+    def _release_args(
+        self,
+        root: Path,
+        lineage_path: Path,
+        checkpoint_dir: Path,
+        browser_dir: Path,
+    ) -> argparse.Namespace:
+        return argparse.Namespace(
+            model_browser_dir=str(browser_dir),
+            output_dir=str(root / "hf"),
+            model_repo_id="owner/model",
+            dataset_repo_id="owner/dataset",
+            baseline_report=str(
+                self._write_report(
+                    root / "baseline.json",
+                    split="test",
+                    checkpoint_dir=None,
+                )
+            ),
+            validation_report=str(
+                self._write_report(
+                    root / "validation.json",
+                    split="validation",
+                    checkpoint_dir=checkpoint_dir,
+                )
+            ),
+            test_report=str(
+                self._write_report(
+                    root / "test.json",
+                    split="test",
+                    checkpoint_dir=checkpoint_dir,
+                )
+            ),
+            lineage_file=str(lineage_path),
+            release_date="2026-08-07",
+        )
+
+    def test_model_card_uses_validated_release_provenance(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
-            lineage_path = self._write_lineage(root)
-            browser_dir = root / "browser"
-            browser_dir.mkdir()
-            (browser_dir / "config.json").write_text("{}", encoding="utf-8")
-            report_path = root / "report.json"
-            report_path.write_text(json.dumps(report), encoding="utf-8")
-            args = argparse.Namespace(
-                model_browser_dir=str(browser_dir),
-                output_dir=str(root / "hf"),
-                model_repo_id="owner/model",
-                dataset_repo_id="owner/dataset",
-                baseline_report=str(report_path),
-                validation_report=str(report_path),
-                test_report=str(report_path),
-                lineage_file=str(lineage_path),
-                release_date="2026-08-07",
+            lineage_path, checkpoint_dir = self._write_lineage(root)
+            browser_dir = self._write_browser_artifact(root, lineage_path)
+            args = self._release_args(
+                root,
+                lineage_path,
+                checkpoint_dir,
+                browser_dir,
             )
+            expected_browser_digest = json.loads(
+                (browser_dir / "teapot_profile_qa_lineage.json").read_text(
+                    encoding="utf-8"
+                )
+            )["artifact_sha256"]
             model_dir = prepare_model_payload(args)
             model_card = (model_dir / "README.md").read_text(encoding="utf-8")
+            published_lineage = validate_artifact_lineage(
+                model_dir,
+                source_lineage_sha256=file_sha256(lineage_path),
+                stage="browser",
+            )
 
         self.assertIn("Promoted checkpoint: `checkpoint-80`", model_card)
         self.assertIn("Latest recorded train loss: 0.0312 at step 80", model_card)
         self.assertIn("Best recorded validation eval loss: 0.0400", model_card)
         self.assertIn("2026-08-07: Browser profile-QA export", model_card)
+        self.assertIn(expected_browser_digest, model_card)
+        self.assertEqual(published_lineage["artifact_sha256"], expected_browser_digest)
         self.assertNotIn("teapot-profile-qa-lora-v5/checkpoint-40", model_card)
         self.assertNotIn("0.0330", model_card)
         self.assertNotIn("0.0287", model_card)
@@ -89,17 +189,25 @@ class ModelCardProvenanceTests(unittest.TestCase):
 
     def test_missing_release_date_fails_clearly(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
-            lineage_path = self._write_lineage(Path(directory))
+            root = Path(directory)
+            lineage_path, _ = self._write_lineage(root)
+            browser_dir = self._write_browser_artifact(root, lineage_path)
 
             with self.assertRaisesRegex(ValueError, "release date is required"):
-                load_model_provenance(lineage_path, None)
+                load_model_provenance(lineage_path, browser_dir, None)
 
     def test_invalid_release_date_fails_clearly(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
-            lineage_path = self._write_lineage(Path(directory))
+            root = Path(directory)
+            lineage_path, _ = self._write_lineage(root)
+            browser_dir = self._write_browser_artifact(root, lineage_path)
 
             with self.assertRaisesRegex(ValueError, "must use YYYY-MM-DD"):
-                load_model_provenance(lineage_path, "August 7, 2026")
+                load_model_provenance(
+                    lineage_path,
+                    browser_dir,
+                    "August 7, 2026",
+                )
 
     def test_missing_training_metrics_fail_clearly(self) -> None:
         cases = [
@@ -109,13 +217,86 @@ class ModelCardProvenanceTests(unittest.TestCase):
         for log_history, expected_message in cases:
             with self.subTest(expected_message=expected_message):
                 with tempfile.TemporaryDirectory() as directory:
-                    lineage_path = self._write_lineage(
-                        Path(directory),
+                    root = Path(directory)
+                    lineage_path, _ = self._write_lineage(
+                        root,
                         log_history=log_history,
                     )
+                    browser_dir = self._write_browser_artifact(root, lineage_path)
 
                     with self.assertRaisesRegex(ValueError, expected_message):
-                        load_model_provenance(lineage_path, "2026-08-07")
+                        load_model_provenance(
+                            lineage_path,
+                            browser_dir,
+                            "2026-08-07",
+                        )
+
+    def test_tampered_browser_artifact_preserves_existing_model_payload(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            lineage_path, checkpoint_dir = self._write_lineage(root)
+            browser_dir = self._write_browser_artifact(root, lineage_path)
+            args = self._release_args(
+                root,
+                lineage_path,
+                checkpoint_dir,
+                browser_dir,
+            )
+            model_output_dir = root / "hf" / "model"
+            model_output_dir.mkdir(parents=True)
+            sentinel = model_output_dir / "keep.txt"
+            sentinel.write_text("unchanged", encoding="utf-8")
+            (browser_dir / "config.json").write_text('{"tampered": true}', encoding="utf-8")
+
+            with self.assertRaisesRegex(ValueError, "artifact digest"):
+                prepare_model_payload(args)
+
+            self.assertEqual(sentinel.read_text(encoding="utf-8"), "unchanged")
+
+    def test_browser_artifact_from_another_lineage_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            first_lineage, _ = self._write_lineage(root / "first")
+            browser_dir = self._write_browser_artifact(root, first_lineage)
+            selected_lineage, selected_checkpoint = self._write_lineage(
+                root / "selected"
+            )
+            args = self._release_args(
+                root,
+                selected_lineage,
+                selected_checkpoint,
+                browser_dir,
+            )
+
+            with self.assertRaisesRegex(ValueError, "selected merge lineage"):
+                prepare_model_payload(args)
+
+    def test_mismatched_evaluation_lineage_preserves_existing_payload(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            lineage_path, checkpoint_dir = self._write_lineage(root)
+            browser_dir = self._write_browser_artifact(root, lineage_path)
+            args = self._release_args(
+                root,
+                lineage_path,
+                checkpoint_dir,
+                browser_dir,
+            )
+            self._write_report(
+                Path(args.test_report),
+                split="test",
+                checkpoint_dir=checkpoint_dir,
+                adapter_digest="f" * 64,
+            )
+            model_output_dir = root / "hf" / "model"
+            model_output_dir.mkdir(parents=True)
+            sentinel = model_output_dir / "keep.txt"
+            sentinel.write_text("unchanged", encoding="utf-8")
+
+            with self.assertRaisesRegex(ValueError, "adapter digest"):
+                prepare_model_payload(args)
+
+            self.assertEqual(sentinel.read_text(encoding="utf-8"), "unchanged")
 
     def test_invalid_lineage_preserves_existing_model_payload(self) -> None:
         with tempfile.TemporaryDirectory() as directory:

--- a/ml/profile-qa/tests/test_model_card_provenance.py
+++ b/ml/profile-qa/tests/test_model_card_provenance.py
@@ -28,8 +28,10 @@ from profile_qa.provenance import (
     EXPECTED_LINEAGE_PIPELINE,
     LINEAGE_SCHEMA_VERSION,
     MERGED_DIGEST_FIELD,
+    SOURCE_LINEAGE_DIGEST_FIELD,
     directory_sha256,
     file_sha256,
+    public_lineage_sha256,
     validate_artifact_lineage,
     write_artifact_lineage,
 )
@@ -75,6 +77,7 @@ class ModelCardProvenanceTests(unittest.TestCase):
                     "peft_type": "LORA",
                     "r": 23,
                     "rank_pattern": {},
+                    "revision": PRIMARY_BASE_MODEL_REVISION,
                     "target_modules": ["k", "o"],
                     "task_type": "SEQ_2_SEQ_LM",
                     "use_dora": False,
@@ -118,7 +121,6 @@ class ModelCardProvenanceTests(unittest.TestCase):
         write_artifact_lineage(
             browser_dir,
             source_lineage=json.loads(lineage_path.read_text(encoding="utf-8")),
-            source_lineage_sha256=file_sha256(lineage_path),
             stage="browser",
             parent_artifact_sha256s={
                 "onnx-fp": "1" * 64,
@@ -229,11 +231,17 @@ class ModelCardProvenanceTests(unittest.TestCase):
                     encoding="utf-8"
                 )
             )["artifact_sha256"]
+            private_lineage_digest = file_sha256(lineage_path)
+            expected_public_lineage_digest = public_lineage_sha256(
+                json.loads(lineage_path.read_text(encoding="utf-8"))
+            )
             model_dir = prepare_model_payload(args)
             model_card = (model_dir / "README.md").read_text(encoding="utf-8")
             published_lineage = validate_artifact_lineage(
                 model_dir,
-                source_lineage_sha256=file_sha256(lineage_path),
+                source_lineage=json.loads(
+                    lineage_path.read_text(encoding="utf-8")
+                ),
                 stage="browser",
                 required_parent_stages=BROWSER_PARENT_ARTIFACT_STAGES,
             )
@@ -253,6 +261,14 @@ class ModelCardProvenanceTests(unittest.TestCase):
         self.assertIn(expected_browser_digest, model_card)
         self.assertEqual(published_lineage["artifact_sha256"], expected_browser_digest)
         self.assertNotIn("adapter_model_id", published_lineage)
+        self.assertEqual(
+            published_lineage[SOURCE_LINEAGE_DIGEST_FIELD],
+            expected_public_lineage_digest,
+        )
+        self.assertNotEqual(
+            published_lineage[SOURCE_LINEAGE_DIGEST_FIELD],
+            private_lineage_digest,
+        )
         self.assertEqual(
             published_lineage[ADAPTER_CHECKPOINT_FIELD],
             "checkpoint-80",
@@ -321,6 +337,7 @@ class ModelCardProvenanceTests(unittest.TestCase):
                     "peft_type": "LORA",
                     "r": 16,
                     "rank_pattern": {},
+                    "revision": PRIMARY_BASE_MODEL_REVISION,
                     "target_modules": ["q", "v"],
                     "use_dora": False,
                     "use_rslora": False,
@@ -355,6 +372,31 @@ class ModelCardProvenanceTests(unittest.TestCase):
             browser_dir = self._write_browser_artifact(root, lineage_path)
 
             with self.assertRaisesRegex(ValueError, "rank_pattern"):
+                load_model_provenance(
+                    lineage_path,
+                    browser_dir,
+                    "2026-08-07",
+                )
+
+    def test_checkpoint_training_revision_must_match_release_base(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            lineage_path, checkpoint_dir = self._write_lineage(root)
+            adapter_config_path = checkpoint_dir / "adapter_config.json"
+            adapter_config = json.loads(
+                adapter_config_path.read_text(encoding="utf-8")
+            )
+            adapter_config["revision"] = "0" * 40
+            adapter_config_path.write_text(
+                json.dumps(adapter_config),
+                encoding="utf-8",
+            )
+            lineage = json.loads(lineage_path.read_text(encoding="utf-8"))
+            lineage[ADAPTER_DIGEST_FIELD] = directory_sha256(checkpoint_dir)
+            lineage_path.write_text(json.dumps(lineage), encoding="utf-8")
+            browser_dir = self._write_browser_artifact(root, lineage_path)
+
+            with self.assertRaisesRegex(RuntimeError, "revision must be"):
                 load_model_provenance(
                     lineage_path,
                     browser_dir,
@@ -400,7 +442,6 @@ class ModelCardProvenanceTests(unittest.TestCase):
                 source_lineage=json.loads(
                     lineage_path.read_text(encoding="utf-8")
                 ),
-                source_lineage_sha256=file_sha256(lineage_path),
                 stage="browser",
                 parent_artifact_sha256s={
                     "onnx-fp": "1" * 64,
@@ -425,6 +466,19 @@ class ModelCardProvenanceTests(unittest.TestCase):
             browser_dir = self._write_browser_artifact(root, first_lineage)
             selected_lineage, selected_checkpoint = self._write_lineage(
                 root / "selected"
+            )
+            (selected_checkpoint / "adapter_model.safetensors").write_bytes(
+                b"different adapter"
+            )
+            selected_lineage_data = json.loads(
+                selected_lineage.read_text(encoding="utf-8")
+            )
+            selected_lineage_data[ADAPTER_DIGEST_FIELD] = directory_sha256(
+                selected_checkpoint
+            )
+            selected_lineage.write_text(
+                json.dumps(selected_lineage_data),
+                encoding="utf-8",
             )
             args = self._release_args(
                 root,
@@ -463,6 +517,136 @@ class ModelCardProvenanceTests(unittest.TestCase):
                 prepare_model_payload(args)
 
             self.assertEqual(sentinel.read_text(encoding="utf-8"), "unchanged")
+
+    def test_promoted_reports_must_use_one_model_representation(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            lineage_path, checkpoint_dir = self._write_lineage(root)
+            browser_dir = self._write_browser_artifact(root, lineage_path)
+            args = self._release_args(
+                root,
+                lineage_path,
+                checkpoint_dir,
+                browser_dir,
+            )
+            test_report_path = Path(args.test_report)
+            test_report = json.loads(test_report_path.read_text(encoding="utf-8"))
+            test_report["provenance"]["model_kind"] = "merged"
+            test_report["provenance"]["model_id"] = "merged-model"
+            test_report["provenance"]["model_sha256"] = "1" * 64
+            test_report_path.write_text(json.dumps(test_report), encoding="utf-8")
+
+            with self.assertRaisesRegex(ValueError, "same model representation"):
+                prepare_model_payload(args)
+
+            with self.assertRaisesRegex(ValueError, "same model representation"):
+                prepare_dataset_payload(args)
+
+    def test_report_provenance_cannot_publish_private_adapter_path(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            lineage_path, checkpoint_dir = self._write_lineage(root)
+            browser_dir = self._write_browser_artifact(root, lineage_path)
+            args = self._release_args(
+                root,
+                lineage_path,
+                checkpoint_dir,
+                browser_dir,
+            )
+            report_path = Path(args.validation_report)
+            report = json.loads(report_path.read_text(encoding="utf-8"))
+            report["provenance"]["adapter_model_id"] = str(checkpoint_dir)
+            report_path.write_text(json.dumps(report), encoding="utf-8")
+
+            with self.assertRaisesRegex(ValueError, "non-publishable provenance"):
+                prepare_model_payload(args)
+
+            with self.assertRaisesRegex(ValueError, "non-publishable provenance"):
+                prepare_dataset_payload(args)
+
+    def test_report_root_cannot_publish_private_metadata(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            lineage_path, checkpoint_dir = self._write_lineage(root)
+            browser_dir = self._write_browser_artifact(root, lineage_path)
+            args = self._release_args(
+                root,
+                lineage_path,
+                checkpoint_dir,
+                browser_dir,
+            )
+            report_path = Path(args.validation_report)
+            report = json.loads(report_path.read_text(encoding="utf-8"))
+            report["adapter_model_id"] = str(checkpoint_dir)
+            report_path.write_text(json.dumps(report), encoding="utf-8")
+
+            with self.assertRaisesRegex(ValueError, "non-publishable fields"):
+                prepare_dataset_payload(args)
+
+    def test_report_provenance_requires_the_complete_publishable_schema(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            lineage_path, checkpoint_dir = self._write_lineage(root)
+            browser_dir = self._write_browser_artifact(root, lineage_path)
+            args = self._release_args(
+                root,
+                lineage_path,
+                checkpoint_dir,
+                browser_dir,
+            )
+            report_path = Path(args.validation_report)
+            report = json.loads(report_path.read_text(encoding="utf-8"))
+            del report["provenance"][BASE_MODEL_REVISION_FIELD]
+            report_path.write_text(json.dumps(report), encoding="utf-8")
+
+            with self.assertRaisesRegex(ValueError, "missing required provenance"):
+                prepare_model_payload(args)
+
+            with self.assertRaisesRegex(ValueError, "missing required provenance"):
+                prepare_dataset_payload(args)
+
+    def test_dataset_reports_reject_private_model_id_values(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            lineage_path, checkpoint_dir = self._write_lineage(root)
+            browser_dir = self._write_browser_artifact(root, lineage_path)
+            args = self._release_args(
+                root,
+                lineage_path,
+                checkpoint_dir,
+                browser_dir,
+            )
+            private_model_id = str(checkpoint_dir.resolve())
+            for report_name in (args.validation_report, args.test_report):
+                report_path = Path(report_name)
+                report = json.loads(report_path.read_text(encoding="utf-8"))
+                report["provenance"]["model_id"] = private_model_id
+                report_path.write_text(json.dumps(report), encoding="utf-8")
+
+            with self.assertRaisesRegex(ValueError, "model_id must be"):
+                prepare_dataset_payload(args)
+
+    def test_dataset_baseline_slot_rejects_a_promoted_report(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            lineage_path, checkpoint_dir = self._write_lineage(root)
+            browser_dir = self._write_browser_artifact(root, lineage_path)
+            args = self._release_args(
+                root,
+                lineage_path,
+                checkpoint_dir,
+                browser_dir,
+            )
+            baseline_path = Path(args.baseline_report)
+            baseline_report = json.loads(baseline_path.read_text(encoding="utf-8"))
+            promoted_test = json.loads(
+                Path(args.test_report).read_text(encoding="utf-8")
+            )
+            baseline_report["provenance"] = promoted_test["provenance"]
+            baseline_path.write_text(json.dumps(baseline_report), encoding="utf-8")
+
+            with self.assertRaisesRegex(ValueError, "baseline model"):
+                prepare_dataset_payload(args)
 
     def test_stale_report_for_another_dataset_preserves_existing_payload(self) -> None:
         with tempfile.TemporaryDirectory() as directory:

--- a/ml/profile-qa/tests/test_model_security.py
+++ b/ml/profile-qa/tests/test_model_security.py
@@ -1,9 +1,17 @@
+import json
 import tempfile
 import unittest
 from pathlib import Path
+from types import SimpleNamespace
 
 from profile_qa.config import PRIMARY_BASE_MODEL_ID, PRIMARY_BASE_MODEL_REVISION
-from profile_qa.train_lora import require_local_model_path, trusted_model_load_kwargs
+from profile_qa.train_lora import (
+    ensure_adapter_base_lineage,
+    require_local_model_path,
+    resolve_resume_checkpoint,
+    run_training,
+    trusted_model_load_kwargs,
+)
 
 
 class ModelSecurityTests(unittest.TestCase):
@@ -30,6 +38,71 @@ class ModelSecurityTests(unittest.TestCase):
     def test_arbitrary_remote_model_is_rejected(self) -> None:
         with self.assertRaisesRegex(RuntimeError, "trusted local directory"):
             trusted_model_load_kwargs("untrusted/model-repository")
+
+    def test_adapter_lineage_requires_pinned_training_revision(self) -> None:
+        valid_config = {
+            "base_model_name_or_path": PRIMARY_BASE_MODEL_ID,
+            "revision": PRIMARY_BASE_MODEL_REVISION,
+        }
+        ensure_adapter_base_lineage(valid_config, source="test adapter")
+
+        for revision in (None, "0" * 40):
+            with (
+                self.subTest(revision=revision),
+                self.assertRaisesRegex(RuntimeError, "revision must be"),
+            ):
+                ensure_adapter_base_lineage(
+                    {
+                        "base_model_name_or_path": PRIMARY_BASE_MODEL_ID,
+                        "revision": revision,
+                    },
+                    source="test adapter",
+                )
+
+    def test_resume_uses_latest_revision_bound_checkpoint(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            output_dir = Path(directory)
+            for step in (40, 80):
+                checkpoint_dir = output_dir / f"checkpoint-{step}"
+                checkpoint_dir.mkdir()
+                (checkpoint_dir / "adapter_config.json").write_text(
+                    json.dumps(
+                        {
+                            "base_model_name_or_path": PRIMARY_BASE_MODEL_ID,
+                            "revision": PRIMARY_BASE_MODEL_REVISION,
+                        }
+                    ),
+                    encoding="utf-8",
+                )
+
+            self.assertEqual(
+                resolve_resume_checkpoint(output_dir),
+                output_dir / "checkpoint-80",
+            )
+
+    def test_resume_rejects_stale_latest_checkpoint_revision(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            output_dir = Path(directory)
+            checkpoint_dir = output_dir / "checkpoint-80"
+            checkpoint_dir.mkdir()
+            (checkpoint_dir / "adapter_config.json").write_text(
+                json.dumps(
+                    {
+                        "base_model_name_or_path": PRIMARY_BASE_MODEL_ID,
+                        "revision": "0" * 40,
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            with self.assertRaisesRegex(RuntimeError, "revision must be"):
+                resolve_resume_checkpoint(output_dir)
+
+    def test_resume_and_adapter_continuation_are_mutually_exclusive(self) -> None:
+        args = SimpleNamespace(resume=True, adapter_model_id="checkpoint-40")
+
+        with self.assertRaisesRegex(RuntimeError, "use exactly one"):
+            run_training(args)
 
 
 if __name__ == "__main__":

--- a/ml/profile-qa/tests/test_release_lineage.py
+++ b/ml/profile-qa/tests/test_release_lineage.py
@@ -32,7 +32,10 @@ from profile_qa.provenance import (
     MERGED_DIGEST_FIELD,
     PARENT_ARTIFACT_DIGESTS_FIELD,
     PROMPT_DIGEST_FIELD,
+    SOURCE_LINEAGE_DIGEST_FIELD,
     directory_sha256,
+    file_sha256,
+    public_lineage_sha256,
     validate_artifact_lineage,
     write_artifact_lineage,
 )
@@ -43,7 +46,12 @@ class ReleaseLineageTests(unittest.TestCase):
         adapter_dir = root / "checkpoint-80"
         adapter_dir.mkdir()
         (adapter_dir / "adapter_config.json").write_text(
-            json.dumps({"base_model_name_or_path": PRIMARY_BASE_MODEL_ID}),
+            json.dumps(
+                {
+                    "base_model_name_or_path": PRIMARY_BASE_MODEL_ID,
+                    "revision": PRIMARY_BASE_MODEL_REVISION,
+                }
+            ),
             encoding="utf-8",
         )
         (adapter_dir / "adapter_model.safetensors").write_bytes(b"adapter")
@@ -73,7 +81,6 @@ class ReleaseLineageTests(unittest.TestCase):
         directory: Path,
         *,
         lineage_data: dict[str, object],
-        lineage_sha256: str,
         stage: str,
         parent_artifact_sha256: str | None = None,
     ) -> None:
@@ -87,7 +94,6 @@ class ReleaseLineageTests(unittest.TestCase):
         write_artifact_lineage(
             directory,
             source_lineage=lineage_data,
-            source_lineage_sha256=lineage_sha256,
             stage=stage,
             parent_artifact_sha256s=(
                 {"onnx-fp": parent_artifact_sha256}
@@ -107,7 +113,6 @@ class ReleaseLineageTests(unittest.TestCase):
             self._write_onnx_stage(
                 fp_dir,
                 lineage_data=lineage.data,
-                lineage_sha256=lineage.sha256,
                 stage="onnx-fp",
             )
             fp_artifact_sha256 = json.loads(
@@ -116,14 +121,12 @@ class ReleaseLineageTests(unittest.TestCase):
             self._write_onnx_stage(
                 int8_dir,
                 lineage_data=lineage.data,
-                lineage_sha256=lineage.sha256,
                 stage="onnx-int8",
                 parent_artifact_sha256=fp_artifact_sha256,
             )
             self._write_onnx_stage(
                 uint8_dir,
                 lineage_data=lineage.data,
-                lineage_sha256=lineage.sha256,
                 stage="onnx-uint8",
                 parent_artifact_sha256=fp_artifact_sha256,
             )
@@ -137,12 +140,17 @@ class ReleaseLineageTests(unittest.TestCase):
             )
             marker = validate_artifact_lineage(
                 browser_dir,
-                source_lineage_sha256=lineage.sha256,
+                source_lineage=lineage.data,
                 stage="browser",
                 required_parent_stages=BROWSER_PARENT_ARTIFACT_STAGES,
             )
 
             self.assertNotIn("adapter_model_id", marker)
+            self.assertEqual(marker[SOURCE_LINEAGE_DIGEST_FIELD], lineage.sha256)
+            self.assertNotEqual(
+                marker[SOURCE_LINEAGE_DIGEST_FIELD],
+                file_sha256(merged_dir / LINEAGE_FILENAME),
+            )
             self.assertEqual(marker[ADAPTER_CHECKPOINT_FIELD], adapter_dir.name)
             self.assertEqual(marker[MERGED_DIGEST_FIELD], lineage.data[MERGED_DIGEST_FIELD])
             parent_digests = marker[PARENT_ARTIFACT_DIGESTS_FIELD]
@@ -160,6 +168,25 @@ class ReleaseLineageTests(unittest.TestCase):
                 )[ARTIFACT_DIGEST_FIELD],
             )
             self.assertTrue((browser_dir / LINEAGE_FILENAME).is_file())
+
+    def test_public_lineage_digest_is_independent_of_private_adapter_path(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            merged_dir, _ = self._write_merged_model(Path(directory))
+            lineage_path = merged_dir / LINEAGE_FILENAME
+            lineage = json.loads(lineage_path.read_text(encoding="utf-8"))
+            relocated_lineage = dict(lineage)
+            relocated_lineage["adapter_model_id"] = (
+                "/home/another-user/checkpoints/checkpoint-80"
+            )
+
+            self.assertEqual(
+                public_lineage_sha256(lineage),
+                public_lineage_sha256(relocated_lineage),
+            )
+            self.assertNotEqual(
+                file_sha256(lineage_path),
+                public_lineage_sha256(lineage),
+            )
 
     def test_full_precision_export_replaces_existing_stage_tree(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
@@ -180,7 +207,7 @@ class ReleaseLineageTests(unittest.TestCase):
             self.assertFalse(sentinel.exists())
             validate_artifact_lineage(
                 fp_dir,
-                source_lineage_sha256=lineage.sha256,
+                source_lineage=lineage.data,
                 stage="onnx-fp",
             )
 
@@ -244,7 +271,6 @@ class ReleaseLineageTests(unittest.TestCase):
             self._write_onnx_stage(
                 fp_dir,
                 lineage_data=lineage.data,
-                lineage_sha256=lineage.sha256,
                 stage="onnx-fp",
             )
             first_fp_sha256 = json.loads(
@@ -257,7 +283,6 @@ class ReleaseLineageTests(unittest.TestCase):
                 self._write_onnx_stage(
                     quantized_dir,
                     lineage_data=lineage.data,
-                    lineage_sha256=lineage.sha256,
                     stage=f"onnx-{dtype}",
                     parent_artifact_sha256=first_fp_sha256,
                 )
@@ -266,7 +291,6 @@ class ReleaseLineageTests(unittest.TestCase):
             write_artifact_lineage(
                 fp_dir,
                 source_lineage=lineage.data,
-                source_lineage_sha256=lineage.sha256,
                 stage="onnx-fp",
             )
 
@@ -289,7 +313,6 @@ class ReleaseLineageTests(unittest.TestCase):
             marker_path = write_artifact_lineage(
                 artifact_dir,
                 source_lineage=lineage.data,
-                source_lineage_sha256=lineage.sha256,
                 stage="browser",
             )
             marker = json.loads(marker_path.read_text(encoding="utf-8"))
@@ -299,8 +322,35 @@ class ReleaseLineageTests(unittest.TestCase):
             with self.assertRaisesRegex(ValueError, "non-publishable fields"):
                 validate_artifact_lineage(
                     artifact_dir,
-                    source_lineage_sha256=lineage.sha256,
+                    source_lineage=lineage.data,
                     stage="browser",
+                )
+
+    def test_artifact_lineage_rejects_tampered_public_field(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            merged_dir, _ = self._write_merged_model(root)
+            lineage = ensure_teapot_export_model(str(merged_dir))
+            artifact_dir = root / "onnx"
+            artifact_dir.mkdir()
+            (artifact_dir / "model.onnx").write_bytes(b"model")
+            marker_path = write_artifact_lineage(
+                artifact_dir,
+                source_lineage=lineage.data,
+                stage="onnx-fp",
+            )
+            marker = json.loads(marker_path.read_text(encoding="utf-8"))
+            marker[ADAPTER_CHECKPOINT_FIELD] = "checkpoint-999"
+            marker_path.write_text(json.dumps(marker), encoding="utf-8")
+
+            with self.assertRaisesRegex(
+                ValueError,
+                "public fields do not match",
+            ):
+                validate_artifact_lineage(
+                    artifact_dir,
+                    source_lineage=lineage.data,
+                    stage="onnx-fp",
                 )
 
     def test_merged_model_tampering_breaks_lineage_validation(self) -> None:
@@ -359,13 +409,39 @@ class ReleaseLineageTests(unittest.TestCase):
             )
             self.assertEqual(provenance["split"], "validation")
 
+    def test_evaluation_rejects_adapter_from_another_base_revision(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            _, adapter_dir = self._write_merged_model(Path(directory))
+            adapter_config_path = adapter_dir / "adapter_config.json"
+            adapter_config = json.loads(
+                adapter_config_path.read_text(encoding="utf-8")
+            )
+            adapter_config["revision"] = "0" * 40
+            adapter_config_path.write_text(
+                json.dumps(adapter_config),
+                encoding="utf-8",
+            )
+
+            with self.assertRaisesRegex(RuntimeError, "revision must be"):
+                evaluation_provenance(
+                    str(adapter_dir),
+                    "validation",
+                    "d" * 64,
+                    "e" * 64,
+                )
+
     def test_evaluation_provenance_rejects_nonportable_checkpoint_label(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
             adapter_dir = root / "checkpoint with spaces"
             adapter_dir.mkdir()
             (adapter_dir / "adapter_config.json").write_text(
-                json.dumps({"base_model_name_or_path": PRIMARY_BASE_MODEL_ID}),
+                json.dumps(
+                    {
+                        "base_model_name_or_path": PRIMARY_BASE_MODEL_ID,
+                        "revision": PRIMARY_BASE_MODEL_REVISION,
+                    }
+                ),
                 encoding="utf-8",
             )
 

--- a/ml/profile-qa/tests/test_release_lineage.py
+++ b/ml/profile-qa/tests/test_release_lineage.py
@@ -4,9 +4,11 @@ import json
 import tempfile
 import unittest
 from pathlib import Path
+from unittest.mock import patch
 
 from profile_qa.config import PRIMARY_BASE_MODEL_ID, PRIMARY_BASE_MODEL_REVISION
 from profile_qa.evaluate import (
+    GENERATION_CONFIG_FIELD,
     evaluation_provenance,
     load_prediction_bundle,
     write_prediction_bundle,
@@ -14,16 +16,20 @@ from profile_qa.evaluate import (
 from profile_qa.export_onnx import (
     assemble_browser_artifact,
     ensure_teapot_export_model,
+    export_onnx,
 )
 from profile_qa.provenance import (
     ADAPTER_CHECKPOINT_FIELD,
     ADAPTER_DIGEST_FIELD,
+    ARTIFACT_DIGEST_FIELD,
     BASE_MODEL_REVISION_FIELD,
+    BROWSER_PARENT_ARTIFACT_STAGES,
     DATASET_DIGEST_FIELD,
     EXPECTED_LINEAGE_PIPELINE,
     LINEAGE_FILENAME,
     LINEAGE_SCHEMA_VERSION,
     MERGED_DIGEST_FIELD,
+    PARENT_ARTIFACT_DIGESTS_FIELD,
     PROMPT_DIGEST_FIELD,
     directory_sha256,
     validate_artifact_lineage,
@@ -68,6 +74,7 @@ class ReleaseLineageTests(unittest.TestCase):
         lineage_data: dict[str, object],
         lineage_sha256: str,
         stage: str,
+        parent_artifact_sha256: str | None = None,
     ) -> None:
         directory.mkdir(parents=True)
         (directory / "encoder_model.onnx").write_bytes(f"{stage}-encoder".encode())
@@ -81,6 +88,11 @@ class ReleaseLineageTests(unittest.TestCase):
             source_lineage=lineage_data,
             source_lineage_sha256=lineage_sha256,
             stage=stage,
+            parent_artifact_sha256s=(
+                {"onnx-fp": parent_artifact_sha256}
+                if parent_artifact_sha256 is not None
+                else None
+            ),
         )
 
     def test_browser_export_preserves_verified_lineage_and_digest(self) -> None:
@@ -97,17 +109,22 @@ class ReleaseLineageTests(unittest.TestCase):
                 lineage_sha256=lineage.sha256,
                 stage="onnx-fp",
             )
+            fp_artifact_sha256 = json.loads(
+                (fp_dir / LINEAGE_FILENAME).read_text(encoding="utf-8")
+            )[ARTIFACT_DIGEST_FIELD]
             self._write_onnx_stage(
                 int8_dir,
                 lineage_data=lineage.data,
                 lineage_sha256=lineage.sha256,
                 stage="onnx-int8",
+                parent_artifact_sha256=fp_artifact_sha256,
             )
             self._write_onnx_stage(
                 uint8_dir,
                 lineage_data=lineage.data,
                 lineage_sha256=lineage.sha256,
                 stage="onnx-uint8",
+                parent_artifact_sha256=fp_artifact_sha256,
             )
             browser_dir = root / "browser"
 
@@ -121,12 +138,106 @@ class ReleaseLineageTests(unittest.TestCase):
                 browser_dir,
                 source_lineage_sha256=lineage.sha256,
                 stage="browser",
+                required_parent_stages=BROWSER_PARENT_ARTIFACT_STAGES,
             )
 
             self.assertNotIn("adapter_model_id", marker)
             self.assertEqual(marker[ADAPTER_CHECKPOINT_FIELD], adapter_dir.name)
             self.assertEqual(marker[MERGED_DIGEST_FIELD], lineage.data[MERGED_DIGEST_FIELD])
+            parent_digests = marker[PARENT_ARTIFACT_DIGESTS_FIELD]
+            self.assertEqual(parent_digests["onnx-fp"], fp_artifact_sha256)
+            self.assertEqual(
+                parent_digests["onnx-int8"],
+                json.loads(
+                    (int8_dir / LINEAGE_FILENAME).read_text(encoding="utf-8")
+                )[ARTIFACT_DIGEST_FIELD],
+            )
+            self.assertEqual(
+                parent_digests["onnx-uint8"],
+                json.loads(
+                    (uint8_dir / LINEAGE_FILENAME).read_text(encoding="utf-8")
+                )[ARTIFACT_DIGEST_FIELD],
+            )
             self.assertTrue((browser_dir / LINEAGE_FILENAME).is_file())
+
+    def test_full_precision_export_replaces_existing_stage_tree(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            merged_dir, _ = self._write_merged_model(root)
+            fp_dir = root / "candidate" / "onnx"
+            fp_dir.mkdir(parents=True)
+            sentinel = fp_dir / "stale.json"
+            sentinel.write_text("stale", encoding="utf-8")
+
+            def fake_export(_command: list[str]) -> None:
+                (fp_dir / "config.json").write_text("{}", encoding="utf-8")
+                (fp_dir / "encoder_model.onnx").write_bytes(b"fresh")
+
+            with patch("profile_qa.export_onnx.run_command", side_effect=fake_export):
+                lineage = export_onnx(str(merged_dir), fp_dir)
+
+            self.assertFalse(sentinel.exists())
+            validate_artifact_lineage(
+                fp_dir,
+                source_lineage_sha256=lineage.sha256,
+                stage="onnx-fp",
+            )
+
+    def test_full_precision_export_rejects_source_overlap(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            merged_dir, _ = self._write_merged_model(root)
+            source_file = merged_dir / "model.safetensors"
+
+            with self.assertRaisesRegex(RuntimeError, "must not overlap"):
+                export_onnx(str(merged_dir), merged_dir / "onnx")
+
+            self.assertTrue(source_file.is_file())
+
+    def test_same_lineage_reexport_rejects_stale_quantized_stages(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            merged_dir, _ = self._write_merged_model(root)
+            lineage = ensure_teapot_export_model(str(merged_dir))
+            fp_dir = root / "onnx"
+            int8_dir = root / "int8"
+            uint8_dir = root / "uint8"
+            self._write_onnx_stage(
+                fp_dir,
+                lineage_data=lineage.data,
+                lineage_sha256=lineage.sha256,
+                stage="onnx-fp",
+            )
+            first_fp_sha256 = json.loads(
+                (fp_dir / LINEAGE_FILENAME).read_text(encoding="utf-8")
+            )[ARTIFACT_DIGEST_FIELD]
+            for dtype, quantized_dir in (
+                ("int8", int8_dir),
+                ("uint8", uint8_dir),
+            ):
+                self._write_onnx_stage(
+                    quantized_dir,
+                    lineage_data=lineage.data,
+                    lineage_sha256=lineage.sha256,
+                    stage=f"onnx-{dtype}",
+                    parent_artifact_sha256=first_fp_sha256,
+                )
+
+            (fp_dir / "encoder_model.onnx").write_bytes(b"fresh-fp-encoder")
+            write_artifact_lineage(
+                fp_dir,
+                source_lineage=lineage.data,
+                source_lineage_sha256=lineage.sha256,
+                stage="onnx-fp",
+            )
+
+            with self.assertRaisesRegex(ValueError, "parent artifact digest"):
+                assemble_browser_artifact(
+                    fp_dir,
+                    {"int8": int8_dir, "uint8": uint8_dir},
+                    root / "browser",
+                    lineage,
+                )
 
     def test_artifact_lineage_rejects_injected_local_path(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
@@ -273,6 +384,34 @@ class ReleaseLineageTests(unittest.TestCase):
             stale_bundle = json.loads(bundle_path.read_text(encoding="utf-8"))
             stale_bundle["provenance"][ADAPTER_DIGEST_FIELD] = "f" * 64
             stale_bundle["provenance"]["model_sha256"] = "f" * 64
+            bundle_path.write_text(json.dumps(stale_bundle), encoding="utf-8")
+
+            with self.assertRaisesRegex(ValueError, "prediction provenance"):
+                load_prediction_bundle(
+                    bundle_path,
+                    expected_provenance=provenance,
+                    records=records,
+                )
+
+    def test_saved_predictions_require_matching_generation_contract(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            bundle_path = Path(directory) / "predictions.json"
+            records = [{"id": "example"}]
+            provenance = evaluation_provenance(
+                PRIMARY_BASE_MODEL_ID,
+                "test",
+                "d" * 64,
+                "e" * 64,
+            )
+            write_prediction_bundle(
+                bundle_path,
+                predictions={"example": "saved answer"},
+                provenance=provenance,
+            )
+            stale_bundle = json.loads(bundle_path.read_text(encoding="utf-8"))
+            stale_bundle["provenance"][GENERATION_CONFIG_FIELD][
+                "max_new_tokens"
+            ] = 80
             bundle_path.write_text(json.dumps(stale_bundle), encoding="utf-8")
 
             with self.assertRaisesRegex(ValueError, "prediction provenance"):

--- a/ml/profile-qa/tests/test_release_lineage.py
+++ b/ml/profile-qa/tests/test_release_lineage.py
@@ -6,7 +6,11 @@ import unittest
 from pathlib import Path
 
 from profile_qa.config import PRIMARY_BASE_MODEL_ID, PRIMARY_BASE_MODEL_REVISION
-from profile_qa.evaluate import evaluation_provenance
+from profile_qa.evaluate import (
+    evaluation_provenance,
+    load_prediction_bundle,
+    write_prediction_bundle,
+)
 from profile_qa.export_onnx import (
     assemble_browser_artifact,
     ensure_teapot_export_model,
@@ -20,6 +24,7 @@ from profile_qa.provenance import (
     LINEAGE_FILENAME,
     LINEAGE_SCHEMA_VERSION,
     MERGED_DIGEST_FIELD,
+    PROMPT_DIGEST_FIELD,
     directory_sha256,
     validate_artifact_lineage,
     write_artifact_lineage,
@@ -168,7 +173,12 @@ class ReleaseLineageTests(unittest.TestCase):
                 ensure_teapot_export_model(str(merged_dir))
 
     def test_evaluation_provenance_identifies_baseline_revision(self) -> None:
-        provenance = evaluation_provenance(PRIMARY_BASE_MODEL_ID, "test", "d" * 64)
+        provenance = evaluation_provenance(
+            PRIMARY_BASE_MODEL_ID,
+            "test",
+            "d" * 64,
+            "e" * 64,
+        )
 
         self.assertEqual(provenance["model_kind"], "baseline")
         self.assertEqual(
@@ -176,6 +186,7 @@ class ReleaseLineageTests(unittest.TestCase):
             PRIMARY_BASE_MODEL_REVISION,
         )
         self.assertEqual(provenance[DATASET_DIGEST_FIELD], "d" * 64)
+        self.assertEqual(provenance[PROMPT_DIGEST_FIELD], "e" * 64)
         self.assertEqual(provenance["split"], "test")
 
     def test_evaluation_provenance_hashes_selected_adapter(self) -> None:
@@ -186,6 +197,7 @@ class ReleaseLineageTests(unittest.TestCase):
                 str(adapter_dir),
                 "validation",
                 "d" * 64,
+                "e" * 64,
             )
 
             self.assertEqual(provenance["model_kind"], "adapter")
@@ -208,7 +220,12 @@ class ReleaseLineageTests(unittest.TestCase):
             )
 
             with self.assertRaisesRegex(ValueError, "portable ASCII label"):
-                evaluation_provenance(str(adapter_dir), "test", "d" * 64)
+                evaluation_provenance(
+                    str(adapter_dir),
+                    "test",
+                    "d" * 64,
+                    "e" * 64,
+                )
 
     def test_evaluation_provenance_preserves_merged_adapter_lineage(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
@@ -218,6 +235,7 @@ class ReleaseLineageTests(unittest.TestCase):
                 str(merged_dir),
                 "test",
                 "d" * 64,
+                "e" * 64,
             )
 
             self.assertEqual(provenance["model_kind"], "merged")
@@ -234,6 +252,82 @@ class ReleaseLineageTests(unittest.TestCase):
                     excluded_relative_paths=frozenset({LINEAGE_FILENAME}),
                 ),
             )
+
+    def test_saved_predictions_require_matching_model_provenance(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            _, adapter_dir = self._write_merged_model(root)
+            records = [{"id": "example"}]
+            provenance = evaluation_provenance(
+                str(adapter_dir),
+                "test",
+                "d" * 64,
+                "e" * 64,
+            )
+            bundle_path = root / "predictions.json"
+            write_prediction_bundle(
+                bundle_path,
+                predictions={"example": "saved answer"},
+                provenance=provenance,
+            )
+            stale_bundle = json.loads(bundle_path.read_text(encoding="utf-8"))
+            stale_bundle["provenance"][ADAPTER_DIGEST_FIELD] = "f" * 64
+            stale_bundle["provenance"]["model_sha256"] = "f" * 64
+            bundle_path.write_text(json.dumps(stale_bundle), encoding="utf-8")
+
+            with self.assertRaisesRegex(ValueError, "prediction provenance"):
+                load_prediction_bundle(
+                    bundle_path,
+                    expected_provenance=provenance,
+                    records=records,
+                )
+
+    def test_saved_predictions_round_trip_with_exact_record_ids(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            bundle_path = Path(directory) / "predictions.json"
+            records = [{"id": "first"}, {"id": "second"}]
+            provenance = evaluation_provenance(
+                PRIMARY_BASE_MODEL_ID,
+                "test",
+                "d" * 64,
+                "e" * 64,
+            )
+            predictions = {"first": "one", "second": "two"}
+            write_prediction_bundle(
+                bundle_path,
+                predictions=predictions,
+                provenance=provenance,
+            )
+
+            self.assertEqual(
+                load_prediction_bundle(
+                    bundle_path,
+                    expected_provenance=provenance,
+                    records=records,
+                ),
+                predictions,
+            )
+
+    def test_plain_saved_prediction_mapping_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            bundle_path = Path(directory) / "predictions.json"
+            bundle_path.write_text(
+                json.dumps({"example": "unbound answer"}),
+                encoding="utf-8",
+            )
+            provenance = evaluation_provenance(
+                PRIMARY_BASE_MODEL_ID,
+                "test",
+                "d" * 64,
+                "e" * 64,
+            )
+
+            with self.assertRaisesRegex(ValueError, "missing object field 'provenance'"):
+                load_prediction_bundle(
+                    bundle_path,
+                    expected_provenance=provenance,
+                    records=[{"id": "example"}],
+                )
 
 
 if __name__ == "__main__":

--- a/ml/profile-qa/tests/test_release_lineage.py
+++ b/ml/profile-qa/tests/test_release_lineage.py
@@ -18,6 +18,7 @@ from profile_qa.export_onnx import (
     ensure_teapot_export_model,
     export_onnx,
 )
+from profile_qa.merge_adapter import prepare_merge_output_directory
 from profile_qa.provenance import (
     ADAPTER_CHECKPOINT_FIELD,
     ADAPTER_DIGEST_FIELD,
@@ -193,6 +194,44 @@ class ReleaseLineageTests(unittest.TestCase):
                 export_onnx(str(merged_dir), merged_dir / "onnx")
 
             self.assertTrue(source_file.is_file())
+
+    def test_merge_output_rejects_adapter_path_overlap_without_writing(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            adapter_dir = root / "checkpoint-80"
+            adapter_dir.mkdir()
+            adapter_file = adapter_dir / "adapter_model.safetensors"
+            adapter_file.write_bytes(b"adapter")
+            cases = (
+                adapter_dir,
+                adapter_dir / "merged",
+                root,
+            )
+
+            for output_dir in cases:
+                with (
+                    self.subTest(output_dir=output_dir),
+                    self.assertRaisesRegex(RuntimeError, "must not overlap"),
+                ):
+                    prepare_merge_output_directory(adapter_dir, output_dir)
+
+            self.assertEqual(adapter_file.read_bytes(), b"adapter")
+            self.assertFalse((adapter_dir / "merged").exists())
+
+    def test_merge_output_replaces_stale_disjoint_tree(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            adapter_dir = root / "checkpoint-80"
+            adapter_dir.mkdir()
+            output_dir = root / "merged"
+            output_dir.mkdir()
+            sentinel = output_dir / "stale.json"
+            sentinel.write_text("stale", encoding="utf-8")
+
+            prepare_merge_output_directory(adapter_dir, output_dir)
+
+            self.assertTrue(output_dir.is_dir())
+            self.assertFalse(sentinel.exists())
 
     def test_same_lineage_reexport_rejects_stale_quantized_stages(self) -> None:
         with tempfile.TemporaryDirectory() as directory:

--- a/ml/profile-qa/tests/test_release_lineage.py
+++ b/ml/profile-qa/tests/test_release_lineage.py
@@ -12,7 +12,10 @@ from profile_qa.export_onnx import (
     ensure_teapot_export_model,
 )
 from profile_qa.provenance import (
+    ADAPTER_CHECKPOINT_FIELD,
     ADAPTER_DIGEST_FIELD,
+    BASE_MODEL_REVISION_FIELD,
+    DATASET_DIGEST_FIELD,
     EXPECTED_LINEAGE_PIPELINE,
     LINEAGE_FILENAME,
     LINEAGE_SCHEMA_VERSION,
@@ -40,8 +43,10 @@ class ReleaseLineageTests(unittest.TestCase):
         lineage = {
             "schema_version": LINEAGE_SCHEMA_VERSION,
             "adapter_model_id": str(adapter_dir.resolve()),
+            ADAPTER_CHECKPOINT_FIELD: adapter_dir.name,
             ADAPTER_DIGEST_FIELD: directory_sha256(adapter_dir),
             "base_model": PRIMARY_BASE_MODEL_ID,
+            BASE_MODEL_REVISION_FIELD: PRIMARY_BASE_MODEL_REVISION,
             "pipeline": EXPECTED_LINEAGE_PIPELINE,
             MERGED_DIGEST_FIELD: directory_sha256(merged_dir),
         }
@@ -76,7 +81,7 @@ class ReleaseLineageTests(unittest.TestCase):
     def test_browser_export_preserves_verified_lineage_and_digest(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
-            merged_dir, _ = self._write_merged_model(root)
+            merged_dir, adapter_dir = self._write_merged_model(root)
             lineage = ensure_teapot_export_model(str(merged_dir))
             fp_dir = root / "onnx"
             int8_dir = root / "int8"
@@ -113,9 +118,35 @@ class ReleaseLineageTests(unittest.TestCase):
                 stage="browser",
             )
 
-            self.assertEqual(marker["adapter_model_id"], lineage.data["adapter_model_id"])
+            self.assertNotIn("adapter_model_id", marker)
+            self.assertEqual(marker[ADAPTER_CHECKPOINT_FIELD], adapter_dir.name)
             self.assertEqual(marker[MERGED_DIGEST_FIELD], lineage.data[MERGED_DIGEST_FIELD])
             self.assertTrue((browser_dir / LINEAGE_FILENAME).is_file())
+
+    def test_artifact_lineage_rejects_injected_local_path(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            merged_dir, adapter_dir = self._write_merged_model(root)
+            lineage = ensure_teapot_export_model(str(merged_dir))
+            artifact_dir = root / "browser"
+            artifact_dir.mkdir()
+            (artifact_dir / "model.onnx").write_bytes(b"model")
+            marker_path = write_artifact_lineage(
+                artifact_dir,
+                source_lineage=lineage.data,
+                source_lineage_sha256=lineage.sha256,
+                stage="browser",
+            )
+            marker = json.loads(marker_path.read_text(encoding="utf-8"))
+            marker["adapter_model_id"] = str(adapter_dir.resolve())
+            marker_path.write_text(json.dumps(marker), encoding="utf-8")
+
+            with self.assertRaisesRegex(ValueError, "non-publishable fields"):
+                validate_artifact_lineage(
+                    artifact_dir,
+                    source_lineage_sha256=lineage.sha256,
+                    stage="browser",
+                )
 
     def test_merged_model_tampering_breaks_lineage_validation(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
@@ -125,35 +156,73 @@ class ReleaseLineageTests(unittest.TestCase):
             with self.assertRaisesRegex(RuntimeError, "merged model digest"):
                 ensure_teapot_export_model(str(merged_dir))
 
+    def test_merge_lineage_from_another_base_revision_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            merged_dir, _ = self._write_merged_model(Path(directory))
+            lineage_path = merged_dir / LINEAGE_FILENAME
+            lineage = json.loads(lineage_path.read_text(encoding="utf-8"))
+            lineage[BASE_MODEL_REVISION_FIELD] = "0" * 40
+            lineage_path.write_text(json.dumps(lineage), encoding="utf-8")
+
+            with self.assertRaisesRegex(RuntimeError, BASE_MODEL_REVISION_FIELD):
+                ensure_teapot_export_model(str(merged_dir))
+
     def test_evaluation_provenance_identifies_baseline_revision(self) -> None:
-        provenance = evaluation_provenance(PRIMARY_BASE_MODEL_ID, "test")
+        provenance = evaluation_provenance(PRIMARY_BASE_MODEL_ID, "test", "d" * 64)
 
         self.assertEqual(provenance["model_kind"], "baseline")
-        self.assertEqual(provenance["model_revision"], PRIMARY_BASE_MODEL_REVISION)
+        self.assertEqual(
+            provenance[BASE_MODEL_REVISION_FIELD],
+            PRIMARY_BASE_MODEL_REVISION,
+        )
+        self.assertEqual(provenance[DATASET_DIGEST_FIELD], "d" * 64)
         self.assertEqual(provenance["split"], "test")
 
     def test_evaluation_provenance_hashes_selected_adapter(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             _, adapter_dir = self._write_merged_model(Path(directory))
 
-            provenance = evaluation_provenance(str(adapter_dir), "validation")
+            provenance = evaluation_provenance(
+                str(adapter_dir),
+                "validation",
+                "d" * 64,
+            )
 
             self.assertEqual(provenance["model_kind"], "adapter")
-            self.assertEqual(provenance["adapter_model_id"], str(adapter_dir.resolve()))
+            self.assertEqual(provenance[ADAPTER_CHECKPOINT_FIELD], adapter_dir.name)
+            self.assertNotIn("adapter_model_id", provenance)
             self.assertEqual(
                 provenance[ADAPTER_DIGEST_FIELD],
                 directory_sha256(adapter_dir),
             )
             self.assertEqual(provenance["split"], "validation")
 
+    def test_evaluation_provenance_rejects_nonportable_checkpoint_label(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            adapter_dir = root / "checkpoint with spaces"
+            adapter_dir.mkdir()
+            (adapter_dir / "adapter_config.json").write_text(
+                json.dumps({"base_model_name_or_path": PRIMARY_BASE_MODEL_ID}),
+                encoding="utf-8",
+            )
+
+            with self.assertRaisesRegex(ValueError, "portable ASCII label"):
+                evaluation_provenance(str(adapter_dir), "test", "d" * 64)
+
     def test_evaluation_provenance_preserves_merged_adapter_lineage(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             merged_dir, adapter_dir = self._write_merged_model(Path(directory))
 
-            provenance = evaluation_provenance(str(merged_dir), "test")
+            provenance = evaluation_provenance(
+                str(merged_dir),
+                "test",
+                "d" * 64,
+            )
 
             self.assertEqual(provenance["model_kind"], "merged")
-            self.assertEqual(provenance["adapter_model_id"], str(adapter_dir.resolve()))
+            self.assertEqual(provenance[ADAPTER_CHECKPOINT_FIELD], adapter_dir.name)
+            self.assertNotIn("adapter_model_id", provenance)
             self.assertEqual(
                 provenance[ADAPTER_DIGEST_FIELD],
                 directory_sha256(adapter_dir),

--- a/ml/profile-qa/tests/test_release_lineage.py
+++ b/ml/profile-qa/tests/test_release_lineage.py
@@ -1,0 +1,171 @@
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from profile_qa.config import PRIMARY_BASE_MODEL_ID, PRIMARY_BASE_MODEL_REVISION
+from profile_qa.evaluate import evaluation_provenance
+from profile_qa.export_onnx import (
+    assemble_browser_artifact,
+    ensure_teapot_export_model,
+)
+from profile_qa.provenance import (
+    ADAPTER_DIGEST_FIELD,
+    EXPECTED_LINEAGE_PIPELINE,
+    LINEAGE_FILENAME,
+    LINEAGE_SCHEMA_VERSION,
+    MERGED_DIGEST_FIELD,
+    directory_sha256,
+    validate_artifact_lineage,
+    write_artifact_lineage,
+)
+
+
+class ReleaseLineageTests(unittest.TestCase):
+    def _write_merged_model(self, root: Path) -> tuple[Path, Path]:
+        adapter_dir = root / "checkpoint-80"
+        adapter_dir.mkdir()
+        (adapter_dir / "adapter_config.json").write_text(
+            json.dumps({"base_model_name_or_path": PRIMARY_BASE_MODEL_ID}),
+            encoding="utf-8",
+        )
+        (adapter_dir / "adapter_model.safetensors").write_bytes(b"adapter")
+
+        merged_dir = root / "merged"
+        merged_dir.mkdir()
+        (merged_dir / "config.json").write_text("{}", encoding="utf-8")
+        (merged_dir / "model.safetensors").write_bytes(b"merged")
+        lineage = {
+            "schema_version": LINEAGE_SCHEMA_VERSION,
+            "adapter_model_id": str(adapter_dir.resolve()),
+            ADAPTER_DIGEST_FIELD: directory_sha256(adapter_dir),
+            "base_model": PRIMARY_BASE_MODEL_ID,
+            "pipeline": EXPECTED_LINEAGE_PIPELINE,
+            MERGED_DIGEST_FIELD: directory_sha256(merged_dir),
+        }
+        (merged_dir / LINEAGE_FILENAME).write_text(
+            json.dumps(lineage, indent=2, sort_keys=True),
+            encoding="utf-8",
+        )
+        return merged_dir, adapter_dir
+
+    def _write_onnx_stage(
+        self,
+        directory: Path,
+        *,
+        lineage_data: dict[str, object],
+        lineage_sha256: str,
+        stage: str,
+    ) -> None:
+        directory.mkdir(parents=True)
+        (directory / "encoder_model.onnx").write_bytes(f"{stage}-encoder".encode())
+        (directory / "decoder_model_merged.onnx").write_bytes(
+            f"{stage}-decoder".encode()
+        )
+        if stage == "onnx-fp":
+            (directory / "config.json").write_text("{}", encoding="utf-8")
+        write_artifact_lineage(
+            directory,
+            source_lineage=lineage_data,
+            source_lineage_sha256=lineage_sha256,
+            stage=stage,
+        )
+
+    def test_browser_export_preserves_verified_lineage_and_digest(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            merged_dir, _ = self._write_merged_model(root)
+            lineage = ensure_teapot_export_model(str(merged_dir))
+            fp_dir = root / "onnx"
+            int8_dir = root / "int8"
+            uint8_dir = root / "uint8"
+            self._write_onnx_stage(
+                fp_dir,
+                lineage_data=lineage.data,
+                lineage_sha256=lineage.sha256,
+                stage="onnx-fp",
+            )
+            self._write_onnx_stage(
+                int8_dir,
+                lineage_data=lineage.data,
+                lineage_sha256=lineage.sha256,
+                stage="onnx-int8",
+            )
+            self._write_onnx_stage(
+                uint8_dir,
+                lineage_data=lineage.data,
+                lineage_sha256=lineage.sha256,
+                stage="onnx-uint8",
+            )
+            browser_dir = root / "browser"
+
+            assemble_browser_artifact(
+                fp_dir,
+                {"int8": int8_dir, "uint8": uint8_dir},
+                browser_dir,
+                lineage,
+            )
+            marker = validate_artifact_lineage(
+                browser_dir,
+                source_lineage_sha256=lineage.sha256,
+                stage="browser",
+            )
+
+            self.assertEqual(marker["adapter_model_id"], lineage.data["adapter_model_id"])
+            self.assertEqual(marker[MERGED_DIGEST_FIELD], lineage.data[MERGED_DIGEST_FIELD])
+            self.assertTrue((browser_dir / LINEAGE_FILENAME).is_file())
+
+    def test_merged_model_tampering_breaks_lineage_validation(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            merged_dir, _ = self._write_merged_model(Path(directory))
+            (merged_dir / "model.safetensors").write_bytes(b"tampered")
+
+            with self.assertRaisesRegex(RuntimeError, "merged model digest"):
+                ensure_teapot_export_model(str(merged_dir))
+
+    def test_evaluation_provenance_identifies_baseline_revision(self) -> None:
+        provenance = evaluation_provenance(PRIMARY_BASE_MODEL_ID, "test")
+
+        self.assertEqual(provenance["model_kind"], "baseline")
+        self.assertEqual(provenance["model_revision"], PRIMARY_BASE_MODEL_REVISION)
+        self.assertEqual(provenance["split"], "test")
+
+    def test_evaluation_provenance_hashes_selected_adapter(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            _, adapter_dir = self._write_merged_model(Path(directory))
+
+            provenance = evaluation_provenance(str(adapter_dir), "validation")
+
+            self.assertEqual(provenance["model_kind"], "adapter")
+            self.assertEqual(provenance["adapter_model_id"], str(adapter_dir.resolve()))
+            self.assertEqual(
+                provenance[ADAPTER_DIGEST_FIELD],
+                directory_sha256(adapter_dir),
+            )
+            self.assertEqual(provenance["split"], "validation")
+
+    def test_evaluation_provenance_preserves_merged_adapter_lineage(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            merged_dir, adapter_dir = self._write_merged_model(Path(directory))
+
+            provenance = evaluation_provenance(str(merged_dir), "test")
+
+            self.assertEqual(provenance["model_kind"], "merged")
+            self.assertEqual(provenance["adapter_model_id"], str(adapter_dir.resolve()))
+            self.assertEqual(
+                provenance[ADAPTER_DIGEST_FIELD],
+                directory_sha256(adapter_dir),
+            )
+            self.assertEqual(
+                provenance["model_sha256"],
+                directory_sha256(
+                    merged_dir,
+                    excluded_relative_paths=frozenset({LINEAGE_FILENAME}),
+                ),
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ml/profile-qa/tests/test_training_api.py
+++ b/ml/profile-qa/tests/test_training_api.py
@@ -24,6 +24,46 @@ def test_trainer_uses_transformers_5_processing_class() -> None:
     assert "tokenizer" not in keyword_names
 
 
+def test_new_peft_checkpoints_persist_the_pinned_base_revision() -> None:
+    """Keep PEFT's saved adapter config bound to the training base revision."""
+
+    source_path = Path(__file__).parents[1] / "profile_qa" / "train_lora.py"
+    tree = ast.parse(source_path.read_text(encoding="utf-8"))
+    get_peft_calls = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Subscript)
+        and isinstance(node.func.slice, ast.Constant)
+        and node.func.slice.value == "get_peft_model"
+    ]
+
+    assert len(get_peft_calls) == 1
+    revision_keywords = [
+        keyword for keyword in get_peft_calls[0].keywords if keyword.arg == "revision"
+    ]
+    assert len(revision_keywords) == 1
+    revision_value = revision_keywords[0].value
+    assert isinstance(revision_value, ast.Name)
+    assert revision_value.id == "PRIMARY_BASE_MODEL_REVISION"
+
+
+def test_merge_validates_the_saved_adapter_base_lineage() -> None:
+    """Prevent merge lineage from claiming an unverified training revision."""
+
+    source_path = Path(__file__).parents[1] / "profile_qa" / "merge_adapter.py"
+    tree = ast.parse(source_path.read_text(encoding="utf-8"))
+    validation_calls = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "ensure_adapter_base_lineage"
+    ]
+
+    assert len(validation_calls) == 1
+
+
 def test_export_recovery_uses_isolated_lock() -> None:
     """Keep exporter recovery guidance pointed at its isolated environment."""
 


### PR DESCRIPTION
## What

- Require explicit merge lineage and ISO release-date inputs when preparing model artifacts.
- Derive the promoted checkpoint from validated lineage.
- Read the latest training loss/step and best validation loss from that checkpoint's `trainer_state.json`.
- Validate the base model, pipeline, checkpoint, numeric metrics, and date before replacing a payload.
- Remove the hard-coded checkpoint, losses, and release date from generated model cards.
- Add end-to-end and negative regression coverage.

## Why

The model-card generator currently publishes one historical checkpoint, loss pair, and release date for every future run. A new model can therefore be released with stale or false provenance even when its artifacts are different.

## Validation

- Targeted provenance tests: 5/5 passed.
- Available unittest suite: 8/8 passed.
- Markdown lint, Python AST/tabnanny, CLI help smoke, and `git diff --check` passed.