### PR TITLE
Run CI Playwright tests against static export

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -52,9 +52,10 @@ export default defineConfig({
     },
   ],
 
-  /* Run your local dev server before starting the tests */
+  /* Run a local server before starting the tests. */
   webServer: {
-    command: "npm run dev",
+    // CI runs the exported Pages artifact after configure-pages applies its base path.
+    command: process.env.CI ? "npm run start" : "npm run dev",
     url: "http://localhost:3000",
     reuseExistingServer: !process.env.CI,
   },


### PR DESCRIPTION
## Summary

- Run Playwright against the exported static site when CI is set.
- Keep the existing Next.js dev-server workflow for local test runs.

## Root cause

`actions/configure-pages` applies the GitHub Pages base path before Playwright launches. The previous `npm run dev` server never satisfied Playwright's root readiness URL, so the deploy workflow timed out before any browser test started.

## Validation

- `git diff --check`
- TypeScript syntax check for `playwright.config.ts`
- Verified the resolved server command is `npm run start` in CI and `npm run dev` locally
- `npm run lint` passed

A full local build could not complete in this runner because of its `uv_resident_set_memory` runtime error; the original GitHub Actions run completed the build successfully. The PR's CI will validate the complete build and Playwright suite.