### PR TITLE
Reposition Drive link and enlarge desktop chat

### DIFF
--- a/src/components/chat/components/ChatContainer.tsx
+++ b/src/components/chat/components/ChatContainer.tsx
@@ -123,7 +123,7 @@ export function ChatContainer({ onClose }: ChatContainerProps): React.ReactEleme
   return (
     <Dialog open onOpenChange={handleOpenChange}>
       <DialogContent
-        className="flex h-[min(80vh,46rem)] w-[calc(100%-2rem)] max-w-md flex-col gap-0 overflow-hidden border border-border/80 bg-popover/98 p-0 shadow-2xl ring-1 ring-white/5 lg:top-auto lg:right-6 lg:bottom-6 lg:left-auto lg:h-[600px] lg:w-96 lg:max-w-none lg:translate-x-0 lg:translate-y-0"
+        className="flex h-[min(80vh,46rem)] w-[calc(100%-2rem)] max-w-md flex-col gap-0 overflow-hidden border border-border/80 bg-popover/98 p-0 shadow-2xl ring-1 ring-white/5 lg:top-auto lg:right-6 lg:bottom-6 lg:left-auto lg:h-[min(42rem,calc(100vh-3rem))] lg:w-[28rem] lg:max-w-none lg:translate-x-0 lg:translate-y-0"
         onCloseAutoFocus={(event) => event.preventDefault()}
         onOpenAutoFocus={(event) => {
           event.preventDefault();

--- a/src/components/resume/ResumeViewer.tsx
+++ b/src/components/resume/ResumeViewer.tsx
@@ -114,7 +114,7 @@ export function ResumeViewer(): React.ReactElement {
         className="relative min-h-0 w-full max-w-4xl flex-1 gap-0 overflow-hidden rounded-xl border border-border/70 bg-card/60 py-0 shadow-sm ring-0"
         data-testid="resume-viewer"
       >
-        <div className="absolute right-2 top-2 z-20 sm:right-3 sm:top-3">
+        <div className="absolute left-2 top-2 z-20 sm:left-3 sm:top-3">
           <Tooltip>
             <TooltipTrigger asChild>
               <Button
@@ -134,7 +134,11 @@ export function ResumeViewer(): React.ReactElement {
                 </a>
               </Button>
             </TooltipTrigger>
-            <TooltipContent data-testid="resume-drive-tooltip" side="left">
+            <TooltipContent
+              data-testid="resume-drive-tooltip"
+              side="right"
+              sideOffset={8}
+            >
               Open in Google Drive
             </TooltipContent>
           </Tooltip>

--- a/tests/home.spec.ts
+++ b/tests/home.spec.ts
@@ -79,6 +79,28 @@ test.describe('Homepage E2E Tests', () => {
       page.getByTestId("resume-viewer").getByTestId("resume-drive-link"),
     ).toBeVisible();
 
+    const resumeViewerBox = await page
+      .getByTestId("resume-viewer")
+      .boundingBox();
+    const resumeLinkBox = await resumeLink.boundingBox();
+
+    expect(resumeViewerBox).not.toBeNull();
+    expect(resumeLinkBox).not.toBeNull();
+    expect(resumeLinkBox!.x).toBeGreaterThanOrEqual(resumeViewerBox!.x - 1);
+    expect(resumeLinkBox!.y).toBeGreaterThanOrEqual(resumeViewerBox!.y - 1);
+    expect(resumeLinkBox!.x + resumeLinkBox!.width).toBeLessThanOrEqual(
+      resumeViewerBox!.x + resumeViewerBox!.width + 1,
+    );
+    expect(resumeLinkBox!.y + resumeLinkBox!.height).toBeLessThanOrEqual(
+      resumeViewerBox!.y + resumeViewerBox!.height + 1,
+    );
+    expect(resumeLinkBox!.x + resumeLinkBox!.width / 2).toBeLessThan(
+      resumeViewerBox!.x + resumeViewerBox!.width / 2,
+    );
+    expect(resumeLinkBox!.y + resumeLinkBox!.height / 2).toBeLessThan(
+      resumeViewerBox!.y + resumeViewerBox!.height / 2,
+    );
+
     await resumeLink.focus();
     await expect(page.getByTestId("resume-drive-tooltip")).toHaveText(
       "Open in Google Drive",
@@ -100,6 +122,41 @@ test.describe('Homepage E2E Tests', () => {
     await expect(
       page.getByRole("dialog", { name: "AI Chatbot" }),
     ).toBeVisible();
+  });
+
+  test("should keep the larger desktop chatbot anchored bottom-right", async ({
+    page,
+  }, testInfo) => {
+    test.skip(
+      testInfo.project.name.startsWith("Mobile"),
+      "Desktop layout applies at the lg breakpoint",
+    );
+    await page.setViewportSize({ width: 1440, height: 900 });
+    await page.goto("/");
+    await page.getByTestId("ai-chatbot-button").click();
+
+    const dialog = page.getByRole("dialog", { name: "AI Chatbot" });
+    await expect(dialog).toBeVisible();
+
+    const layout = await dialog.evaluate((element) => {
+      const styles = window.getComputedStyle(element);
+      return {
+        bottom: Number.parseFloat(styles.bottom),
+        height: Number.parseFloat(styles.height),
+        position: styles.position,
+        right: Number.parseFloat(styles.right),
+        rootFontSize: Number.parseFloat(
+          window.getComputedStyle(document.documentElement).fontSize,
+        ),
+        width: Number.parseFloat(styles.width),
+      };
+    });
+
+    expect(layout.position).toBe("fixed");
+    expect(layout.right).toBeCloseTo(24, 0);
+    expect(layout.bottom).toBeCloseTo(24, 0);
+    expect(layout.width / layout.rootFontSize).toBeGreaterThan(24);
+    expect(layout.height / layout.rootFontSize).toBeGreaterThan(37.5);
   });
 
   test("should retain the configured profile description when GitHub fails", async ({


### PR DESCRIPTION
## Summary

- move the branded Google Drive overlay from the top-right to the top-left of the resume viewer
- point its tooltip inward so it stays readable at the viewport edge
- enlarge the desktop chat from 24rem × 37.5rem to 28rem × up to 42rem
- preserve the chat's 24px bottom-right anchor and all mobile sizing
- add resilient layout coverage for both placements

## Why

The Drive shortcut belongs in the viewer's top-left. The existing large-screen chat override also made the dialog narrower than its medium-screen size, so this makes the desktop experience roomier without changing mobile behavior or chat functionality.

## Validation

- [x] `npm run lint`
- [x] `npm run build`
- [x] Playwright test discovery for `tests/home.spec.ts`
- [x] generated Tailwind CSS inspection
- [x] [Lint workflow](https://github.com/justinthelaw/justinthelaw/actions/runs/31501842671)
- [x] [Full Playwright browser matrix](https://github.com/justinthelaw/justinthelaw/actions/runs/31501842771)

The local `npm run flight-check` completed clean, lint, and build, then encountered the sandbox's browser-download certificate/proxy error. GitHub Actions subsequently ran and passed the authoritative full browser matrix.