### PR TITLE
Enlarge social profile buttons

### DIFF
--- a/src/components/links/LinkIconButton.tsx
+++ b/src/components/links/LinkIconButton.tsx
@@ -49,7 +49,7 @@ export function LinkIconButton({
       asChild
       variant="ghost"
       size="icon"
-      className="size-8 rounded-lg p-1.5 text-muted-foreground hover:bg-muted hover:text-foreground sm:size-9 md:size-10"
+      className="size-10 rounded-lg p-1.5 text-muted-foreground hover:bg-muted hover:text-foreground sm:size-11 md:size-12"
     >
       <a
         href={link}
@@ -60,7 +60,7 @@ export function LinkIconButton({
         <img
           src={iconSource}
           alt={altText}
-          className="block size-6 object-contain sm:size-7 md:size-8"
+          className="block size-7 object-contain sm:size-8 md:size-9"
           loading="eager"
           decoding="async"
           onError={handleIconError}

--- a/tests/home.spec.ts
+++ b/tests/home.spec.ts
@@ -256,4 +256,65 @@ test.describe('Homepage E2E Tests', () => {
       expect(resolvedSource?.endsWith(`/${socialIconFiles[index]}`)).toBe(true);
     }
   });
+
+  test('should render larger social controls at every responsive tier', async ({
+    page,
+  }, testInfo) => {
+    test.skip(
+      testInfo.project.name !== 'chromium',
+      'One browser is sufficient for responsive CSS sizing',
+    );
+
+    const sizeTiers = [
+      { viewportWidth: 375, previousControlRem: 2, previousIconRem: 1.5 },
+      { viewportWidth: 640, previousControlRem: 2.25, previousIconRem: 1.75 },
+      { viewportWidth: 768, previousControlRem: 2.5, previousIconRem: 2 },
+    ];
+
+    for (const sizeTier of sizeTiers) {
+      await page.setViewportSize({ width: sizeTier.viewportWidth, height: 900 });
+      await page.goto('/');
+
+      const socialLinks = page.getByTestId('social-footer').getByRole('link');
+      await expect(socialLinks).toHaveCount(getSocialIconFiles().length);
+
+      const measurements = await socialLinks.evaluateAll((links) => {
+        const rootFontSize = Number.parseFloat(
+          window.getComputedStyle(document.documentElement).fontSize,
+        );
+
+        return links.map((link) => {
+          const image = link.querySelector('img');
+          if (!(image instanceof HTMLImageElement)) {
+            throw new Error('Social link is missing its icon image');
+          }
+
+          const controlBounds = link.getBoundingClientRect();
+          const iconBounds = image.getBoundingClientRect();
+
+          return {
+            controlHeightRem: controlBounds.height / rootFontSize,
+            controlWidthRem: controlBounds.width / rootFontSize,
+            iconHeightRem: iconBounds.height / rootFontSize,
+            iconWidthRem: iconBounds.width / rootFontSize,
+          };
+        });
+      });
+
+      for (const measurement of measurements) {
+        expect(measurement.controlWidthRem).toBeGreaterThan(
+          sizeTier.previousControlRem,
+        );
+        expect(measurement.controlHeightRem).toBeGreaterThan(
+          sizeTier.previousControlRem,
+        );
+        expect(measurement.iconWidthRem).toBeGreaterThan(
+          sizeTier.previousIconRem,
+        );
+        expect(measurement.iconHeightRem).toBeGreaterThan(
+          sizeTier.previousIconRem,
+        );
+      }
+    }
+  });
 });


### PR DESCRIPTION
## Summary

- enlarge every configured social profile control across base, small, and medium-plus viewports
- enlarge the GitHub, LinkedIn, Hugging Face, and GitLab logos with the controls
- preserve the shared ShadCN button styling, accessible names, focus behavior, external-link safety, and asset fallbacks
- add responsive regression coverage that measures every configured social control at all three sizing tiers

## Responsive sizing

| Tier | Control | Logo |
| --- | ---: | ---: |
| Base | 40px | 28px |
| `sm` | 44px | 32px |
| `md+` | 48px | 36px |

## Validation

- [x] `git diff --check`
- [x] `npm run lint`
- [x] `npm run build` (TypeScript, production compile, and static export)
- [x] Playwright test discovery for `tests/home.spec.ts`
- [x] generated Tailwind CSS includes all new responsive size utilities
- [x] [Lint workflow](https://github.com/justinthelaw/justinthelaw/actions/runs/31554004498)
- [x] [Full Playwright browser matrix](https://github.com/justinthelaw/justinthelaw/actions/runs/31554004487)

`npm run flight-check` completed clean, lint, and build locally, then stopped because the sandbox proxy returned empty Playwright browser archives. GitHub Actions subsequently ran and passed the authoritative full browser matrix.