### PR TITLE
Refine resume viewer and inference status copy

### DIFF
--- a/docs/CUSTOMIZATION.md
+++ b/docs/CUSTOMIZATION.md
@@ -103,13 +103,13 @@ Keep section IDs generic so forks can reuse the retrieval behavior:
 `src/config/site.ts` imports this file as `PROFILE_SECTIONS`, and
 `ml/profile-qa/profile_qa/public_profile.py` loads the same JSON for synthetic
 data generation. The identity section's `subject` object supplies the browser
-welcome and system-prompt identity as well as the names and pronouns rendered
-into synthetic questions, conversation histories, refusal examples, and the
-training instruction. `PERSONAL_CONTEXT` is derived from these sections for
-compatibility. The browser prompt builder always includes identity facts,
-retrieves relevant sections from the latest question plus recent turns, and
-trims user input only after selected sections and history fit the active model
-budget.
+welcome, inference-status, and system-prompt identity as well as the names and
+pronouns rendered into synthetic questions, conversation histories, refusal
+examples, and the training instruction. `PERSONAL_CONTEXT` is derived from
+these sections for compatibility. The browser prompt builder always includes
+identity facts, retrieves relevant sections from the latest question plus
+recent turns, and trims user input only after selected sections and history fit
+the active model budget.
 
 Put reusable categories in section IDs and person-specific terms in fact text or
 fact keywords. Browser retrieval uses section `priority`, section `keywords`,

--- a/src/components/chat/components/ChatMessages.tsx
+++ b/src/components/chat/components/ChatMessages.tsx
@@ -5,7 +5,7 @@
 
 import React, { Fragment, useState } from "react";
 
-import { PROFILE_SUBJECT } from "@/config";
+import { GENERATION_STATUS_MESSAGES } from "@/config";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
@@ -14,14 +14,6 @@ import type { ChatMessage } from "@/types";
 
 import { LimitWarning } from "./LimitWarning";
 import { Typewriter } from "./Typewriter";
-
-export const GENERATION_STATUS_MESSAGES = [
-  `Reviewing ${PROFILE_SUBJECT.shortName}'s public profile...`,
-  `Finding relevant public details about ${PROFILE_SUBJECT.shortName}...`,
-  `Checking ${PROFILE_SUBJECT.shortName}'s public resume context...`,
-  `Reviewing ${PROFILE_SUBJECT.shortName}'s public project history...`,
-  "Preparing a profile-grounded answer...",
-] as const;
 
 export interface ChatMessagesProps {
   messages: ChatMessage[];
@@ -36,6 +28,30 @@ export interface ChatMessagesProps {
   onRetryModelLoad: () => void;
 }
 
+function GenerationStatus(): React.ReactElement {
+  const [message] = useState(
+    () =>
+      GENERATION_STATUS_MESSAGES[
+        Math.floor(Math.random() * GENERATION_STATUS_MESSAGES.length)
+      ],
+  );
+
+  return (
+    <div
+      className="flex items-center gap-2 text-sm text-muted-foreground"
+      data-testid="generation-status"
+    >
+      <Spinner
+        aria-hidden="true"
+        aria-label={undefined}
+        className="size-3.5"
+        role="presentation"
+      />
+      <span>{message}</span>
+    </div>
+  );
+}
+
 export function ChatMessages({
   messages,
   currentResponse,
@@ -48,12 +64,6 @@ export function ChatMessages({
   trimmedPersonalContextCharacters,
   onRetryModelLoad,
 }: ChatMessagesProps): React.ReactElement {
-  const [generationStatusMessage] = useState(
-    () =>
-      GENERATION_STATUS_MESSAGES[
-        Math.floor(Math.random() * GENERATION_STATUS_MESSAGES.length)
-      ]
-  );
   const showModelStatus = isLoading && !loadingMessage?.includes("Generating");
 
   return (
@@ -168,10 +178,7 @@ export function ChatMessages({
                   </div>
                   <div className="whitespace-pre-line leading-relaxed [overflow-wrap:anywhere]">
                     {!currentResponse ? (
-                      <div className="flex items-center gap-2 text-sm text-muted-foreground">
-                        <Spinner className="size-3.5" />
-                        <span>{generationStatusMessage}</span>
-                      </div>
+                      <GenerationStatus />
                     ) : (
                       <Fragment>
                         {currentResponse}

--- a/src/components/resume/ResumeViewer.tsx
+++ b/src/components/resume/ResumeViewer.tsx
@@ -12,12 +12,32 @@ import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import { Spinner } from "@/components/ui/spinner";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 
 const PDF_PREVIEW_URL = `https://drive.google.com/file/d/${SITE_CONFIG.resumeFileId}/preview`;
 const PDF_OPEN_URL = `https://drive.google.com/file/d/${SITE_CONFIG.resumeFileId}/view?usp=sharing`;
 const LOADING_TIMEOUT_MS = 15000; // Increased to 15s
 const MAX_RETRIES = 2;
 const logger = createLogger(LOG_AREAS.RESUME);
+
+function GoogleDriveIcon(): React.ReactElement {
+  return (
+    <svg
+      aria-hidden="true"
+      className="size-5"
+      focusable="false"
+      viewBox="0 0 24 24"
+    >
+      <path d="M8.6 2h6.8l6.8 11.8h-6.8L8.6 2Z" fill="#0F9D58" />
+      <path d="m8.6 2 3.4 5.9-6.8 11.8-3.4-5.9L8.6 2Z" fill="#F4B400" />
+      <path d="m5.2 19.7 3.4-5.9h13.6l-3.4 5.9H5.2Z" fill="#4285F4" />
+    </svg>
+  );
+}
 
 export function ResumeViewer(): React.ReactElement {
   const [isLoading, setIsLoading] = useState(true);
@@ -90,7 +110,35 @@ export function ResumeViewer(): React.ReactElement {
 
   return (
     <div className="flex h-full w-full max-w-5xl flex-col items-center gap-3 p-4">
-      <Card className="relative w-full max-w-4xl flex-1 gap-0 overflow-hidden rounded-xl border border-border/70 bg-card/60 py-0 shadow-sm ring-0">
+      <Card
+        className="relative w-full max-w-4xl flex-1 gap-0 overflow-hidden rounded-xl border border-border/70 bg-card/60 py-0 shadow-sm ring-0"
+        data-testid="resume-viewer"
+      >
+        <div className="absolute right-2 top-2 z-20 sm:right-3 sm:top-3">
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                asChild
+                className="min-h-11 min-w-11 border-border/80 bg-background/90 shadow-md backdrop-blur-sm hover:bg-muted"
+                size="icon-lg"
+                variant="outline"
+              >
+                <a
+                  aria-label="Open resume in Google Drive"
+                  data-testid="resume-drive-link"
+                  href={PDF_OPEN_URL}
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  <GoogleDriveIcon />
+                </a>
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent data-testid="resume-drive-tooltip" side="left">
+              Open in Google Drive
+            </TooltipContent>
+          </Tooltip>
+        </div>
         {isLoading && !hasError && (
           <div className="absolute inset-0 z-10 flex items-center justify-center bg-card/95 backdrop-blur-sm">
             <div className="text-center">
@@ -133,15 +181,6 @@ export function ResumeViewer(): React.ReactElement {
           />
         )}
       </Card>
-      <Button asChild variant="outline">
-        <a
-          href={PDF_OPEN_URL}
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          Open resume in Google Drive
-        </a>
-      </Button>
     </div>
   );
 }

--- a/src/components/resume/ResumeViewer.tsx
+++ b/src/components/resume/ResumeViewer.tsx
@@ -111,7 +111,7 @@ export function ResumeViewer(): React.ReactElement {
   return (
     <div className="flex h-full w-full max-w-5xl flex-col items-center gap-3 p-4">
       <Card
-        className="relative w-full max-w-4xl flex-1 gap-0 overflow-hidden rounded-xl border border-border/70 bg-card/60 py-0 shadow-sm ring-0"
+        className="relative min-h-0 w-full max-w-4xl flex-1 gap-0 overflow-hidden rounded-xl border border-border/70 bg-card/60 py-0 shadow-sm ring-0"
         data-testid="resume-viewer"
       >
         <div className="absolute right-2 top-2 z-20 sm:right-3 sm:top-3">

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -25,5 +25,7 @@ export {
 export {
   GENERATION_PARAMS,
   CHATBOT_CONFIG,
+  GENERATION_STATUS_MESSAGES,
   createChatbotConfig,
+  createGenerationStatusMessages,
 } from "./prompts";

--- a/src/config/prompts.ts
+++ b/src/config/prompts.ts
@@ -27,6 +27,26 @@ function possessive(value: string): string {
   return value.endsWith("s") ? `${value}'` : `${value}'s`;
 }
 
+export function createGenerationStatusMessages(
+  subject: ProfileSubject,
+): readonly string[] {
+  const shortName = subject.shortName;
+  const possessiveShortName = possessive(shortName);
+
+  return [
+    `Reading ${possessiveShortName} secret diary...`,
+    `Calling ${shortName} right now...`,
+    `Decoding ${possessiveShortName} commits...`,
+    `Skimming ${possessiveShortName} highlight reel...`,
+    `Checking ${possessiveShortName} receipts...`,
+    `Consulting ${possessiveShortName} rubber duck...`,
+    `Connecting ${possessiveShortName} career dots...`,
+    `Paging through ${possessiveShortName} lore...`,
+    `Dusting off ${possessiveShortName} brag book...`,
+    `Channeling my inner ${shortName}...`,
+  ] as const;
+}
+
 export function createChatbotConfig(subject: ProfileSubject) {
   return {
     welcomeMessages: [
@@ -38,8 +58,12 @@ export function createChatbotConfig(subject: ProfileSubject) {
       `Thanks for visiting! Do you want to learn more about ${subject.shortName}?`,
     ],
 
+    generationStatusMessages: createGenerationStatusMessages(subject),
+
     systemPrompt: `You are ${possessive(subject.name)} AI assistant. Use only the provided context. Reply in 1-2 short sentences. If the answer is absent, say the context does not say.`,
   } as const;
 }
 
 export const CHATBOT_CONFIG = createChatbotConfig(PROFILE_SUBJECT);
+export const GENERATION_STATUS_MESSAGES =
+  CHATBOT_CONFIG.generationStatusMessages;

--- a/tests/chatbot.spec.ts
+++ b/tests/chatbot.spec.ts
@@ -3,8 +3,12 @@ import {
   getPersonalContextBudget,
   getPromptBudget,
 } from "../src/services/ai/contextProvider";
-import { CHATBOT_CONFIG } from "../src/config";
-import { GENERATION_STATUS_MESSAGES } from "../src/components/chat/components/ChatMessages";
+import {
+  CHATBOT_CONFIG,
+  GENERATION_STATUS_MESSAGES,
+  PROFILE_SUBJECT,
+  createGenerationStatusMessages,
+} from "../src/config";
 
 const HELD_LOADING_MESSAGE = "Downloading model... 83%";
 const HOLD_MODEL_LOADING_SESSION_KEY = "__holdModelLoading";
@@ -13,11 +17,32 @@ const FAIL_MODEL_LOADING_SESSION_KEY = "__failModelLoading";
 const HOLD_GENERATION_SESSION_KEY = "__holdGeneration";
 const THROW_WORKER_SESSION_KEY = "__throwWorker";
 
-test("generation status messages describe only the public-profile workflow", () => {
-  expect(GENERATION_STATUS_MESSAGES).toHaveLength(5);
+test("generation status messages are playful and fork-friendly", () => {
+  const possessiveShortName = PROFILE_SUBJECT.shortName.endsWith("s")
+    ? `${PROFILE_SUBJECT.shortName}'`
+    : `${PROFILE_SUBJECT.shortName}'s`;
+
+  expect(GENERATION_STATUS_MESSAGES.length).toBeGreaterThanOrEqual(8);
+  expect(new Set(GENERATION_STATUS_MESSAGES).size).toBe(
+    GENERATION_STATUS_MESSAGES.length,
+  );
+  expect(GENERATION_STATUS_MESSAGES).toContain(
+    `Reading ${possessiveShortName} secret diary...`,
+  );
+  expect(GENERATION_STATUS_MESSAGES).toContain(
+    `Calling ${PROFILE_SUBJECT.shortName} right now...`,
+  );
   for (const message of GENERATION_STATUS_MESSAGES) {
-    expect(message).toMatch(/public|profile-grounded/);
+    expect(message).toContain(PROFILE_SUBJECT.shortName);
+    expect(message).toMatch(/\.\.\.$/);
   }
+
+  const forkedSubject = { ...PROFILE_SUBJECT, shortName: "Fork Owner" };
+  const forkedMessages = createGenerationStatusMessages(forkedSubject);
+  expect(forkedMessages).toHaveLength(GENERATION_STATUS_MESSAGES.length);
+  expect(
+    forkedMessages.every((message) => message.includes("Fork Owner")),
+  ).toBe(true);
 });
 
 interface MockWorkerInitOptions {
@@ -652,6 +677,11 @@ test.describe("Chatbot UI Tests", () => {
     await page.getByTestId("chat-input").fill("Tell me about Justin.");
     await page.getByTestId("chat-send-button").click();
     await expect(page.getByTestId("chat-input")).toBeDisabled();
+    const generationStatus = page.getByTestId("generation-status");
+    await expect(generationStatus).toBeVisible();
+    expect(GENERATION_STATUS_MESSAGES).toContain(
+      (await generationStatus.textContent())?.trim(),
+    );
 
     await page.getByRole("button", { name: "Close chat" }).click();
 

--- a/tests/home.spec.ts
+++ b/tests/home.spec.ts
@@ -73,6 +73,16 @@ test.describe('Homepage E2E Tests', () => {
       "href",
       `https://drive.google.com/file/d/${SITE_CONFIG.resumeFileId}/view?usp=sharing`,
     );
+    await expect(resumeLink).toHaveAttribute("target", "_blank");
+    await expect(resumeLink).toHaveAttribute("rel", "noopener noreferrer");
+    await expect(
+      page.getByTestId("resume-viewer").getByTestId("resume-drive-link"),
+    ).toBeVisible();
+
+    await resumeLink.focus();
+    await expect(page.getByTestId("resume-drive-tooltip")).toHaveText(
+      "Open in Google Drive",
+    );
   });
 
   test("should open AI chatbot when button is clicked", async ({ page }) => {


### PR DESCRIPTION
## Summary

- replace the separate Google Drive resume button with a branded, accessible icon overlay in the PDF viewer
- add a ShadCN tooltip, secure external-link attributes, and focused viewer/link coverage
- restore `min-h-0` so the viewer and overlay remain accessible on short landscape viewports
- replace the five generic inference messages with ten concise, playful variants that refresh per inference
- derive every message from the canonical profile subject so forks customize the copy by changing `identity.subject.shortName`
- document that the canonical profile identity also drives inference-status copy

## Validation

- [x] [GitHub Actions: Lint](https://github.com/justinthelaw/justinthelaw/actions/runs/31498731460) — full pre-commit suite passed
- [x] [GitHub Actions: Playwright Tests](https://github.com/justinthelaw/justinthelaw/actions/runs/31498731500) — build, lint, browser install, and full five-project E2E matrix passed
- [x] `npm run lint` with Node 24.19.0 / npm 12.0.2
- [x] `npm run build` with Node 24.19.0 / npm 12.0.2
- [x] Focused Playwright config test: creative messages are varied and fork-friendly
- [x] Focused Playwright export test: Drive preview, external URL, and accessible label are emitted
- [x] Docs updated for the user-facing customization behavior

The local sandbox could not download Playwright browsers because its proxy rejected the future-dated CDN certificate; the repository's GitHub Actions browser matrix completed successfully instead.

## Checklist

- [x] Scope is focused and reviewable
- [x] Security impact considered
- [x] No breaking changes
